### PR TITLE
Client pool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,11 @@
         "mjaschen/phpgeo": "^4.2",
         "toflar/state-set-index": "^2.0.1",
         "psr/log": "^2.0 || ^3.0",
-        "nitotm/efficient-language-detector": "^2.0"
+        "nitotm/efficient-language-detector": "^2.0",
+        "symfony/filesystem": "^6.2"
     },
     "require-dev": {
         "symfony/var-dumper": "^6.2",
-        "symfony/filesystem": "^6.2",
         "symplify/easy-coding-standard": "11.2.4.72",
         "symfony/finder": "^6.2",
         "phpunit/phpunit": "^10.0",

--- a/src/LoupeClientPool.php
+++ b/src/LoupeClientPool.php
@@ -1,10 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Loupe\Loupe;
 
-use Loupe\Loupe\Configuration;
-use Loupe\Loupe\Loupe;
-use Loupe\Loupe\LoupeFactory;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Path;
 
@@ -22,57 +21,32 @@ use Symfony\Component\Filesystem\Path;
 
 class LoupeClientPool
 {
-    protected LoupeFactory $factory;
-    protected Filesystem $filesystem;
-
     /**
      * @var Loupe[]
      */
     protected array $clients = [];
 
-    public function __construct(protected string $path)
-    {
+    protected LoupeFactory $factory;
+
+    protected Filesystem $filesystem;
+
+    public function __construct(
+        protected string $path
+    ) {
         $this->factory = new LoupeFactory();
         $this->filesystem = new Filesystem();
 
         // Create the base directory if it doesn't exist
-        if (! $this->filesystem->exists($this->path)) {
+        if (!$this->filesystem->exists($this->path)) {
             $this->filesystem->mkdir($this->path);
         }
-    }
-
-    public function get(string $index, Configuration $configuration): Loupe
-    {
-        return ($this->clients[$index] ??= $this->make($index, $configuration));
-    }
-
-    public function make(string $index, Configuration $configuration): Loupe
-    {
-        $this->createIndex($index);
-
-        return $this->factory->create($this->indexDirectory($index), $configuration);
-    }
-
-    public function indexDirectory(string $index): string
-    {
-        return Path::makeAbsolute($index, $this->path);
-    }
-
-    public function indexPath(string $index): string
-    {
-        return Path::makeAbsolute("{$index}/loupe.db", $this->path);
-    }
-
-    public function indexExists(string $index): bool
-    {
-        return $this->filesystem->exists($this->indexPath($index));
     }
 
     public function createIndex(string $index): void
     {
         $db = $this->indexPath($index);
-        if (! $this->filesystem->exists($db)) {
-            $this->filesystem->touch($db);
+        if (!$this->filesystem->exists($db)) {
+            $this->filesystem->dumpFile($db, '');
         }
     }
 
@@ -82,5 +56,32 @@ class LoupeClientPool
         if ($this->filesystem->exists($dir)) {
             $this->filesystem->remove($dir);
         }
+    }
+
+    public function get(string $index, Configuration $configuration): Loupe
+    {
+        return $this->clients[$index] ??= $this->make($index, $configuration);
+    }
+
+    public function indexDirectory(string $index): string
+    {
+        return Path::makeAbsolute($index, $this->path);
+    }
+
+    public function indexExists(string $index): bool
+    {
+        return $this->filesystem->exists($this->indexPath($index));
+    }
+
+    public function indexPath(string $index): string
+    {
+        return Path::makeAbsolute("{$index}/loupe.db", $this->path);
+    }
+
+    public function make(string $index, Configuration $configuration): Loupe
+    {
+        $this->createIndex($index);
+
+        return $this->factory->create($this->indexDirectory($index), $configuration);
     }
 }

--- a/src/LoupeClientPool.php
+++ b/src/LoupeClientPool.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Loupe\Loupe;
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Loupe;
+use Loupe\Loupe\LoupeFactory;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * Manage a pool of Loupe clients, each representing a separate index.
+ *
+ * Usage:
+ *
+ * ```php
+ * $pool = new LoupeClientPool('/path/to/indexes');
+ * $configuration = Configuration::create()->withPrimaryKey('uid');
+ * $client = $pool->get('movies', $configuration);
+ * ```
+ */
+
+class LoupeClientPool
+{
+    protected LoupeFactory $factory;
+    protected Filesystem $filesystem;
+
+    /**
+     * @var Loupe[]
+     */
+    protected array $clients = [];
+
+    public function __construct(protected string $path)
+    {
+        $this->factory = new LoupeFactory();
+        $this->filesystem = new Filesystem();
+
+        // Create the base directory if it doesn't exist
+        if (! $this->filesystem->exists($this->path)) {
+            $this->filesystem->mkdir($this->path);
+        }
+    }
+
+    public function get(string $index, Configuration $configuration): Loupe
+    {
+        return ($this->clients[$index] ??= $this->make($index, $configuration));
+    }
+
+    public function make(string $index, Configuration $configuration): Loupe
+    {
+        $this->createIndex($index);
+
+        return $this->factory->create($this->indexDirectory($index), $configuration);
+    }
+
+    public function indexDirectory(string $index): string
+    {
+        return Path::makeAbsolute($index, $this->path);
+    }
+
+    public function indexPath(string $index): string
+    {
+        return Path::makeAbsolute("{$index}/loupe.db", $this->path);
+    }
+
+    public function indexExists(string $index): bool
+    {
+        return $this->filesystem->exists($this->indexPath($index));
+    }
+
+    public function createIndex(string $index): void
+    {
+        $db = $this->indexPath($index);
+        if (! $this->filesystem->exists($db)) {
+            $this->filesystem->touch($db);
+        }
+    }
+
+    public function dropIndex(string $index): void
+    {
+        $dir = $this->indexDirectory($index);
+        if ($this->filesystem->exists($dir)) {
+            $this->filesystem->remove($dir);
+        }
+    }
+}

--- a/tests/Unit/LoupeClientPoolTest.php
+++ b/tests/Unit/LoupeClientPoolTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit;
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Loupe;
+use Loupe\Loupe\LoupeClientPool;
+use PHPUnit\Framework\TestCase;
+
+class LoupeClientPoolTest extends TestCase
+{
+    public function testMake(): void
+    {
+        $dir = $this->createTempDir();
+        $pool = new LoupeClientPool($dir);
+        $client = $pool->make('docs', Configuration::create());
+
+        $this->assertInstanceOf(Loupe::class, $client);
+    }
+
+    public function testPaths(): void
+    {
+        $dir = $this->createTempDir();
+        $pool = new LoupeClientPool($dir);
+
+        $docsClient = $pool->make('docs', Configuration::create());
+        $this->assertFileExists($dir . '/docs/loupe.db');
+
+        $invoicesClient = $pool->make('invoices', Configuration::create());
+        $this->assertFileExists($dir . '/invoices/loupe.db');
+    }
+
+    public function testState(): void
+    {
+        $dir = $this->createTempDir();
+        $pool = new LoupeClientPool($dir);
+
+        $this->assertFalse($pool->indexExists('docs'));
+        $client = $pool->make('docs', Configuration::create());
+        $this->assertTrue($pool->indexExists('docs'));
+
+        $pool->dropIndex('docs');
+        $this->assertFalse($pool->indexExists('docs'));
+        $this->assertFileDoesNotExist($dir . '/docs/loupe.db');
+
+        $pool->createIndex('docs');
+        $this->assertTrue($pool->indexExists('docs'));
+        $this->assertFileExists($dir . '/docs/loupe.db');
+    }
+
+    protected function createTempDir(): string
+    {
+        $tmpDataDir = sys_get_temp_dir() . '/' . uniqid('loupe');
+        mkdir($tmpDataDir, 0777, true);
+        return $tmpDataDir;
+    }
+}

--- a/tests/Unit/LoupeFactoryTest.php
+++ b/tests/Unit/LoupeFactoryTest.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Unit;
 
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Loupe;
 use Loupe\Loupe\LoupeFactory;
 use PHPUnit\Framework\TestCase;
 
 class LoupeFactoryTest extends TestCase
 {
+    public function testCreate(): void
+    {
+        $factory = new LoupeFactory();
+        $this->assertInstanceOf(Loupe::class, $factory->create('./test', Configuration::create()));
+    }
+
+    public function testCreateInMemory(): void
+    {
+        $factory = new LoupeFactory();
+        $this->assertInstanceOf(Loupe::class, $factory->createInMemory(Configuration::create()));
+    }
+
     public function testIsSupported(): void
     {
         $factory = new LoupeFactory();


### PR DESCRIPTION
- Create a client pool to manage multiple indexes
- Allow creating/deleting/checking existence of indexes by name
- Client pool has a base path that contains all indexes
- Move `symfony/filesystem` into normal dependencies
- Called this `Manager` originally, but `ClientPool` sounds like something at home in the database world
- Very open to renaming this, though
- Closes #15

## Usage

```php
$pool = new LoupeClientPool('/storage/search/');
$config = Configuration::create()->withPrimaryKey('uid');

// Create clients for separate indexes
$movieIndex = $pool->get('movies', $configuration);
$docIndex = $pool->get('documents', $configuration);

// Check if index exists
$pool->indexExists('documents');

// Drop index
$pool->dropIndex('documents');
```