### PR TITLE
Add GeoBoundingBox filter

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -286,11 +286,11 @@ $results = [
 
 Additional to a query based on distance we can also search for locations inside a bounding box.
 In this example we have 4 documents and 3 with geo coordinates (New York, London, Vienna).
-We have a bounding context which goes from Dublin to Athen which so returns only London and Vienna.
+We create a bounding box filter which spans from Dublin to Athens which then only matches our documents in London and Vienna.
 
 Keep in mind that the order of the arguments is important.
-The `_geoBoundingBox` expect `attributeName`, `north` (top), `east` (right), `south` (bottom), `west` (left).
-In this specific example top is Dublin Latitude, right is Athen Longitude, bottom is Athen Latitude and left is Dublin Longitude.
+The `_geoBoundingBox` expects `attributeName`, `north` (top), `east` (right), `south` (bottom), `west` (left).
+In this specific example, `top` is the latitude of Dublin,`right` is the longitude of Athens,`bottom` is the latitude of Athens and`left` equals Dublin's longitude.
 
 ```php
 $searchParameters = SearchParameters::create()
@@ -299,7 +299,7 @@ $searchParameters = SearchParameters::create()
 ;
 ```
 
-This will result looks like this::
+This is going to be your result:
 
 ```php
 $results = [

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -283,3 +283,51 @@ $results = [
 
 [Config]: configuration.md
 [Restaurant_Fixture]: ./../tests/Functional/IndexData/restaurants.json
+
+Additional to a query based on distance we can also search for locations inside a bounding box.
+In this example we have 4 documents and 3 with geo coordinates (New York, London, Vienna).
+We have a bounding context which goes from Dublin to Athen which so returns only London and Vienna.
+
+Keep in mind that the order of the arguments is important.
+The `_geoBoundingBox` expect `attributeName`, `north` (top), `east` (right), `south` (bottom), `west` (left).
+In this specific example top is Dublin Latitude, right is Athen Longitude, bottom is Athen Latitude and left is Dublin Longitude.
+
+```php
+$searchParameters = SearchParameters::create()
+    ->withAttributesToRetrieve(['id', 'name', 'location'])
+    ->withFilter('_geoBoundingBox(location, 53.3498, 23.7275, 37.9838, -6.2603)')
+;
+```
+
+This will result looks like this::
+
+```php
+$results = [
+    'hits' => [
+        [
+            'id' => '2',
+            'title' => 'London',
+            'location' => [
+                'lat' => 51.5074,
+                'lng' => -0.1278,
+            ],
+        ],
+        [
+            'id' => '3',
+            'title' => 'Vienna',
+            'location' => [
+                'lat' => 48.2082,
+                'lng' => 16.3738,
+            ],
+        ],
+    ],
+    'query' => '',
+    'hitsPerPage' => 20,
+    'page' => 1,
+    'totalPages' => 1,
+    'totalHits' => 2,
+];
+```
+
+[Config]: configuration.md
+[Restaurant_Fixture]: ./../tests/Functional/IndexData/locations.json

--- a/src/Internal/Filter/Ast/GeoBoundingBox.php
+++ b/src/Internal/Filter/Ast/GeoBoundingBox.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Filter\Ast;
+
+use Location\Bounds;
+use Location\Coordinate;
+
+class GeoBoundingBox extends Node
+{
+    public function __construct(
+        public string $attributeName,
+        public float $north,
+        public float $east,
+        public float $south,
+        public float $west,
+    ) {
+    }
+
+    public function getBbox(): Bounds
+    {
+        // phpgeo bounds are top left to bottom right but meilisearch and so loupe is top right to bottom left
+        return new Bounds(
+            new Coordinate($this->north, $this->west),
+            new Coordinate($this->south, $this->east),
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'attribute' => $this->attributeName,
+            'north' => $this->north,
+            'east' => $this->east,
+            'south' => $this->south,
+            'west' => $this->west,
+        ];
+    }
+}

--- a/src/Internal/Filter/Ast/GeoBoundingBox.php
+++ b/src/Internal/Filter/Ast/GeoBoundingBox.php
@@ -20,7 +20,6 @@ class GeoBoundingBox extends Node
 
     public function getBbox(): Bounds
     {
-        // phpgeo bounds are top left to bottom right but meilisearch and so loupe is top right to bottom left
         return new Bounds(
             new Coordinate($this->north, $this->west),
             new Coordinate($this->south, $this->east),

--- a/src/Internal/Filter/Ast/GeoBoundingBox.php
+++ b/src/Internal/Filter/Ast/GeoBoundingBox.php
@@ -9,31 +9,34 @@ use Location\Coordinate;
 
 class GeoBoundingBox extends Node
 {
+    private Bounds $bbox;
+
     public function __construct(
         public string $attributeName,
-        public float $north,
-        public float $east,
-        public float $south,
-        public float $west,
+        float $north,
+        float $east,
+        float $south,
+        float $west,
     ) {
+        $this->bbox = new Bounds(
+            new Coordinate($north, $west),
+            new Coordinate($south, $east),
+        );
     }
 
     public function getBbox(): Bounds
     {
-        return new Bounds(
-            new Coordinate($this->north, $this->west),
-            new Coordinate($this->south, $this->east),
-        );
+        return $this->bbox;
     }
 
     public function toArray(): array
     {
         return [
             'attribute' => $this->attributeName,
-            'north' => $this->north,
-            'east' => $this->east,
-            'south' => $this->south,
-            'west' => $this->west,
+            'north' => $this->bbox->getNorth(),
+            'east' => $this->bbox->getEast(),
+            'south' => $this->bbox->getSouth(),
+            'west' => $this->bbox->getWest(),
         ];
     }
 }

--- a/src/Internal/Filter/Lexer.php
+++ b/src/Internal/Filter/Lexer.php
@@ -25,6 +25,8 @@ class Lexer extends AbstractLexer
 
     public const T_FLOAT = 5;
 
+    public const T_GEO_BOUNDING_BOX = 102;
+
     public const T_GEO_RADIUS = 101;
 
     public const T_GREATER_THAN = 12;
@@ -113,6 +115,9 @@ class Lexer extends AbstractLexer
 
             case $value === '_geoRadius':
                 return self::T_GEO_RADIUS;
+
+            case $value === '_geoBoundingBox':
+                return self::T_GEO_BOUNDING_BOX;
 
                 // Attribute names
             case IndexInfo::isValidAttributeName($value):

--- a/src/Internal/Filter/Parser.php
+++ b/src/Internal/Filter/Parser.php
@@ -10,6 +10,7 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Ast\Ast;
 use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
 use Loupe\Loupe\Internal\Filter\Ast\Filter;
+use Loupe\Loupe\Internal\Filter\Ast\GeoBoundingBox;
 use Loupe\Loupe\Internal\Filter\Ast\GeoDistance;
 use Loupe\Loupe\Internal\Filter\Ast\Group;
 use Loupe\Loupe\Internal\Filter\Ast\Node;
@@ -49,6 +50,7 @@ class Parser
             if ($start && !$this->lexer->token?->isA(
                 Lexer::T_ATTRIBUTE_NAME,
                 Lexer::T_GEO_RADIUS,
+                Lexer::T_GEO_BOUNDING_BOX,
                 Lexer::T_OPEN_PARENTHESIS
             )) {
                 $this->syntaxError('an attribute name, _geoRadius() or \'(\'');
@@ -58,6 +60,11 @@ class Parser
 
             if ($this->lexer->token?->type === Lexer::T_GEO_RADIUS) {
                 $this->handleGeoRadius($engine);
+                continue;
+            }
+
+            if ($this->lexer->token?->type === Lexer::T_GEO_BOUNDING_BOX) {
+                $this->handleGeoBoundingBox($engine);
                 continue;
             }
 
@@ -232,6 +239,41 @@ class Parser
         $this->lexer->moveNext();
 
         $this->addNode(new Filter($attributeName, Operator::fromString($operator), $this->getTokenValueBasedOnType()));
+    }
+
+    private function handleGeoBoundingBox(Engine $engine): void
+    {
+        $this->assertOpeningParenthesis($this->lexer->lookahead);
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
+
+        $attributeName = (string) $this->lexer->token?->value;
+
+        $this->validateFilterableAttribute($engine, $attributeName);
+
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
+        $north = $this->assertAndExtractFloat($this->lexer->token, true);
+        $this->assertComma($this->lexer->lookahead);
+
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
+        $east = $this->assertAndExtractFloat($this->lexer->token, true);
+        $this->assertComma($this->lexer->lookahead);
+
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
+        $south = $this->assertAndExtractFloat($this->lexer->token, true);
+        $this->assertComma($this->lexer->lookahead);
+
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
+        $west = $this->assertAndExtractFloat($this->lexer->token, true);
+        $this->assertClosingParenthesis($this->lexer->lookahead);
+
+        $this->addNode(new GeoBoundingBox($attributeName, $north, $east, $south, $west));
+
+        $this->lexer->moveNext();
     }
 
     private function handleGeoRadius(Engine $engine): void

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Result;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
 use Loupe\Loupe\Internal\Filter\Ast\Filter;
+use Loupe\Loupe\Internal\Filter\Ast\GeoBoundingBox;
 use Loupe\Loupe\Internal\Filter\Ast\GeoDistance;
 use Loupe\Loupe\Internal\Filter\Ast\Group;
 use Loupe\Loupe\Internal\Filter\Ast\Node;
@@ -606,6 +607,51 @@ class Searcher
             $whereStatement[] = self::DISTANCE_ALIAS . '_' . $node->attributeName;
             $whereStatement[] = '<=';
             $whereStatement[] = $node->distance;
+
+            // End group
+            $whereStatement[] = ')';
+        }
+
+        if ($node instanceof GeoBoundingBox) {
+            // Not existing attributes need be handled as no match
+            if (!\in_array($node->attributeName, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
+                $whereStatement[] = '1 = 0';
+                return;
+            }
+
+            // Start a group GeoDistance BBOX
+            $whereStatement[] = '(';
+
+            // Same like above for
+            $bounds = $node->getBbox();
+
+            // Prevent nullable
+            $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
+            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+            $whereStatement[] = '!=';
+            $whereStatement[] = $nullTerm;
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+            $whereStatement[] = '!=';
+            $whereStatement[] = $nullTerm;
+
+            $whereStatement[] = 'AND';
+
+            // Longitude
+            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+            $whereStatement[] = 'BETWEEN';
+            $whereStatement[] = $bounds->getWest();
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $bounds->getEast();
+
+            $whereStatement[] = 'AND';
+
+            // Latitude
+            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+            $whereStatement[] = 'BETWEEN';
+            $whereStatement[] = $bounds->getSouth();
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $bounds->getNorth();
 
             // End group
             $whereStatement[] = ')';

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -286,6 +286,44 @@ class Searcher
     }
 
     /**
+     * @return array<string|float>
+     */
+    private function createGeoBoundingBoxWhereStatement(string $documentAlias, GeoBoundingBox|GeoDistance $node, Bounds $bounds): array
+    {
+        $whereStatement = [];
+
+        // Prevent nullable
+        $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+
+        $whereStatement[] = 'AND';
+
+        // Longitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getWest();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getEast();
+
+        $whereStatement[] = 'AND';
+
+        // Latitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getSouth();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getNorth();
+
+        return $whereStatement;
+    }
+
+    /**
      * @param array<int> $states
      */
     private function createStatesMatchWhere(array $states, string $table, string $term, int $levenshteinDistance, string $termColumnName): string
@@ -760,43 +798,5 @@ class Searcher
     private function sortDocuments(): void
     {
         $this->sorting->applySorters($this);
-    }
-
-    /**
-     * @return array<string|float>
-     */
-    private function createGeoBoundingBoxWhereStatement(string $documentAlias, GeoBoundingBox|GeoDistance $node, Bounds $bounds): array
-    {
-        $whereStatement = [];
-
-        // Prevent nullable
-        $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-        $whereStatement[] = '!=';
-        $whereStatement[] = $nullTerm;
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-        $whereStatement[] = '!=';
-        $whereStatement[] = $nullTerm;
-
-        $whereStatement[] = 'AND';
-
-        // Longitude
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getWest();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getEast();
-
-        $whereStatement[] = 'AND';
-
-        // Latitude
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getSouth();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getNorth();
-
-        return $whereStatement;
     }
 }

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -7,6 +7,7 @@ namespace Loupe\Loupe\Internal\Search;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
+use Location\Bounds;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
 use Loupe\Loupe\Internal\Filter\Ast\Filter;
@@ -573,33 +574,7 @@ class Searcher
             // locations we shouldn't.
             $bounds = $node->getBbox();
 
-            // Prevent nullable
-            $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-            $whereStatement[] = '!=';
-            $whereStatement[] = $nullTerm;
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-            $whereStatement[] = '!=';
-            $whereStatement[] = $nullTerm;
-
-            $whereStatement[] = 'AND';
-
-            // Longitude
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-            $whereStatement[] = 'BETWEEN';
-            $whereStatement[] = $bounds->getWest();
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $bounds->getEast();
-
-            $whereStatement[] = 'AND';
-
-            // Latitude
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-            $whereStatement[] = 'BETWEEN';
-            $whereStatement[] = $bounds->getSouth();
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $bounds->getNorth();
+            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
 
             // And now calculate the real distance to filter out the ones that are within the BBOX (which is a square)
             // but not within the radius (which is a circle).
@@ -625,33 +600,7 @@ class Searcher
             // Same like above for
             $bounds = $node->getBbox();
 
-            // Prevent nullable
-            $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-            $whereStatement[] = '!=';
-            $whereStatement[] = $nullTerm;
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-            $whereStatement[] = '!=';
-            $whereStatement[] = $nullTerm;
-
-            $whereStatement[] = 'AND';
-
-            // Longitude
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-            $whereStatement[] = 'BETWEEN';
-            $whereStatement[] = $bounds->getWest();
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $bounds->getEast();
-
-            $whereStatement[] = 'AND';
-
-            // Latitude
-            $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-            $whereStatement[] = 'BETWEEN';
-            $whereStatement[] = $bounds->getSouth();
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $bounds->getNorth();
+            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
 
             // End group
             $whereStatement[] = ')';
@@ -811,5 +760,43 @@ class Searcher
     private function sortDocuments(): void
     {
         $this->sorting->applySorters($this);
+    }
+
+    /**
+     * @return array<string|float>
+     */
+    private function createGeoBoundingBoxWhereStatement(string $documentAlias, GeoBoundingBox|GeoDistance $node, Bounds $bounds): array
+    {
+        $whereStatement = [];
+
+        // Prevent nullable
+        $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+
+        $whereStatement[] = 'AND';
+
+        // Longitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getWest();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getEast();
+
+        $whereStatement[] = 'AND';
+
+        // Latitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getSouth();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getNorth();
+
+        return $whereStatement;
     }
 }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1000,10 +1000,8 @@ class SearchTest extends TestCase
         $searchParameters = SearchParameters::create()
             ->withFilter(sprintf(
                 '_geoBoundingBox(location, %s, %s, %s, %s)',
-                // Top Right (North East) (why north east see: https://github.com/loupe-php/loupe/issues/83)
                 $dublin['lat'],
                 $athen['lng'],
-                // Bottom Left (South West) (why south west see: https://github.com/loupe-php/loupe/issues/83)
                 $athen['lat'],
                 $dublin['lng'],
             ))

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -370,6 +370,36 @@ class ParserTest extends TestCase
             "Col 26: Error: Expected ',', got '2.00'",
         ];
 
+        yield 'Invalid number of parameters for _geoBoundingBox no attribute' => [
+            '_geoBoundingBox(1.00, 2.00, 2.00, 3.00)',
+            "Col 16: Error: Expected filterable attribute, got '1.00'",
+        ];
+
+        yield 'Invalid number of parameters for _geoBoundingBox missing parameter' => [
+            '_geoBoundingBox(location, 1.00, 2.00, 2.00)',
+            "Col 42: Error: Expected ',', got ')'",
+        ];
+
+        yield 'Invalid number of parameters for _geoBoundingBox to much parameters' => [
+            '_geoBoundingBox(location, 1.00, 2.00, 2.00, 3.00, 4.00)',
+            "Col 48: Error: Expected ')', got ','",
+        ];
+
+        yield 'Missing ( for _geoBoundingBox' => [
+            '_geoBoundingBox&location, 1.00, 2.00, 2.00, 3.00)',
+            "Col 15: Error: Expected '(', got '&'",
+        ];
+
+        yield 'Missing ) for _geoBoundingBox' => [
+            '_geoBoundingBox(location, 1.00, 2.00, 2.00, 3.00',
+            "Col 44: Error: Expected ')', got end of string.",
+        ];
+
+        yield 'Missing comma for _geoBoundingBox' => [
+            '_geoBoundingBox(location, 1.00 2.00, 2.00, 3.00)',
+            "Col 31: Error: Expected ',', got '2.00'",
+        ];
+
         yield 'Unclosed IN ()' => [
             "genres IN ('Action', 'Music'",
             "Col 21: Error: Expected ')",

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -400,6 +400,16 @@ class ParserTest extends TestCase
             "Col 31: Error: Expected ',', got '2.00'",
         ];
 
+        yield 'Invalid coordinates for _geoBoundingBox latitude' => [
+            '_geoBoundingBox(location, 1.0, 2.00, 92.00, 3.00)',
+            "Col 16: Error: Expected Latitude value must be numeric -90.0 .. +90.0 (given: 92), got 'location, 1, 2, 92, 3'",
+        ];
+
+        yield 'Invalid coordinates for _geoBoundingBox longitude' => [
+            '_geoBoundingBox(location, 1.0, 182.00, 2.00, 3.00)',
+            "Col 16: Error: Expected Longitude value must be numeric -180.0 .. +180.0 (given: 182), got 'location, 1, 182, 2, 3'",
+        ];
+
         yield 'Unclosed IN ()' => [
             "genres IN ('Action', 'Music'",
             "Col 21: Error: Expected ')",

--- a/tests/Unit/Internal/Filter/ParserTest.php
+++ b/tests/Unit/Internal/Filter/ParserTest.php
@@ -173,6 +173,19 @@ class ParserTest extends TestCase
             ],
         ];
 
+        yield 'Basic geo bounding box' => [
+            '_geoBoundingBox(location, 53.3498, 23.7275, 37.9838, -6.2603)',
+            [
+                [
+                    'attribute' => 'location',
+                    'north' => 53.3498,
+                    'east' => 23.7275,
+                    'south' => 37.9838,
+                    'west' => -6.2603,
+                ],
+            ],
+        ];
+
         yield 'Basic IN filter' => [
             "genres IN ('Drama', 'Action', 'Documentary')",
             [


### PR DESCRIPTION
Why Loupe already supports filtering by a GeoDistance. Which support we already merged also int SEAL. It would also be nice to filter by a bounding box (rectangle). That is mostly used for things when a user navigates around a map and have a specific area shown.

See fore more information: #83 

fixes #83

Implemented as far as I could get with my knowledge.
