### PR TITLE
Restore doctrine dbal 3.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^8.1",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "doctrine/dbal": "^3.10 || ^4.0",
+        "doctrine/dbal": "^3.9 || ^4.0",
         "wamania/php-stemmer": "^3.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "mjaschen/phpgeo": "^4.2",

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -61,7 +61,11 @@ class Engine
         $this->indexer = new Indexer($this);
         $this->highlighter = new Highlighter($this);
         $this->filterParser = new Parser();
-        $this->sqliteVersion = $this->connection->getServerVersion();
+        $this->sqliteVersion = match (true) {
+            \is_callable([$this->connection, 'getServerVersion']) => $this->connection->getServerVersion(),
+            (($nativeConnection = $this->connection->getNativeConnection()) instanceof \SQLite3) => $nativeConnection->version()['versionString'],
+            (($nativeConnection = $this->connection->getNativeConnection()) instanceof \PDO) => $nativeConnection->getAttribute(\PDO::ATTR_SERVER_VERSION),
+        };
     }
 
     /**

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -75,7 +75,11 @@ final class LoupeFactory
             throw new InvalidConfigurationException('You need either the sqlite3 (recommended) or pdo_sqlite PHP extension.');
         }
 
-        $sqliteVersion = $connection->getServerVersion();
+        $sqliteVersion = match (true) {
+            \is_callable([$connection, 'getServerVersion']) => $connection->getServerVersion(),
+            (($nativeConnection = $connection->getNativeConnection()) instanceof \SQLite3) => $nativeConnection->version()['versionString'],
+            (($nativeConnection = $connection->getNativeConnection()) instanceof \PDO) => $nativeConnection->getAttribute(\PDO::ATTR_SERVER_VERSION),
+        };
 
         if (version_compare($sqliteVersion, self::MIN_SQLITE_VERSION, '<')) {
             throw new \InvalidArgumentException(sprintf(


### PR DESCRIPTION
- Improve server version detection.
- Allow 3.9 again as 3.10 is not released yet.

Both broke in #93.
