### PR TITLE
Added support for highlighting array fields

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -614,15 +614,30 @@ class Searcher
                 continue;
             }
 
-            $highlightResult = $this->engine->getHighlighter()
-                ->highlight($formatted[$attribute], $tokenCollection);
+            if (\is_array($formatted[$attribute])) {
+                foreach ($formatted[$attribute] as $key => $formattedEntry) {
+                    $highlightResult = $this->engine->getHighlighter()
+                        ->highlight($formattedEntry, $tokenCollection);
 
-            if (\in_array($attribute, $attributesToHighlight, true)) {
-                $formatted[$attribute] = $highlightResult->getHighlightedText();
-            }
+                    if (\in_array($attribute, $attributesToHighlight, true)) {
+                        $formatted[$attribute][$key] = $highlightResult->getHighlightedText();
+                    }
 
-            if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
-                $matchesPosition[$attribute] = $highlightResult->getMatches();
+                    if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
+                        $matchesPosition[$attribute][$key] = $highlightResult->getMatches();
+                    }
+                }
+            } else {
+                $highlightResult = $this->engine->getHighlighter()
+                    ->highlight($formatted[$attribute], $tokenCollection);
+
+                if (\in_array($attribute, $attributesToHighlight, true)) {
+                    $formatted[$attribute] = $highlightResult->getHighlightedText();
+                }
+
+                if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
+                    $matchesPosition[$attribute] = $highlightResult->getMatches();
+                }
             }
         }
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -307,7 +307,7 @@ class SearchTest extends TestCase
                 'totalHits' => 1,
             ],
         ];
-        
+
         yield 'Highlight with array fields' => [
             'Animation',
             ['genres'],
@@ -334,7 +334,7 @@ class SearchTest extends TestCase
                 'totalHits' => 1,
             ],
         ];
-        
+
         yield 'Highlight with matches position with array fields' => [
             'Family',
             ['genres'],
@@ -358,8 +358,8 @@ class SearchTest extends TestCase
                                     [
                                         'start' => 0,
                                         'length' => 6,
-                                    ]
-                                ]
+                                    ],
+                                ],
                             ],
                         ],
                     ],
@@ -379,10 +379,10 @@ class SearchTest extends TestCase
                                 0 => [
                                     'start' => 127,
                                     'length' => 6,
-                                ]
+                                ],
                             ],
                         ],
-                    ]
+                    ],
                 ],
                 'query' => 'Family',
                 'hitsPerPage' => 20,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -177,6 +177,7 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_matchesPosition' => [
                             'overview' => [
                                 [
@@ -209,10 +210,12 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_formatted' => [
                             'id' => 24,
                             'title' => 'Kill Bill: Vol. 1',
                             'overview' => 'An <em>assassin</em> is shot by her ruthless employer, Bill, and other members of their <em>assassination</em> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
                         ],
                     ],
                 ],
@@ -234,10 +237,12 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_formatted' => [
                             'id' => 24,
                             'title' => 'Kill Bill: Vol. 1',
                             'overview' => 'An <em>assassin</em> is shot by her ruthless employer, Bill, and other members of their <em>assassination</em> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
                         ],
                     ],
                 ],
@@ -259,10 +264,12 @@ class SearchTest extends TestCase
                         'id' => 12,
                         'title' => 'Finding Nemo',
                         'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
                         '_formatted' => [
                             'id' => 12,
                             'title' => 'Finding Nemo',
                             'overview' => "Nemo, an adventurous young clownfish, is unexpectedly taken from his Great <em>Barrier Reef</em> home to a dentist's office aquarium. It's up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.",
+                            'genres' => ['Animation', 'Family'],
                         ],
                     ],
                 ],
@@ -284,10 +291,12 @@ class SearchTest extends TestCase
                         'id' => 12,
                         'title' => 'Finding Nemo',
                         'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
                         '_formatted' => [
                             'id' => 12,
                             'title' => 'Finding <em>Nemo</em>',
                             'overview' => "<em>Nemo</em>, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist's office aquarium. It's up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring <em>Nemo</em> home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.",
+                            'genres' => ['Animation', 'Family'],
                         ],
                     ],
                 ],
@@ -296,6 +305,90 @@ class SearchTest extends TestCase
                 'page' => 1,
                 'totalPages' => 1,
                 'totalHits' => 1,
+            ],
+        ];
+        
+        yield 'Highlight with array fields' => [
+            'Animation',
+            ['genres'],
+            false,
+            [
+                'hits' => [
+                    [
+                        'id' => 12,
+                        'title' => 'Finding Nemo',
+                        'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
+                        '_formatted' => [
+                            'id' => 12,
+                            'title' => 'Finding Nemo',
+                            'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                            'genres' => ['<em>Animation</em>', 'Family'],
+                        ],
+                    ],
+                ],
+                'query' => 'Animation',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+        ];
+        
+        yield 'Highlight with matches position with array fields' => [
+            'Family',
+            ['genres'],
+            true,
+            [
+                'hits' => [
+                    [
+                        'id' => 12,
+                        'title' => 'Finding Nemo',
+                        'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
+                        '_formatted' => [
+                            'id' => 12,
+                            'title' => 'Finding Nemo',
+                            'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                            'genres' => ['Animation', '<em>Family</em>'],
+                        ],
+                        '_matchesPosition' => [
+                            'genres' => [
+                                1 => [
+                                    [
+                                        'start' => 0,
+                                        'length' => 6,
+                                    ]
+                                ]
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 20,
+                        'title' => 'My Life Without Me',
+                        'overview' => 'A fatally ill mother with only two months to live creates a list of things she wants to do before she dies without telling her family of her illness.',
+                        'genres' => ['Drama', 'Romance'],
+                        '_formatted' => [
+                            'id' => 20,
+                            'title' => 'My Life Without Me',
+                            'overview' => 'A fatally ill mother with only two months to live creates a list of things she wants to do before she dies without telling her family of her illness.',
+                            'genres' => ['Drama', 'Romance'],
+                        ],
+                        '_matchesPosition' => [
+                            'overview' => [
+                                0 => [
+                                    'start' => 127,
+                                    'length' => 6,
+                                ]
+                            ],
+                        ],
+                    ]
+                ],
+                'query' => 'Family',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 2,
             ],
         ];
     }
@@ -885,7 +978,7 @@ class SearchTest extends TestCase
     public function testHighlighting(string $query, array $attributesToHighlight, bool $showMatchesPosition, array $expectedResults): void
     {
         $configuration = Configuration::create()
-            ->withSearchableAttributes(['title', 'overview'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
             ->withFilterableAttributes(['genres'])
             ->withSortableAttributes(['title'])
         ;
@@ -897,7 +990,7 @@ class SearchTest extends TestCase
             ->withQuery($query)
             ->withAttributesToHighlight($attributesToHighlight)
             ->withShowMatchesPosition($showMatchesPosition)
-            ->withAttributesToRetrieve(['id', 'title', 'overview'])
+            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
             ->withSort(['title:asc'])
         ;
 


### PR DESCRIPTION
When adding an array field to the searchable attributes currently triggers a php error when using the highlighting feature.

Error:
```
PHP Fatal error:  Uncaught TypeError: Loupe\Loupe\Internal\Search\Highlighter\Highlighter::highlight(): Argument #1 ($text) must be of type string, array given, called in vendor\loupe\loupe\src\Internal\Search\Searcher.php on line 618
```

Example code:
```php
<?php

use Loupe\Loupe\Configuration;
use Loupe\Loupe\Loupe;
use Loupe\Loupe\LoupeFactory;
use Loupe\Loupe\SearchParameters;

require_once(__DIR__ . '/vendor/autoload.php');

$configuration = Configuration::create()
    ->withPrimaryKey('id')
    ->withSearchableAttributes(['Title', 'Answers'])
    ->withLanguages(['de'])
;

$loupeFactory = new LoupeFactory();
$loupe = $loupeFactory->create(__DIR__ . '/loupe', $configuration);
$loupe->deleteDocument(1);
$loupe->addDocument([
    'id' => 1,
    'Title' => 'Hallo Welt',
    'Answers' => [
        'Hallo',
        'Welt',
        'Lorem ipsum Hallo',
    ]
]);

$searchParameters = SearchParameters::create()
    ->withQuery('hallo')
    ->withAttributesToSearchOn(['Title', 'Answers'])
    ->withAttributesToHighlight(['Title', 'Answers'])
;
$results = $loupe->search($searchParameters);

var_dump($results->getHits());
```

I'm not entirely sure whether this fix catches all edge cases and side effects - but at least for me it works like I expected it.