### PR TITLE
Add possibility to define highlight start and end tag

### DIFF
--- a/src/Internal/Search/Highlighter/Highlighter.php
+++ b/src/Internal/Search/Highlighter/Highlighter.php
@@ -17,8 +17,12 @@ class Highlighter
     ) {
     }
 
-    public function highlight(string $text, TokenCollection $queryTokens): HighlightResult
-    {
+    public function highlight(
+        string $text,
+        TokenCollection $queryTokens,
+        string $startTag = '<em>',
+        string $endTag = '</em>',
+    ): HighlightResult {
         if ($text === '') {
             return new HighlightResult($text, []);
         }
@@ -42,9 +46,6 @@ class Highlighter
         uasort($matches, function (array $a, array $b) {
             return $a['start'] <=> $b['start'];
         });
-
-        $startTag = '<em>';
-        $endTag = '</em>';
 
         $pos = 0;
         $highlightedText = '';

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -612,6 +612,9 @@ class Searcher
             $this->searchParameters->getAttributesToHighlight()
         ;
 
+        $highlightStartTag = $this->searchParameters->getHighlightStartTag();
+        $highlightEndTag = $this->searchParameters->getHighlightEndTag();
+
         foreach ($searchableAttributes as $attribute) {
             // Do not include any attribute not required by the result (limited by attributesToRetrieve)
             if (!isset($formatted[$attribute])) {
@@ -621,7 +624,12 @@ class Searcher
             if (\is_array($formatted[$attribute])) {
                 foreach ($formatted[$attribute] as $key => $formattedEntry) {
                     $highlightResult = $this->engine->getHighlighter()
-                        ->highlight($formattedEntry, $tokenCollection);
+                        ->highlight(
+                            $formattedEntry,
+                            $tokenCollection,
+                            $highlightStartTag,
+                            $highlightEndTag
+                        );
 
                     if (\in_array($attribute, $attributesToHighlight, true)) {
                         $formatted[$attribute][$key] = $highlightResult->getHighlightedText();
@@ -633,7 +641,12 @@ class Searcher
                 }
             } else {
                 $highlightResult = $this->engine->getHighlighter()
-                    ->highlight((string) $formatted[$attribute], $tokenCollection);
+                    ->highlight(
+                        (string) $formatted[$attribute],
+                        $tokenCollection,
+                        $highlightStartTag,
+                        $highlightEndTag
+                    );
 
                 if (\in_array($attribute, $attributesToHighlight, true)) {
                     $formatted[$attribute] = $highlightResult->getHighlightedText();

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -28,6 +28,10 @@ final class SearchParameters
 
     private string $filter = '';
 
+    private string $highlightEndTag = '</em>';
+
+    private string $highlightStartTag = '<em>';
+
     private int $hitsPerPage = 20;
 
     private int $page = 1;
@@ -94,6 +98,8 @@ final class SearchParameters
         $hash = [];
 
         $hash[] = json_encode($this->getAttributesToHighlight());
+        $hash[] = json_encode($this->getHighlightStartTag());
+        $hash[] = json_encode($this->getHighlightEndTag());
         $hash[] = json_encode($this->getAttributesToRetrieve());
         $hash[] = json_encode($this->getAttributesToSearchOn());
         $hash[] = json_encode($this->getFilter());
@@ -104,6 +110,16 @@ final class SearchParameters
         $hash[] = json_encode($this->showRankingScore());
 
         return hash('sha256', implode(';', $hash));
+    }
+
+    public function getHighlightEndTag(): string
+    {
+        return $this->highlightEndTag;
+    }
+
+    public function getHighlightStartTag(): string
+    {
+        return $this->highlightStartTag;
     }
 
     public function getHitsPerPage(): int
@@ -142,12 +158,17 @@ final class SearchParameters
     /**
      * @param array<string> $attributesToHighlight
      */
-    public function withAttributesToHighlight(array $attributesToHighlight): self
-    {
+    public function withAttributesToHighlight(
+        array $attributesToHighlight,
+        string $highlightStartTag = '<em>',
+        string $highlightEndTag = '</em>',
+    ): self {
         sort($attributesToHighlight);
 
         $clone = clone $this;
         $clone->attributesToHighlight = $attributesToHighlight;
+        $clone->highlightStartTag = $highlightStartTag;
+        $clone->highlightEndTag = $highlightEndTag;
 
         return $clone;
     }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -263,6 +263,36 @@ class SearchTest extends TestCase
             ],
         ];
 
+        yield 'Highlight with custom start and end tag' => [
+            'assasin',
+            ['title', 'overview'],
+            ['title', 'overview'],
+            false,
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <mark>assassin</mark> is shot by her ruthless employer, Bill, and other members of their <mark>assassination</mark> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
+                        ],
+                    ],
+                ],
+                'query' => 'assasin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            '<mark>',
+            '</mark>',
+        ];
+
         yield 'Highlight without typo' => [
             'assassin',
             ['title', 'overview'],
@@ -1012,12 +1042,20 @@ class SearchTest extends TestCase
     }
 
     /**
+     * @param array<string> $searchableAttributes
      * @param array<string> $attributesToHighlight
      * @param array<mixed> $expectedResults
      */
     #[DataProvider('highlightingProvider')]
-    public function testHighlighting(string $query, array $searchableAttributes, array $attributesToHighlight, bool $showMatchesPosition, array $expectedResults): void
-    {
+    public function testHighlighting(
+        string $query,
+        array $searchableAttributes,
+        array $attributesToHighlight,
+        bool $showMatchesPosition,
+        array $expectedResults,
+        string $highlightStartTag = '<em>',
+        string $highlightEndTag = '</em>',
+    ): void {
         $configuration = Configuration::create()
             ->withSearchableAttributes($searchableAttributes)
             ->withFilterableAttributes(['genres'])
@@ -1029,7 +1067,7 @@ class SearchTest extends TestCase
 
         $searchParameters = SearchParameters::create()
             ->withQuery($query)
-            ->withAttributesToHighlight($attributesToHighlight)
+            ->withAttributesToHighlight($attributesToHighlight, $highlightStartTag, $highlightEndTag)
             ->withShowMatchesPosition($showMatchesPosition)
             ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
             ->withSort(['title:asc'])


### PR DESCRIPTION
Currently always `<em></em>` is used for the highlighted text but `<mark></mark>` or custom tags with classes are maybe in some cases used.

Currently looking into how to implement such things into SEAL: https://github.com/schranz-search/schranz-search/issues/343