### PR TITLE
Include state cache always

### DIFF
--- a/src/Internal/StateSetIndex/StateSet.php
+++ b/src/Internal/StateSetIndex/StateSet.php
@@ -95,7 +95,7 @@ class StateSet implements StateSetInterface
                 $data = $this->loadFromStorage();
                 $this->dumpStateSetCache($data);
             } else {
-                $data = require_once $cacheFile;
+                $data = require $cacheFile;
             }
         }
 


### PR DESCRIPTION
Method initialize was using `require_once` to read a state file. This caused the cache to be read correctly on the first initialize call but returned a simple `true` on subsequent usages (See documentation of `require_once`). This has been changed to use `require` instead and now always reads the file.