### PR TITLE
Version 0.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
+              run: composer update --no-interaction --no-suggest
 
             - name: Run the CS fixer
               run: composer cs
@@ -37,13 +37,13 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
+              run: composer update --no-interaction --no-suggest
 
             - name: Run PHPStan
               run: composer phpstan
 
     tests:
-        name: PHP ${{ matrix.php }} with SQLite ${{ matrix.sqlite }}
+        name: 'PHP ${{ matrix.php }} with SQLite ${{ matrix.sqlite }} (Composer Flags: ${{ matrix.composer }})'
         runs-on: ubuntu-latest
         # Share the bash between the steps:
         defaults:
@@ -54,6 +54,7 @@ jobs:
             matrix:
                 sqlite: ['3.16.0', 'default']
                 php: ['8.1', '8.2']
+                composer: ['--prefer-stable', '--prefer-lowest']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -81,7 +82,7 @@ jobs:
                   source ~/.bash_profile
 
             - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
+              run: composer update --no-interaction --no-suggest ${{ matrix.composer }}
 
             - name: Run the unit tests
               run: composer tests

--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ Array
 
 ## Docs
 
-* [Schema](./docs/schema.md).
-* [Configuration](./docs/configuration.md).
-* [Searching](./docs/searching.md).
-* [Tokenizer](./docs/tokenizer.md).
+* [Schema](./docs/schema.md)
+* [Configuration](./docs/configuration.md)
+* [Indexing](./docs/indexing.md)
+* [Searching](./docs/searching.md)
+* [Tokenizer](./docs/tokenizer.md)
 
 "Why Loupe?" you ask? "Loupe" means "magnifier" in French and I felt like this was the appropriate choice for this 
 library after having given [my PHP crawler library][Escargot] a French name :-)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "ext-pdo_sqlite": "*",
         "ext-intl": "*",
         "doctrine/dbal": "^3.6",
         "wamania/php-stemmer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "ext-pdo_sqlite": "*",
         "ext-intl": "*",
-        "doctrine/dbal": "^3.5",
+        "doctrine/dbal": "^3.6",
         "wamania/php-stemmer": "^3.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "voku/portable-utf8": "^6.0",

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -1,0 +1,48 @@
+# Indexing
+
+There are two methods to index documents in Loupe. Either you index only one document like so:
+
+```php
+$indexResult = $loupe->addDocument([
+    'id' => 12,
+    'title' => 'Finding Nemo',
+    'overview' => 'Nemo, an adventurous young clownfish, …',
+    'genres' => ['Animation', 'Family']
+]);
+```
+
+Or you can index multiple documents:
+
+```php
+$indexResult = $loupe->addDocuments([
+    'id' => 11,
+    'title' => 'Star Wars',
+    'overview' => 'Princess Leia is captured and held hostage by the evil Imperial forces …',
+    'genres' => ['Adventure', 'Action', 'Science Fiction']
+], [
+    'id' => 12,
+    'title' => 'Finding Nemo',
+    'overview' => 'Nemo, an adventurous young clownfish, …',
+    'genres' => ['Animation', 'Family']
+]);
+```
+
+Whenever possible, you should use the `addDocuments()` method when you want to index multiple documents at the same 
+time. There are certain tasks like e.g. updating term frequencies and cleaning up the internal storage state etc. 
+which only have to happen once after all the documents are added. So it is more efficient to use `addDocuments()` 
+instead of calling `addDocument()` multiple times.
+
+Both of the methods return an `IndexResult` which provides the following methods:
+
+* `successfulDocumentsCount()` - contains the number of successfully indexed documents.
+* `erroredDocumentsCount()` - contains the number of errored documents.
+* `exceptionForDocument(int|string $documentId)` - allows you to check if a specific document ID errored and if so, 
+  why. This method returns either `null` (if it was successful) or an exception implementing `LoupeExceptionInterface`.
+* `allDocumentExceptions()` - returns all document related exceptions with the document ID as the key and an 
+  exception implementing `LoupeExceptionInterface` as value.
+* `generalException()` - returns either `null` (if there was no general exception) or an exception implementing 
+  `LoupeExceptionInterface`. A general exception is one that could not be linked to a document ID.
+
+For schema related logic, read [the dedicated schema docs][Schema].
+
+[Schema]: schema.md

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -39,8 +39,8 @@ This works, because `Star Wars` is a `string`, `overview` as well and the `genre
 
 ## Non-matching types
 
-If, however, you now want to index a second document that does not fulfill this schema, you will get an
-`InvalidDocumentException`:
+If, however, you now want to index a second document that does not fulfill this schema, you will get an 
+`IndexResult` containing an `InvalidDocumentException`:
 
 ```php
 $loupe->addDocument([

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -191,6 +191,16 @@ $results = [
 ];
 ```
 
+## Caching
+
+Loupe does not ship with built-in caching, so you are free to choose the caching mechanism of your choice. However,
+you can identify a search parameter combination using the `getHash()` method:
+
+```php
+$hash = \Loupe\Loupe\SearchParameters::create()
+    ->getHash();
+```
+
 ## Geo search
 
 Yes, Loupe also supports geo search! In contrast to MeiliSearch, however, Loupe does not need any special `_geo` 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -173,6 +173,8 @@ final class Configuration
      */
     public function withLanguages(array $languages): self
     {
+        sort($languages);
+
         $clone = clone $this;
         $clone->languages = $languages;
 

--- a/src/IndexResult.php
+++ b/src/IndexResult.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe;
+
+use Loupe\Loupe\Exception\LoupeExceptionInterface;
+
+final class IndexResult
+{
+    /**
+     * @param array<string|int, LoupeExceptionInterface> $documentExceptions
+     */
+    public function __construct(
+        private int $successfulCount,
+        private array $documentExceptions = [],
+        private ?LoupeExceptionInterface $generalException = null
+    ) {
+    }
+
+    /**
+     * @return array<string|int, LoupeExceptionInterface>
+     */
+    public function allDocumentExceptions(): array
+    {
+        return $this->documentExceptions;
+    }
+
+    public function erroredDocumentsCount(): int
+    {
+        return \count($this->documentExceptions);
+    }
+
+    public function exceptionForDocument(int|string $documentId): ?LoupeExceptionInterface
+    {
+        return $this->documentExceptions[$documentId] ?? null;
+    }
+
+    public function generalException(): ?LoupeExceptionInterface
+    {
+        return $this->generalException;
+    }
+
+    public function successfulDocumentsCount(): int
+    {
+        return $this->successfulCount;
+    }
+}

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -42,12 +42,13 @@ class Engine
         private Highlighter $highlighter,
         private Parser $filterParser
     ) {
-        if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform) {
-            throw new \InvalidArgumentException('Only SQLite is supported.');
+        $nativeConnection = $this->connection->getNativeConnection();
+
+        if (!$this->connection->getDatabasePlatform() instanceof SqlitePlatform || !$nativeConnection instanceof \PDO) {
+            throw new \InvalidArgumentException('Only SQLite via pdo_sqlite is supported.');
         }
 
-        $sqliteVersion = $this->connection->executeQuery('SELECT sqlite_version()')
-            ->fetchOne();
+        $sqliteVersion = $nativeConnection->getAttribute(\PDO::ATTR_SERVER_VERSION);
 
         if (version_compare($sqliteVersion, self::MIN_SQLITE_VERSION, '<')) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Loupe\Loupe\Configuration;
-use Loupe\Loupe\Exception\LoupeExceptionInterface;
+use Loupe\Loupe\IndexResult;
 use Loupe\Loupe\Internal\Filter\Parser;
 use Loupe\Loupe\Internal\Index\Indexer;
 use Loupe\Loupe\Internal\Index\IndexInfo;
@@ -75,13 +75,10 @@ class Engine
 
     /**
      * @param array<array<string, mixed>> $documents
-     * @throws LoupeExceptionInterface
      */
-    public function addDocuments(array $documents): self
+    public function addDocuments(array $documents): IndexResult
     {
-        $this->indexer->addDocuments($documents);
-
-        return $this;
+        return $this->indexer->addDocuments($documents);
     }
 
     public function countDocuments(): int

--- a/src/Internal/Filter/Ast/Group.php
+++ b/src/Internal/Filter/Ast/Group.php
@@ -26,6 +26,11 @@ class Group extends Node
         return $this->children;
     }
 
+    public function isEmpty(): bool
+    {
+        return $this->getChildren() === [];
+    }
+
     public function toArray(): array
     {
         $return = [];

--- a/src/Internal/Filter/Parser.php
+++ b/src/Internal/Filter/Parser.php
@@ -256,7 +256,6 @@ class Parser
 
             if ($this->lexer->lookahead?->type === Lexer::T_CLOSE_PARENTHESIS) {
                 $this->lexer->moveNext();
-                $this->lexer->moveNext();
                 break;
             }
 
@@ -270,8 +269,6 @@ class Parser
 
     private function handleIs(mixed $attributeName, Engine $engine): void
     {
-        $isMultiFilterable = \in_array($attributeName, $engine->getIndexInfo()->getMultiFilterableAttributes(), true);
-
         if ($this->lexer->lookahead?->type === Lexer::T_NULL) {
             $this->addNode(new Filter($attributeName, Operator::Equals, LoupeTypes::VALUE_NULL));
             return;

--- a/src/Loupe.php
+++ b/src/Loupe.php
@@ -16,24 +16,18 @@ final class Loupe
 
     /**
      * @param array<string, mixed> $document
-     *
-     * @throws IndexException
      */
-    public function addDocument(array $document): self
+    public function addDocument(array $document): IndexResult
     {
         return $this->addDocuments([$document]);
     }
 
     /**
      * @param array<int, array<string, mixed>> $documents
-     *
-     * @throws IndexException
      */
-    public function addDocuments(array $documents): self
+    public function addDocuments(array $documents): IndexResult
     {
-        $this->engine->addDocuments($documents);
-
-        return $this;
+        return $this->engine->addDocuments($documents);
     }
 
     public function countDocuments(): int

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -15,7 +15,7 @@ use Loupe\Loupe\Internal\Search\Highlighter\Highlighter;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
 use Nitotm\Eld\LanguageDetector;
 
-class LoupeFactory
+final class LoupeFactory
 {
     public function create(string $dbPath, Configuration $configuration): Loupe
     {

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -6,33 +6,92 @@ namespace Loupe\Loupe;
 
 use Doctrine\DBAL\Configuration as DbalConfiguration;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\API\SQLite\UserDefinedFunctions;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Logging\Middleware;
 use Loupe\Loupe\Exception\InvalidConfigurationException;
+use Loupe\Loupe\Internal\CosineSimilarity;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Parser;
+use Loupe\Loupe\Internal\Geo;
+use Loupe\Loupe\Internal\Levenshtein;
 use Loupe\Loupe\Internal\Search\Highlighter\Highlighter;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
+use Loupe\Loupe\Internal\Util;
 use Nitotm\Eld\LanguageDetector;
 
 final class LoupeFactory
 {
+    private const MIN_SQLITE_VERSION = '3.16.0'; // Introduction of Pragma functions
+
     public function create(string $dbPath, Configuration $configuration): Loupe
     {
         if (!file_exists($dbPath)) {
             throw InvalidConfigurationException::becauseInvalidDbPath($dbPath);
         }
 
-        return $this->createFromConnection(DriverManager::getConnection([
-            'url' => 'pdo-sqlite://notused:inthis@case/' . realpath($dbPath),
-        ], $this->getDbalConfiguration($configuration)), $configuration);
+        return $this->createFromConnection($this->createConnection($configuration, $dbPath), $configuration);
     }
 
     public function createInMemory(Configuration $configuration): Loupe
     {
-        return $this->createFromConnection(DriverManager::getConnection([
-            'url' => 'pdo-sqlite://:memory:',
-        ], $this->getDbalConfiguration($configuration)), $configuration);
+        return $this->createFromConnection($this->createConnection($configuration), $configuration);
+    }
+
+    public function isSupported(): bool
+    {
+        try {
+            $this->createConnection(Configuration::create());
+        } catch (\Throwable) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function createConnection(Configuration $configuration, ?string $dbPath = null): Connection
+    {
+        $connection = null;
+        $dsnPart = $dbPath === null ? ':memory:' : ('notused:inthis@case/' . realpath($dbPath));
+
+        // Try sqlite3 first, it seems way faster than the pdo-sqlite driver
+        try {
+            $connection = DriverManager::getConnection([
+                'url' => 'sqlite3://' . $dsnPart,
+            ], $this->getDbalConfiguration($configuration));
+        } catch (Exception $e) {
+            try {
+                $connection = DriverManager::getConnection([
+                    'url' => 'pdo-sqlite://' . $dsnPart,
+                ], $this->getDbalConfiguration($configuration));
+            } catch (Exception $e) {
+                // Noop
+            }
+        }
+
+        if ($connection === null) {
+            throw new InvalidConfigurationException('You need either the sqlite3 (recommended) or pdo_sqlite PHP extension.');
+        }
+
+        /** @var \PDO $nativeConnection */
+        $nativeConnection = $connection->getNativeConnection(); // Must be \PDO because we know what we instantiate here
+
+        $sqliteVersion = $nativeConnection->getAttribute(\PDO::ATTR_SERVER_VERSION);
+
+        if (version_compare($sqliteVersion, self::MIN_SQLITE_VERSION, '<')) {
+            throw new \InvalidArgumentException(sprintf(
+                'You need at least version "%s" of SQLite.',
+                self::MIN_SQLITE_VERSION
+            ));
+        }
+
+        // Use Write-Ahead Logging if possible
+        $connection->executeQuery('PRAGMA journal_mode=WAL;');
+
+        $this->registerSQLiteFunctions($connection, $sqliteVersion);
+
+        return $connection;
     }
 
     private function createFromConnection(Connection $connection, Configuration $configuration): Loupe
@@ -73,5 +132,42 @@ final class LoupeFactory
         }
 
         return $config;
+    }
+
+    private function registerSQLiteFunctions(Connection $connection, string $sqliteVersion): void
+    {
+        $functions = [
+            'max_levenshtein' => [
+                'callback' => [Levenshtein::class, 'maxLevenshtein'],
+                'numArgs' => 4,
+            ],
+            'geo_distance' => [
+                'callback' => [Geo::class, 'geoDistance'],
+                'numArgs' => 4,
+            ],
+            'loupe_relevance' => [
+                'callback' => [CosineSimilarity::class, 'fromQuery'],
+                'numArgs' => 3,
+            ],
+        ];
+
+        // Introduction of LN()
+        if (version_compare($sqliteVersion, '3.35.0', '<') || !$this->sqlLiteFunctionExists($connection, 'ln')) {
+            $functions['ln'] = [
+                'callback' => [Util::class, 'log'],
+                'numArgs' => 1,
+            ];
+        }
+
+        /** @phpstan-ignore-next-line */
+        UserDefinedFunctions::register([$connection->getNativeConnection(), 'sqliteCreateFunction'], $functions);
+    }
+
+    private function sqlLiteFunctionExists(Connection $connection, string $function): bool
+    {
+        return (bool) $connection->executeQuery(
+            'SELECT EXISTS(SELECT 1 FROM pragma_function_list WHERE name=?)',
+            [$function]
+        )->fetchOne();
     }
 }

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -77,6 +77,26 @@ final class SearchParameters
         return $this->filter;
     }
 
+    /**
+     * Returns a hash of all the search settings. Use this if you want to cache results per request.
+     */
+    public function getHash(): string
+    {
+        $hash = [];
+
+        $hash[] = json_encode($this->getAttributesToHighlight());
+        $hash[] = json_encode($this->getAttributesToRetrieve());
+        $hash[] = json_encode($this->getAttributesToSearchOn());
+        $hash[] = json_encode($this->getFilter());
+        $hash[] = json_encode($this->getHitsPerPage());
+        $hash[] = json_encode($this->getPage());
+        $hash[] = json_encode($this->getQuery());
+        $hash[] = json_encode($this->showMatchesPosition());
+        $hash[] = json_encode($this->showRankingScore());
+
+        return hash('sha256', implode(';', $hash));
+    }
+
     public function getHitsPerPage(): int
     {
         return $this->hitsPerPage;
@@ -115,6 +135,8 @@ final class SearchParameters
      */
     public function withAttributesToHighlight(array $attributesToHighlight): self
     {
+        sort($attributesToHighlight);
+
         $clone = clone $this;
         $clone->attributesToHighlight = $attributesToHighlight;
 
@@ -126,6 +148,8 @@ final class SearchParameters
      */
     public function withAttributesToRetrieve(array $attributesToRetrieve): self
     {
+        sort($attributesToRetrieve);
+
         $clone = clone $this;
         $clone->attributesToRetrieve = $attributesToRetrieve;
 
@@ -137,6 +161,8 @@ final class SearchParameters
      */
     public function withAttributesToSearchOn(array $attributesToSearchOn): self
     {
+        sort($attributesToSearchOn);
+
         $clone = clone $this;
         $clone->attributesToSearchOn = $attributesToSearchOn;
 

--- a/src/SearchResult.php
+++ b/src/SearchResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe;
 
-class SearchResult
+final class SearchResult
 {
     /**
      * @param array<array<string, mixed>> $hits

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -215,6 +215,44 @@ class ParserTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'Pointless nested groups' => [
+            "(((genres > 42 AND genres < 50 OR (genres IS NULL)) OR foobar = 'test'))",
+            [
+                [
+
+                    [
+                        [
+                            [
+                                'attribute' => 'genres',
+                                'operator' => '>',
+                                'value' => 42.0,
+                            ],
+                            ['AND'],
+                            [
+                                'attribute' => 'genres',
+                                'operator' => '<',
+                                'value' => 50.0,
+                            ],
+                            ['OR'],
+                            [
+                                [
+                                    'attribute' => 'genres',
+                                    'operator' => '=',
+                                    'value' => LoupeTypes::VALUE_NULL,
+                                ],
+                            ],
+                        ],
+                        ['OR'],
+                        [
+                            'attribute' => 'foobar',
+                            'operator' => '=',
+                            'value' => 'test',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public static function invalidFilterProvider(): \Generator

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -153,6 +153,31 @@ class ParserTest extends TestCase
             ],
         ];
 
+        yield 'IN filter at the end of a group' => [
+            "(genres IN ('Drama', 'Action') OR genres IN ('Documentary'))",
+            [
+                [
+                    [
+                        'attribute' => 'genres',
+                        'operator' => 'IN',
+                        'value' => [
+                            'Drama',
+                            'Action',
+                        ],
+                    ],
+                    ['OR'],
+                    [
+                        'attribute' => 'genres',
+                        'operator' => 'IN',
+                        'value' => [
+                            'Documentary',
+                        ],
+                    ],
+                ],
+
+            ],
+        ];
+
         yield 'Basic NOT IN filter' => [
             "genres NOT IN ('Drama', 'Action', 'Documentary')",
             [

--- a/tests/Unit/LoupeFactoryTest.php
+++ b/tests/Unit/LoupeFactoryTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit;
+
+use Loupe\Loupe\LoupeFactory;
+use PHPUnit\Framework\TestCase;
+
+class LoupeFactoryTest extends TestCase
+{
+    public function testIsSupported(): void
+    {
+        $factory = new LoupeFactory();
+        $this->assertTrue($factory->isSupported());
+    }
+}

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -10,6 +10,16 @@ use PHPUnit\Framework\TestCase;
 
 class SearchParametersTest extends TestCase
 {
+    public function testHash(): void
+    {
+        $searchParameters = SearchParameters::create();
+
+        $this->assertNotSame(
+            $searchParameters->getHash(),
+            $searchParameters->withPage(2)->getHash()
+        );
+    }
+
     public function testMaxHitsPerPage(): void
     {
         $this->expectException(InvalidSearchParametersException::class);


### PR DESCRIPTION
## New features

* Both `addDocuments()` and `addDocument()` now return an `IndexResult`. This means that when there's an issue in a document, `addDocuments()` now continues to index the rest of the documents and does not abort immediately anymore. `IndexResult` gives you access to the summary and individual exceptions of documents.
* Added `SearchParameters::getHash()` to identify a search query to allow for customized caching.
* Prefer the sqlite3 driver over pdo-sqlite for performance reasons.
* Uses the connection to determine the SQLite version instead of a separate query (better performance)

## Bugfixes

* Fixed wrong minimum requirement of Doctrine DBAL, the CI now also tests for `--prefer-lowest`.
* Fixed nested groups in filters were not properly parsed.
* Fixed IN() statement combined with groups