### PR TITLE
Improve indexing performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Markdown file][Blog_Repository] that should give you more information about the 
 Performance depends on many factors but here are some ballpark numbers based on indexing the [~32k movies fixture by 
 MeiliSearch][MeiliSearch_Movies]:
 
-* Indexing is slow, it will take about 15min (~ 35 documents per second)
+* Indexing is slow, it will take about 7min (~ 75 documents per second)
 * The slowest possible search query (typo tolerance enabled, ordered by relevance) finishes in < 400ms
 
 Note that anything above 50k documents is probably not a use case for Loupe. You may report your own performance 

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -201,6 +201,8 @@ class Engine
             throw new \InvalidArgumentException('Need to provide data to insert.');
         }
 
+        // Do not use the query builder in this method as it is heavily used and the query builder will slow down
+        // performance considerably here.
         $query = 'SELECT ' .
             implode(', ', array_filter(array_merge([$insertIdColumn], $uniqueIndexColumns))) .
             ' FROM ' .

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -17,7 +17,7 @@ class Tokenizer
     private Language $language;
 
     /**
-     * @var array<string,string>
+     * @var array<string,array<string,string>>
      */
     private array $stemmerCache = [];
 


### PR DESCRIPTION
I've found a few ways to considerably improve indexing performance and basically cut it in half.

One fix was also found in https://github.com/Toflar/state-set-index.

Approx. 30% is now spent on detecting languages which we can improve as well. I did one PR (https://github.com/patrickschur/language-detection/pull/54) but there is probably more potential in that library than just this.