### PR TITLE
LanguageDetector tries to write into vendor directory

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -311,7 +311,7 @@ class Engine
         $generateNgramsRefFile = function (string $ngramsRefFile, array $languages): bool {
             // Prepare for the next time
             $languageDetector = new LanguageDetector();
-            $file = $languageDetector->langSubset($languages)->file;
+            $file = $languageDetector->langSubset($languages, false)->file;
 
             if ($file !== null) {
                 file_put_contents($ngramsRefFile, '<?php return ' . var_export($file, true) . ';');


### PR DESCRIPTION
Example code:
```php
<?php

use Loupe\Loupe\Configuration;
use Loupe\Loupe\Loupe;
use Loupe\Loupe\LoupeFactory;
use Loupe\Loupe\SearchParameters;

require_once(__DIR__ . '/vendor/autoload.php');

$configuration = Configuration::create()
    ->withPrimaryKey('id')
    ->withSearchableAttributes(['Title'])
    ->withLanguages(['de', 'en'])
;

$loupeFactory = new LoupeFactory();
$loupe = $loupeFactory->create(__DIR__ . '/loupe', $configuration);
$loupe->deleteDocument(1);
$loupe->addDocument([
    'id' => 1,
    'Title' => 'Hallo Welt',
]);

$searchParameters = SearchParameters::create()
    ->withQuery('hallo')
    ->withAttributesToSearchOn(['Title'])
    ->withAttributesToHighlight(['Title'])
;
$results = $loupe->search($searchParameters);

var_dump($results->getHits());
```

The important part here is that the vendor directory and all sub directories are not writable:
![image](https://github.com/loupe-php/loupe/assets/545671/04d54fd2-2bd1-4c11-b79f-9b088a0c8700)

The script above will trigger a php warning:
```
PHP Warning:  file_put_contents(./vendor/nitotm/efficient-language-detector/src/../resources/ngrams/subset/ngramsM60-2.qyy0ksvmfeo0o8sckwscoswcg8w0sgg.php): Failed to open stream: Permission denied in ./vendor/nitotm/efficient-language-detector/src/LanguageSubset.php on line 167
```

The error is triggered in \Loupe\Loupe\Internal\Engine::loadNGramsFile(). The method "\Nitotm\Eld\LanguageDetector::langSubset()" is called without a save argument which defaults to true.