### PR TITLE
Fixed missing index

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -391,6 +391,7 @@ class IndexInfo
             ->setNotnull(true);
 
         $table->setPrimaryKey(['term', 'document', 'attribute', 'position']);
+        $table->addIndex(['document']);
     }
 
     private function addTermsToSchema(Schema $schema): void


### PR DESCRIPTION
Used in relevance sorting (`SELECT group_concat(tfidf) FROM %s WHERE %s.id=document`).