### PR TITLE
Set min requirement for doctrine dbal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "ext-pdo_sqlite": "*",
         "ext-intl": "*",
-        "doctrine/dbal": "^3.5",
+        "doctrine/dbal": "^3.6",
         "wamania/php-stemmer": "^3.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "voku/portable-utf8": "^6.0",


### PR DESCRIPTION
3.5.0 does not have the ArrayParameter class this does only exist since 3.6.

<img width="1018" alt="Bildschirmfoto 2023-08-26 um 17 23 28" src="https://github.com/loupe-php/loupe/assets/1698337/71daf2e7-3ccd-48be-a153-75700d21e8bb">
