### PR TITLE
Additional SQLite connection optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Note that some implementation details (e.g. libraries used) referenced in this b
 Performance depends on many factors but here are some ballpark numbers based on indexing the [~32k movies fixture by 
 MeiliSearch][MeiliSearch_Movies] and the test files in `bin` of this repository:
 
-* Indexing (`php bin/index_performance_test.php`) will take a little over 3min (~170 documents per second)
+* Indexing (`php bin/index_performance_test.php`) will take a little over 2min (~230 documents per second)
 * Querying (`php bin/search_performance_test.php`) for `Amakin Dkywalker` with typo tolerance enabled and ordered by 
   relevance finishes in about `120 ms`
 

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -87,8 +87,7 @@ final class LoupeFactory
             ));
         }
 
-        // Use Write-Ahead Logging if possible
-        $connection->executeQuery('PRAGMA journal_mode=WAL;');
+        $this->optimizeSQLiteConnection($connection);
 
         $this->registerSQLiteFunctions($connection);
 
@@ -117,6 +116,36 @@ final class LoupeFactory
         }
 
         return $config;
+    }
+
+    private function optimizeSQLiteConnection(Connection $connection): void
+    {
+        $optimizations = [
+            // Increase page size to 8KB to reduce disk i/o
+            'PRAGMA page_size = 8192;',
+            // Set cache size to 20MB to reduce disk i/o
+            'PRAGMA cache_size = -20000;',
+            // Use write-ahead logging to allow concurrent reads and writes
+            'PRAGMA journal_mode=WAL;',
+            // Incremental vacuum to keep the database size in check
+            'PRAGMA auto_vacuum = incremental;',
+            // Incremental vacuum to keep the database size in check
+            'PRAGMA incremental_vacuum;',
+            // Set mmap size to 32MB to avoid i/o for database reads
+            'PRAGMA mmap_size = 33554432;',
+            // Store temporary tables in memory instead of on disk
+            'PRAGMA temp_store = MEMORY;',
+            // Set timeout to 2 seconds to avoid locking issues
+            'PRAGMA busy_timeout = 2000',
+        ];
+
+        foreach ($optimizations as $optimization) {
+            try {
+                $connection->executeQuery($optimization);
+            } catch (\Throwable $th) {
+                // Assume that the pragma is not supported
+            }
+        }
     }
 
     private function registerSQLiteFunctions(Connection $connection): void


### PR DESCRIPTION
(Hi 👋 Fantastic piece of software you've created, thanks a lot for open-sourcing it!)

I've been toying a bit with optimizing sqlite connections on production sites and thought these might make sense to include by default. The good thing is that Loupe is usually the only client of its particular database, so it can make a few assumptions about how to optimize the connection. Not sure if you agree with all of these suggestions, but it'd be great to get a discussion started.

- Add a few optimizations to reduce disk I/O
- Add a timeout to avoid errors if db is locked by another instance
- Enable incremental vacuum to auto-reduce database size
- Tested this on a few sites and I'm seeing about a 10% increase in speed (as measured by `processingTimeMs`)