### PR TITLE
Fix php-error in highlighter in an edge-case

### DIFF
--- a/src/Internal/Search/Highlighter/Highlighter.php
+++ b/src/Internal/Search/Highlighter/Highlighter.php
@@ -79,7 +79,7 @@ class Highlighter
             'starts' => [],
             'ends' => [],
         ];
-        $lastEnd = 0;
+        $lastEnd = null;
 
         foreach ($matches as $match) {
             $end = $match['start'] + $match['length'];


### PR DESCRIPTION
If something matches at the second character of a field there was a php error in the highlighter.

Example:
```php
<?php

use Loupe\Loupe\Configuration;
use Loupe\Loupe\Loupe;
use Loupe\Loupe\LoupeFactory;
use Loupe\Loupe\SearchParameters;

require_once(__DIR__ . '/vendor/autoload.php');

$configuration = Configuration::create()
    ->withPrimaryKey('id')
    ->withSearchableAttributes(['Title'])
    ->withLanguages(['de'])
;

$loupeFactory = new LoupeFactory();
$loupe = $loupeFactory->create(__DIR__ . '/loupe', $configuration);
$loupe->deleteDocument(1);
$loupe->addDocument([
    'id' => 1,
    'Title' => '"Hallo" Welt',
]);

$searchParameters = SearchParameters::create()
    ->withQuery('hallo')
    ->withAttributesToSearchOn(['Title'])
    ->withAttributesToHighlight(['Title'])
;
$results = $loupe->search($searchParameters);
```

Output:
```
Fatal error: Uncaught ValueError: max(): Argument #1 ($value) must contain at least one element in vendor\loupe\loupe\src\Internal\Search\Highlighter\Highlighter.php:87
```

The reason for this error is in the Highlighter::extractSpansFromMatches() method with the start value of $lastEnd.