### PR TITLE
Add test case for sort by asc and des with null and missing values

### DIFF
--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -998,6 +998,115 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testSortAscWithNullAndNotExtingValue(): void
+    {
+        $configuration = Configuration::create();
+
+        $configuration = $configuration
+            ->withFilterableAttributes(['rating'])
+            ->withSortableAttributes(['name', 'rating'])
+            ->withSearchableAttributes(['name'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'name' => 'Star Wars',
+            ],
+            [
+                'id' => 2,
+                'name' => 'Indiana Jones',
+                'rating' => 3.5,
+            ],
+            [
+                'id' => 3,
+                'name' => 'Jurassic Park',
+                'rating' => 4,
+            ],
+            [
+                'id' => 4,
+                'name' => 'Interstellar',
+                'rating' => null,
+            ],
+            [
+                'id' => 5,
+                'name' => 'Back to the future',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withAttributesToRetrieve(['id', 'name', 'rating'])
+            ->withSort(['rating:asc'])
+        ;
+
+        $result = $loupe->search($searchParameters);
+        $this->assertGreaterThan(1, \count($result->getHits()));
+
+        $beforeRating = \PHP_INT_MIN;
+        foreach ($result->getHits() as $result) {
+            $rating = $result['rating'] ?? 0;
+            $this->assertGreaterThanOrEqual($beforeRating, $rating);
+
+            $beforeRating = $rating;
+        }
+    }
+
+    public function testSortDescWithNullAndNotExtingValue(): void
+    {
+        $configuration = Configuration::create();
+
+        $configuration = $configuration
+            ->withFilterableAttributes(['rating'])
+            ->withSortableAttributes(['name', 'rating'])
+            ->withSearchableAttributes(['name'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'name' => 'Star Wars',
+            ],
+            [
+                'id' => 2,
+                'name' => 'Indiana Jones',
+                'rating' => 3.5,
+            ],
+            [
+                'id' => 3,
+                'name' => 'Jurassic Park',
+                'rating' => 4,
+            ],
+            [
+                'id' => 4,
+                'name' => 'Interstellar',
+                'rating' => null,
+            ],
+            [
+                'id' => 5,
+                'name' => 'Back to the future',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withAttributesToRetrieve(['id', 'name', 'rating'])
+            ->withSort(['rating:desc'])
+        ;
+
+        $result = $loupe->search($searchParameters);
+        $this->assertGreaterThan(1, \count($result->getHits()));
+
+        $beforeRating = \PHP_INT_MAX;
+        foreach ($result->getHits() as $result) {
+            $rating = $result['rating'] ?? 0;
+            $this->assertLessThanOrEqual($beforeRating, $rating);
+            $beforeRating = $rating;
+        }
+    }
+
     public function testSorting(): void
     {
         $loupe = $this->setupLoupeWithDepartmentsFixture();


### PR DESCRIPTION
Sorting for a attribute which is maybe not set or null unexpectly different to other search engines and natural behaviour.

Ported this test case from SEAL to Loupe here.