### PR TITLE
Add support for NOT Equals != operator

### DIFF
--- a/src/Internal/Filter/Ast/Operator.php
+++ b/src/Internal/Filter/Ast/Operator.php
@@ -43,6 +43,7 @@ enum Operator: string
     {
         return match ($operator) {
             '=' => self::Equals,
+            '!=' => self::NotEquals,
             '>' => self::GreaterThan,
             '>=' => self::GreaterThanOrEquals,
             '<' => self::LowerThan,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -15,6 +15,81 @@ class SearchTest extends TestCase
 {
     use FunctionalTestTrait;
 
+    public static function equalFilterProvider(): \Generator
+    {
+        yield '= on multiple attribute' => [
+            "departments = 'Backoffice'",
+            [
+                [
+                    'id' => 6,
+                    'firstname' => 'Huckleberry',
+                ],
+                [
+                    'id' => 5,
+                    'firstname' => 'Marko',
+                ],
+                [
+                    'id' => 2,
+                    'firstname' => 'Uta',
+                ],
+            ],
+        ];
+
+        yield '!= on multiple attribute' => [
+            "departments != 'Backoffice'",
+            [
+                [
+                    'id' => 3,
+                    'firstname' => 'Alexander',
+                ],
+                [
+                    'id' => 4,
+                    'firstname' => 'Jonas',
+                ],
+                [
+                    'id' => 1,
+                    'firstname' => 'Sandra',
+                ],
+            ],
+        ];
+
+        yield '= on single attribute' => [
+            "gender = 'female'",
+            [
+                [
+                    'id' => 1,
+                    'firstname' => 'Sandra',
+                ],
+                [
+                    'id' => 2,
+                    'firstname' => 'Uta',
+                ],
+            ],
+        ];
+
+        yield '!= on single attribute' => [
+            "gender != 'female'",
+            [
+                [
+                    'id' => 3,
+                    'firstname' => 'Alexander',
+                ],
+                [
+                    'id' => 6,
+                    'firstname' => 'Huckleberry',
+                ],
+                [
+                    'id' => 4,
+                    'firstname' => 'Jonas',
+                ],
+                [
+                    'id' => 5,
+                    'firstname' => 'Marko',
+                ],
+            ],
+        ];
+    }
+
     public static function highlightingProvider(): \Generator
     {
         yield 'Highlight with matches position only' => [
@@ -270,6 +345,27 @@ class SearchTest extends TestCase
             'page' => 1,
             'totalPages' => 1,
             'totalHits' => 1,
+        ]);
+    }
+
+    #[DataProvider('equalFilterProvider')]
+    public function testEqualFilter(string $filter, array $expectedHits): void
+    {
+        $loupe = $this->setupLoupeWithDepartmentsFixture();
+
+        $searchParameters = SearchParameters::create()
+            ->withAttributesToRetrieve(['id', 'firstname'])
+            ->withFilter($filter)
+            ->withSort(['firstname:asc'])
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => $expectedHits,
+            'query' => '',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => \count($expectedHits),
         ]);
     }
 

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -35,6 +35,17 @@ class ParserTest extends TestCase
             ],
         ];
 
+        yield 'Basic not equals filter' => [
+            "genres != 'Drama'",
+            [
+                [
+                    'attribute' => 'genres',
+                    'operator' => '!=',
+                    'value' => 'Drama',
+                ],
+            ],
+        ];
+
         yield 'Basic float filter' => [
             'age > 42.67',
             [


### PR DESCRIPTION
Add not equals operator.

And fix NOT IN operator.

--> own pull request fixed in #20 

Currently the negative operators do not work as expected, when try to filter out all which matches a specific value they are still shown aslong as they have another value which should not be the case.

Example in SEAL:

| Id | Tags        | Expected | Current     |  Why?
|----|-------------|----------|-------------|-----------
| 1  | Tech<br> UI |          |   X         | Has one none -> logic need to be inverted
| 2  | UI<br>UX    |          |   X         | Has one none -> logic need to be inverted
| 3  | Tech<br>UX  |    X    |   X          | 
| 4  |             |    X    |              | Empty currently filter out -> logic need to be inverted

The query is `tags != 'UI'` and the expected result is `3` and `4`, but the result is: `1`, `2`, `3`. Same currently appears for the `NOT IN` filter I adopted the existing test cases there as they still are returning which should filtered out.

Also adopted the test cases for the expected result.

## Solution

The current SQL looks like this:

```sql
// != example
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id IN (
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_value != 'Backoffice'
)
ORDER BY d.firstname ASC LIMIT 20

// NOT IN example
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id IN (
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_value NOT IN ('Backoffice', 'Project Managemen')
)
ORDER BY d.firstname ASC LIMIT 20
```

But to get the expected result we would require to change for `NOT` statements (NOT IN and !=) the current SQL which looks like this:

```sql
// != example
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id NOT IN (  // <--- replace IN with NOT IN
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_value = 'Backoffice' // <--- replace != with =
)
ORDER BY d.firstname ASC LIMIT 20

// NOT IN example
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id NOT IN (  // <--- replace IN with NOT IN
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_valu IN ('Backoffice', 'Project Managemen') // <--- replace != with =
)
ORDER BY d.firstname ASC LIMIT 20
```

## TODO

 - [ ] We should maybe add test fixtures somebody which have maybe no `departments` currently empty multi value is not tested.