### PR TITLE
Fixed relevance calculation for non-existent terms

### DIFF
--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -33,10 +33,12 @@ class Relevance extends AbstractSorter
         $select = sprintf(
             'loupe_relevance(
                     %s,
+                    %s,
                     (SELECT group_concat(idf) FROM %s),
                     (SELECT group_concat(tfidf) FROM %s WHERE %s.id=document)
             ) AS %s',
             $searcher->getQueryBuilder()->createNamedParameter($searcher->getQueryId()),
+            $searcher->getQueryBuilder()->createNamedParameter(\count($searcher->getTokens()->allTermsWithVariants())),
             Searcher::CTE_TERM_MATCHES,
             Searcher::CTE_TERM_DOCUMENT_MATCHES,
             $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -129,7 +129,7 @@ final class LoupeFactory
             ],
             'loupe_relevance' => [
                 'callback' => [CosineSimilarity::class, 'fromQuery'],
-                'numArgs' => 3,
+                'numArgs' => 4,
             ],
         ];
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1229,12 +1229,12 @@ class SearchTest extends TestCase
                     'title' => 'Star Wars',
                 ],
                 [
-                    'id' => 25,
-                    'title' => 'Jarhead',
-                ],
-                [
                     'id' => 28,
                     'title' => 'Apocalypse Now',
+                ],
+                [
+                    'id' => 25,
+                    'title' => 'Jarhead',
                 ],
             ],
             'query' => 'I like Star Wars',
@@ -1462,6 +1462,61 @@ class SearchTest extends TestCase
                 ],
             ],
             'query' => 'life learning',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 3,
+        ]);
+    }
+
+    public function testRelevanceAndRankingScoreForNonExistentQueryTerms(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['content'])
+            ->withSortableAttributes(['content'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'content' => 'The game of life is a game of everlasting learning',
+            ],
+            [
+                'id' => 2,
+                'content' => 'The unexamined life is not worth living',
+            ],
+            [
+                'id' => 3,
+                'content' => 'Never stop learning',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('foobar life learning')
+            ->withAttributesToRetrieve(['id', 'content'])
+            ->withShowRankingScore(true)
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 1,
+                    'content' => 'The game of life is a game of everlasting learning',
+                    '_rankingScore' => 0.6301,
+                ],
+                [
+                    'id' => 3,
+                    'content' => 'Never stop learning',
+                    '_rankingScore' => 0.51447,
+                ],
+                [
+                    'id' => 2,
+                    'content' => 'The unexamined life is not worth living',
+                    '_rankingScore' => 0.36379,
+                ],
+            ],
+            'query' => 'foobar life learning',
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,


### PR DESCRIPTION
It's important that we pad the term matches to the total tokens searched so that terms that do not exist in our entire index are handled with a TF-IDF of 1. Otherwise, if you'd search for "foobar" and there is not a single document with "foobar" in your index, it would not be considered in the cosine similarity giving you completely wrong results.