### PR TITLE
Allow searching only a subset of the searchable attributes

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -45,6 +45,17 @@ $searchParameters = \Loupe\Loupe\SearchParameters::create()
 ;
 ```
 
+## Attributes to search on
+
+By default, Loupe searches all [configured `searchable attributes`][Config] but you can limit your query to only a 
+subset of those:
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToSearchOn(['firstname'])
+;
+```
+
 ## Filter
 
 Loupe provides a powerful way to filter your documents. Know SQL? Then you'll have absolutely no issues filtering 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Search;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Loupe\Loupe\Internal\Engine;
@@ -164,6 +165,14 @@ class Searcher
         );
 
         $cteSelectQb->from(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS, $termsDocumentsAlias);
+
+        if (['*'] !== $this->searchParameters->getAttributesToSearchOn()) {
+            $cteSelectQb->andWhere(sprintf(
+                $termsDocumentsAlias . '.attribute IN (%s)',
+                $this->queryBuilder->createNamedParameter($this->searchParameters->getAttributesToSearchOn(), ArrayParameterType::STRING)
+            ));
+        }
+
         $cteSelectQb->andWhere(sprintf($termsDocumentsAlias . '.term IN (SELECT id FROM %s)', self::CTE_TERM_MATCHES));
 
         // Ensure phrase positions if any

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -12,6 +12,8 @@ final class SearchParameters
 
     private array $attributesToRetrieve = ['*'];
 
+    private array $attributesToSearchOn = ['*'];
+
     private string $filter = '';
 
     private int $hitsPerPage = 20;
@@ -37,6 +39,11 @@ final class SearchParameters
     public function getAttributesToRetrieve(): array
     {
         return $this->attributesToRetrieve;
+    }
+
+    public function getAttributesToSearchOn(): array
+    {
+        return $this->attributesToSearchOn;
     }
 
     public function getFilter(): string
@@ -81,6 +88,14 @@ final class SearchParameters
     {
         $clone = clone $this;
         $clone->attributesToRetrieve = $attributesToRetrieve;
+
+        return $clone;
+    }
+
+    public function withAttributesToSearchOn(array $attributesToSearchOn): self
+    {
+        $clone = clone $this;
+        $clone->attributesToSearchOn = $attributesToSearchOn;
 
         return $clone;
     }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -644,29 +644,58 @@ class SearchTest extends TestCase
         ]);
     }
 
-    public function testSimpleSearch(): void
+    public function testSearchWithAttributesToSearchOn(): void
     {
-        $loupe = $this->setupLoupeWithDepartmentsFixture();
+        $loupe = $this->setupLoupeWithMoviesFixture();
 
         $searchParameters = SearchParameters::create()
-            ->withQuery('uta')
-            ->withAttributesToRetrieve(['id', 'firstname', 'lastname'])
-            ->withSort(['firstname:asc'])
+            ->withQuery('four')
+            ->withAttributesToSearchOn(['title'])
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc'])
         ;
 
         $this->searchAndAssertResults($loupe, $searchParameters, [
             'hits' => [
                 [
-                    'id' => 2,
-                    'firstname' => 'Uta',
-                    'lastname' => 'Koertig',
+                    'id' => 5,
+                    'title' => 'Four Rooms',
                 ],
             ],
-            'query' => 'uta',
+            'query' => 'four',
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,
             'totalHits' => 1,
+        ]);
+    }
+
+    public function testSimpleSearch(): void
+    {
+        $loupe = $this->setupLoupeWithMoviesFixture();
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('four')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc'])
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 5,
+                    'title' => 'Four Rooms',
+                ],
+                [
+                    'id' => 6,
+                    'title' => 'Judgment Night',
+                ],
+            ],
+            'query' => 'four',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 2,
         ]);
     }
 
@@ -906,6 +935,24 @@ class SearchTest extends TestCase
 
         $loupe = $this->createLoupe($configuration);
         $this->indexFixture($loupe, 'departments');
+
+        return $loupe;
+    }
+
+    private function setupLoupeWithMoviesFixture(Configuration $configuration = null): Loupe
+    {
+        if ($configuration === null) {
+            $configuration = Configuration::create();
+        }
+
+        $configuration = $configuration
+            ->withFilterableAttributes(['genres'])
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
 
         return $loupe;
     }


### PR DESCRIPTION
## Attributes to search on

By default, Loupe searches all configured `searchable attributes` but you can now limit your query to only a 
subset of those:

```php
$searchParameters = \Loupe\Loupe\SearchParameters::create()
    ->withAttributesToSearchOn(['firstname'])
;
```