### PR TITLE
Fix NOT IN operator behave still returns result for multi value attributes

### DIFF
--- a/src/Internal/Filter/Ast/Operator.php
+++ b/src/Internal/Filter/Ast/Operator.php
@@ -50,6 +50,15 @@ enum Operator: string
         };
     }
 
+    public function getMultiValueOperator(): self
+    {
+        return match ($this) {
+            // negatives need to be inverted for the multi value check so they are correctly filtered out
+            self::NotIn => self::In,
+            default => $this,
+        };
+    }
+
     private function quote($connection, float|string &$value): void
     {
         if (\is_string($value)) {

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -413,9 +413,14 @@ class Searcher
         if ($node instanceof Filter) {
             // Multi filterable need a sub query
             if (\in_array($node->attribute, $this->engine->getIndexInfo()->getMultiFilterableAttributes(), true)) {
-                $whereStatement[] = $documentAlias . '.id IN (';
+                // @see https://github.com/loupe-php/loupe/pull/19
+                $previousOperator = $node->operator;
+                $operator = $node->operator->getMultiValueOperator();
+                $node->operator = $operator;
+                $whereStatement[] = $documentAlias . '.id ' . ($node->operator !== $previousOperator ? 'NOT IN' : 'IN') . ' (';
                 $whereStatement[] = $this->createSubQueryForMultiAttribute($node);
                 $whereStatement[] = ')';
+                $node->operator = $previousOperator;
 
             // Single attributes are on the document itself
             } else {

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -157,16 +157,8 @@ class SearchTest extends TestCase
                     'firstname' => 'Alexander',
                 ],
                 [
-                    'id' => 4,
-                    'firstname' => 'Jonas',
-                ],
-                [
                     'id' => 1,
                     'firstname' => 'Sandra',
-                ],
-                [
-                    'id' => 2,
-                    'firstname' => 'Uta',
                 ],
             ],
         ];


### PR DESCRIPTION
Currently the negative operators do not work as expected, when try to filter out all which matches a specific value they are still shown aslong as they have another value which should not be the case.

Example in SEAL:

| Id | Tags        | Expected | Current     |  Why?
|----|-------------|----------|-------------|-----------
| 1  | Tech<br> UI |          |   X         | Has one none -> logic need to be inverted
| 2  | UI<br>UX    |          |   X         | Has one none -> logic need to be inverted
| 3  | Tech<br>UX  |    X    |   X          | 
| 4  |             |    X    |              | Empty currently filter out -> logic need to be inverted

The query is `tags NOT IN ('UI')` and the expected result is `3` and `4`, but the result is: `1`, `2`, `3`. Same currently appears for the `NOT IN` filter I adopted the existing test cases there as they still are returning which should filtered out.

Also adopted the test cases for the expected result.

## Solution

The current SQL looks like this:

```sql
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id IN (
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_value NOT IN ('Backoffice', 'Project Managemen')
)
ORDER BY d.firstname ASC LIMIT 20
```

But to get the expected result we would require to change for `NOT IN` statement the current SQL which looks like this:

```sql
SELECT COUNT() OVER() AS totalHits, d.document
FROM documents d WHERE d.id NOT IN (  // <--- replace IN with NOT IN
    SELECT document FROM multi_attributes_documents mad
    INNER JOIN multi_attributes ma
        ON ma.attribute=:dcValue1
        AND ma.id = mad.attribute
    WHERE ma.string_valu IN ('Backoffice', 'Project Managemen') // <--- replace NOT IN with IN
)
ORDER BY d.firstname ASC LIMIT 20
```

