### PR TITLE
Add reproducer for issue with big distances

### DIFF
--- a/tests/Functional/IndexData/locations.json
+++ b/tests/Functional/IndexData/locations.json
@@ -1,0 +1,29 @@
+[
+    {
+        "id": "1",
+        "title": "New York",
+        "location": {
+            "lat": 40.7128,
+            "lng": -74.006
+        }
+    },
+    {
+        "id": "2",
+        "title": "London",
+        "location": {
+            "lat": 51.5074,
+            "lng": -0.1278
+        }
+    },
+    {
+        "id": "3",
+        "title": "Vienna",
+        "location": {
+            "lat": 48.2082,
+            "lng": 16.3738
+        }
+    },
+    {
+        "id": "4"
+    }
+]


### PR DESCRIPTION
#### Big distances

I found out that a distance from

 - `4587758 m` filter works
 - but `4587759 m` filter or bigger ends in no result

Setup:

 - Berlin
   - New York ~6400 km
   - London ~ 932 km
   - Wien ~ 524 km

Filter on Berlin radius 6000 km ends in no result.

The `4587758 m` works but all numbers over `4587759 m` fails.

#### Retrieve distance without sorting

Additional I found out that it seems not be possible to retrieve the distance `_geoDistance(location)` if no sort by / sortable to the the distance is given.