### PR TITLE
0.6.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
             fail-fast: false
             matrix:
                 sqlite: ['3.16.0', 'default']
-                php: ['8.1', '8.2']
+                php: ['8.1', '8.2', '8.3']
                 composer: ['--prefer-stable', '--prefer-lowest']
         steps:
             - name: Setup PHP

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -140,6 +140,14 @@ $searchParameters = \Loupe\Loupe\SearchParameters::create()
 ```
 
 Your result hits will then contain a `_formatted` key where you'll find the matches embedded in `<em>` and `</em>` tags.
+The opening and closing tags can also be configured, in case you need something different from `<em>` and `</em>`. For this,
+use the second and third parameters like so:
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToHighlight(['title', 'overview'], '<mark>', '</mark>')
+```
+
 This is how this could look like when having searched for `assassin`:
 
 ```php

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -188,7 +188,11 @@ class IndexInfo
                 ->where("key = 'documentSchema'")
                 ->fetchOne();
 
-            $this->documentSchema = Util::decodeJson($schema);
+            if ($schema === false) {
+                $this->documentSchema = [];
+            } else {
+                $this->documentSchema = Util::decodeJson($schema);
+            }
         }
 
         return $this->documentSchema;

--- a/src/Internal/Search/Highlighter/Highlighter.php
+++ b/src/Internal/Search/Highlighter/Highlighter.php
@@ -17,8 +17,12 @@ class Highlighter
     ) {
     }
 
-    public function highlight(string $text, TokenCollection $queryTokens): HighlightResult
-    {
+    public function highlight(
+        string $text,
+        TokenCollection $queryTokens,
+        string $startTag = '<em>',
+        string $endTag = '</em>',
+    ): HighlightResult {
         if ($text === '') {
             return new HighlightResult($text, []);
         }
@@ -42,9 +46,6 @@ class Highlighter
         uasort($matches, function (array $a, array $b) {
             return $a['start'] <=> $b['start'];
         });
-
-        $startTag = '<em>';
-        $endTag = '</em>';
 
         $pos = 0;
         $highlightedText = '';

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -614,15 +614,30 @@ class Searcher
                 continue;
             }
 
-            $highlightResult = $this->engine->getHighlighter()
-                ->highlight($formatted[$attribute], $tokenCollection);
+            if (\is_array($formatted[$attribute])) {
+                foreach ($formatted[$attribute] as $key => $formattedEntry) {
+                    $highlightResult = $this->engine->getHighlighter()
+                        ->highlight($formattedEntry, $tokenCollection);
 
-            if (\in_array($attribute, $attributesToHighlight, true)) {
-                $formatted[$attribute] = $highlightResult->getHighlightedText();
-            }
+                    if (\in_array($attribute, $attributesToHighlight, true)) {
+                        $formatted[$attribute][$key] = $highlightResult->getHighlightedText();
+                    }
 
-            if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
-                $matchesPosition[$attribute] = $highlightResult->getMatches();
+                    if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
+                        $matchesPosition[$attribute][$key] = $highlightResult->getMatches();
+                    }
+                }
+            } else {
+                $highlightResult = $this->engine->getHighlighter()
+                    ->highlight($formatted[$attribute], $tokenCollection);
+
+                if (\in_array($attribute, $attributesToHighlight, true)) {
+                    $formatted[$attribute] = $highlightResult->getHighlightedText();
+                }
+
+                if ($this->searchParameters->showMatchesPosition() && $highlightResult->getMatches() !== []) {
+                    $matchesPosition[$attribute] = $highlightResult->getMatches();
+                }
             }
         }
 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -612,6 +612,9 @@ class Searcher
             $this->searchParameters->getAttributesToHighlight()
         ;
 
+        $highlightStartTag = $this->searchParameters->getHighlightStartTag();
+        $highlightEndTag = $this->searchParameters->getHighlightEndTag();
+
         foreach ($searchableAttributes as $attribute) {
             // Do not include any attribute not required by the result (limited by attributesToRetrieve)
             if (!isset($formatted[$attribute])) {
@@ -621,7 +624,12 @@ class Searcher
             if (\is_array($formatted[$attribute])) {
                 foreach ($formatted[$attribute] as $key => $formattedEntry) {
                     $highlightResult = $this->engine->getHighlighter()
-                        ->highlight($formattedEntry, $tokenCollection);
+                        ->highlight(
+                            $formattedEntry,
+                            $tokenCollection,
+                            $highlightStartTag,
+                            $highlightEndTag
+                        );
 
                     if (\in_array($attribute, $attributesToHighlight, true)) {
                         $formatted[$attribute][$key] = $highlightResult->getHighlightedText();
@@ -633,7 +641,12 @@ class Searcher
                 }
             } else {
                 $highlightResult = $this->engine->getHighlighter()
-                    ->highlight((string) $formatted[$attribute], $tokenCollection);
+                    ->highlight(
+                        (string) $formatted[$attribute],
+                        $tokenCollection,
+                        $highlightStartTag,
+                        $highlightEndTag
+                    );
 
                 if (\in_array($attribute, $attributesToHighlight, true)) {
                     $formatted[$attribute] = $highlightResult->getHighlightedText();

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -28,6 +28,10 @@ final class SearchParameters
 
     private string $filter = '';
 
+    private string $highlightEndTag = '</em>';
+
+    private string $highlightStartTag = '<em>';
+
     private int $hitsPerPage = 20;
 
     private int $page = 1;
@@ -94,6 +98,8 @@ final class SearchParameters
         $hash = [];
 
         $hash[] = json_encode($this->getAttributesToHighlight());
+        $hash[] = json_encode($this->getHighlightStartTag());
+        $hash[] = json_encode($this->getHighlightEndTag());
         $hash[] = json_encode($this->getAttributesToRetrieve());
         $hash[] = json_encode($this->getAttributesToSearchOn());
         $hash[] = json_encode($this->getFilter());
@@ -104,6 +110,16 @@ final class SearchParameters
         $hash[] = json_encode($this->showRankingScore());
 
         return hash('sha256', implode(';', $hash));
+    }
+
+    public function getHighlightEndTag(): string
+    {
+        return $this->highlightEndTag;
+    }
+
+    public function getHighlightStartTag(): string
+    {
+        return $this->highlightStartTag;
     }
 
     public function getHitsPerPage(): int
@@ -142,12 +158,17 @@ final class SearchParameters
     /**
      * @param array<string> $attributesToHighlight
      */
-    public function withAttributesToHighlight(array $attributesToHighlight): self
-    {
+    public function withAttributesToHighlight(
+        array $attributesToHighlight,
+        string $highlightStartTag = '<em>',
+        string $highlightEndTag = '</em>',
+    ): self {
         sort($attributesToHighlight);
 
         $clone = clone $this;
         $clone->attributesToHighlight = $attributesToHighlight;
+        $clone->highlightStartTag = $highlightStartTag;
+        $clone->highlightEndTag = $highlightEndTag;
 
         return $clone;
     }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -177,6 +177,7 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_matchesPosition' => [
                             'overview' => [
                                 [
@@ -209,10 +210,12 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_formatted' => [
                             'id' => 24,
                             'title' => 'Kill Bill: Vol. 1',
                             'overview' => 'An <em>assassin</em> is shot by her ruthless employer, Bill, and other members of their <em>assassination</em> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
                         ],
                     ],
                 ],
@@ -234,10 +237,12 @@ class SearchTest extends TestCase
                         'id' => 24,
                         'title' => 'Kill Bill: Vol. 1',
                         'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
                         '_formatted' => [
                             'id' => 24,
                             'title' => 'Kill Bill: Vol. 1',
                             'overview' => 'An <em>assassin</em> is shot by her ruthless employer, Bill, and other members of their <em>assassination</em> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
                         ],
                     ],
                 ],
@@ -259,10 +264,12 @@ class SearchTest extends TestCase
                         'id' => 12,
                         'title' => 'Finding Nemo',
                         'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
                         '_formatted' => [
                             'id' => 12,
                             'title' => 'Finding Nemo',
                             'overview' => "Nemo, an adventurous young clownfish, is unexpectedly taken from his Great <em>Barrier Reef</em> home to a dentist's office aquarium. It's up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.",
+                            'genres' => ['Animation', 'Family'],
                         ],
                     ],
                 ],
@@ -284,10 +291,12 @@ class SearchTest extends TestCase
                         'id' => 12,
                         'title' => 'Finding Nemo',
                         'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
                         '_formatted' => [
                             'id' => 12,
                             'title' => 'Finding <em>Nemo</em>',
                             'overview' => "<em>Nemo</em>, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist's office aquarium. It's up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring <em>Nemo</em> home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.",
+                            'genres' => ['Animation', 'Family'],
                         ],
                     ],
                 ],
@@ -296,6 +305,90 @@ class SearchTest extends TestCase
                 'page' => 1,
                 'totalPages' => 1,
                 'totalHits' => 1,
+            ],
+        ];
+
+        yield 'Highlight with array fields' => [
+            'Animation',
+            ['genres'],
+            false,
+            [
+                'hits' => [
+                    [
+                        'id' => 12,
+                        'title' => 'Finding Nemo',
+                        'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
+                        '_formatted' => [
+                            'id' => 12,
+                            'title' => 'Finding Nemo',
+                            'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                            'genres' => ['<em>Animation</em>', 'Family'],
+                        ],
+                    ],
+                ],
+                'query' => 'Animation',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+        ];
+
+        yield 'Highlight with matches position with array fields' => [
+            'Family',
+            ['genres'],
+            true,
+            [
+                'hits' => [
+                    [
+                        'id' => 12,
+                        'title' => 'Finding Nemo',
+                        'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                        'genres' => ['Animation', 'Family'],
+                        '_formatted' => [
+                            'id' => 12,
+                            'title' => 'Finding Nemo',
+                            'overview' => 'Nemo, an adventurous young clownfish, is unexpectedly taken from his Great Barrier Reef home to a dentist\'s office aquarium. It\'s up to his worrisome father Marlin and a friendly but forgetful fish Dory to bring Nemo home -- meeting vegetarian sharks, surfer dude turtles, hypnotic jellyfish, hungry seagulls, and more along the way.',
+                            'genres' => ['Animation', '<em>Family</em>'],
+                        ],
+                        '_matchesPosition' => [
+                            'genres' => [
+                                1 => [
+                                    [
+                                        'start' => 0,
+                                        'length' => 6,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 20,
+                        'title' => 'My Life Without Me',
+                        'overview' => 'A fatally ill mother with only two months to live creates a list of things she wants to do before she dies without telling her family of her illness.',
+                        'genres' => ['Drama', 'Romance'],
+                        '_formatted' => [
+                            'id' => 20,
+                            'title' => 'My Life Without Me',
+                            'overview' => 'A fatally ill mother with only two months to live creates a list of things she wants to do before she dies without telling her family of her illness.',
+                            'genres' => ['Drama', 'Romance'],
+                        ],
+                        '_matchesPosition' => [
+                            'overview' => [
+                                0 => [
+                                    'start' => 127,
+                                    'length' => 6,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'query' => 'Family',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 2,
             ],
         ];
     }
@@ -885,7 +978,7 @@ class SearchTest extends TestCase
     public function testHighlighting(string $query, array $attributesToHighlight, bool $showMatchesPosition, array $expectedResults): void
     {
         $configuration = Configuration::create()
-            ->withSearchableAttributes(['title', 'overview'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
             ->withFilterableAttributes(['genres'])
             ->withSortableAttributes(['title'])
         ;
@@ -897,7 +990,7 @@ class SearchTest extends TestCase
             ->withQuery($query)
             ->withAttributesToHighlight($attributesToHighlight)
             ->withShowMatchesPosition($showMatchesPosition)
-            ->withAttributesToRetrieve(['id', 'title', 'overview'])
+            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
             ->withSort(['title:asc'])
         ;
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -263,6 +263,36 @@ class SearchTest extends TestCase
             ],
         ];
 
+        yield 'Highlight with custom start and end tag' => [
+            'assasin',
+            ['title', 'overview'],
+            ['title', 'overview'],
+            false,
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <mark>assassin</mark> is shot by her ruthless employer, Bill, and other members of their <mark>assassination</mark> circle – but she lives to plot her vengeance.',
+                            'genres' => ['Action', 'Crime'],
+                        ],
+                    ],
+                ],
+                'query' => 'assasin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            '<mark>',
+            '</mark>',
+        ];
+
         yield 'Highlight without typo' => [
             'assassin',
             ['title', 'overview'],
@@ -1012,12 +1042,20 @@ class SearchTest extends TestCase
     }
 
     /**
+     * @param array<string> $searchableAttributes
      * @param array<string> $attributesToHighlight
      * @param array<mixed> $expectedResults
      */
     #[DataProvider('highlightingProvider')]
-    public function testHighlighting(string $query, array $searchableAttributes, array $attributesToHighlight, bool $showMatchesPosition, array $expectedResults): void
-    {
+    public function testHighlighting(
+        string $query,
+        array $searchableAttributes,
+        array $attributesToHighlight,
+        bool $showMatchesPosition,
+        array $expectedResults,
+        string $highlightStartTag = '<em>',
+        string $highlightEndTag = '</em>',
+    ): void {
         $configuration = Configuration::create()
             ->withSearchableAttributes($searchableAttributes)
             ->withFilterableAttributes(['genres'])
@@ -1029,7 +1067,7 @@ class SearchTest extends TestCase
 
         $searchParameters = SearchParameters::create()
             ->withQuery($query)
-            ->withAttributesToHighlight($attributesToHighlight)
+            ->withAttributesToHighlight($attributesToHighlight, $highlightStartTag, $highlightEndTag)
             ->withShowMatchesPosition($showMatchesPosition)
             ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
             ->withSort(['title:asc'])


### PR DESCRIPTION
# Version 0.6.0

* Highlighting now also works on array fields
* Highlighting can now take configurable opening and closing tags

    ```php
    $searchParameters = \Loupe\Loupe\SearchParameters::create()
        ->withAttributesToHighlight(['title', 'overview'], '<mark>', '</mark>')
    ```
