### PR TITLE
Delete all documents

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -1,5 +1,7 @@
 # Indexing
 
+## Adding documents
+
 There are two methods to index documents in Loupe. Either you index only one document like so:
 
 ```php
@@ -42,6 +44,32 @@ Both of the methods return an `IndexResult` which provides the following methods
   exception implementing `LoupeExceptionInterface` as value.
 * `generalException()` - returns either `null` (if there was no general exception) or an exception implementing 
   `LoupeExceptionInterface`. A general exception is one that could not be linked to a document ID.
+
+## Removing documents
+
+To remove documents from the index, you can either remove a single document or batch the removal for
+better performance. Whenever possible, you should prefer deleting multiple documents at once over
+deleting each document on its own to improve performance and cleanup cost.
+
+You'll need to pass in the id of a document to have it removed from the index.
+
+```php
+$loupe->deleteDocument(123);
+```
+
+Or you can remove multiple documents at once:
+
+```php
+$loupe->deleteDocuments([123, 456]);
+```
+
+## Removing all documents
+
+If you need to remove all documents at once and start with a clean slate, there's a method for that:
+
+```php
+$loupe->deleteAllDocuments();
+```
 
 For schema related logic, read [the dedicated schema docs][Schema].
 

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -98,6 +98,13 @@ class Engine
         return $this;
     }
 
+    public function deleteAllDocuments(): self
+    {
+        $this->indexer->deleteAllDocuments();
+
+        return $this;
+    }
+
     public function getConfiguration(): Configuration
     {
         return $this->configuration;

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -88,19 +88,19 @@ class Engine
             ->fetchOne();
     }
 
+    public function deleteAllDocuments(): self
+    {
+        $this->indexer->deleteAllDocuments();
+
+        return $this;
+    }
+
     /**
      * @param array<int|string> $ids
      */
     public function deleteDocuments(array $ids): self
     {
         $this->indexer->deleteDocuments($ids);
-
-        return $this;
-    }
-
-    public function deleteAllDocuments(): self
-    {
-        $this->indexer->deleteAllDocuments();
 
         return $this;
     }

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -95,6 +95,20 @@ class Indexer
         return new IndexResult($successfulCount, $documentExceptions);
     }
 
+    public function deleteAllDocuments(): self
+    {
+        if ($this->engine->getIndexInfo()->needsSetup()) {
+            return $this;
+        }
+
+        $this->engine->getConnection()
+            ->executeStatement(sprintf('DELETE FROM %s', IndexInfo::TABLE_NAME_DOCUMENTS));
+
+        $this->reviseStorage();
+
+        return $this;
+    }
+
     /**
      * @param array<int|string> $ids
      */
@@ -114,20 +128,6 @@ class Indexer
                     'ids' => ArrayParameterType::STRING,
                 ]
             );
-
-        $this->reviseStorage();
-
-        return $this;
-    }
-
-    public function deleteAllDocuments(): self
-    {
-        if ($this->engine->getIndexInfo()->needsSetup()) {
-            return $this;
-        }
-
-        $this->engine->getConnection()
-            ->executeStatement(sprintf('DELETE FROM %s', IndexInfo::TABLE_NAME_DOCUMENTS));
 
         $this->reviseStorage();
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -127,9 +127,7 @@ class Indexer
         }
 
         $this->engine->getConnection()
-            ->executeStatement(
-                sprintf('DELETE FROM %s WHERE user_id IN(:ids)', IndexInfo::TABLE_NAME_DOCUMENTS)
-            );
+            ->executeStatement(sprintf('DELETE FROM %s', IndexInfo::TABLE_NAME_DOCUMENTS));
 
         $this->reviseStorage();
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -120,6 +120,22 @@ class Indexer
         return $this;
     }
 
+    public function deleteAllDocuments(): self
+    {
+        if ($this->engine->getIndexInfo()->needsSetup()) {
+            return $this;
+        }
+
+        $this->engine->getConnection()
+            ->executeStatement(
+                sprintf('DELETE FROM %s WHERE user_id IN(:ids)', IndexInfo::TABLE_NAME_DOCUMENTS)
+            );
+
+        $this->reviseStorage();
+
+        return $this;
+    }
+
     private function indexAttributeValue(string $attribute, string|float|bool|null $value, int $documentId): void
     {
         if ($value === null) {

--- a/src/Loupe.php
+++ b/src/Loupe.php
@@ -35,6 +35,11 @@ final class Loupe
         return $this->engine->countDocuments();
     }
 
+    public function deleteAllDocuments(): void
+    {
+        $this->engine->deleteAllDocuments();
+    }
+
     /**
      * @throws IndexException
      */
@@ -49,11 +54,6 @@ final class Loupe
     public function deleteDocuments(array $ids): void
     {
         $this->engine->deleteDocuments($ids);
-    }
-
-    public function deleteAllDocuments(): void
-    {
-        $this->engine->deleteAllDocuments();
     }
 
     public function getConfiguration(): Configuration

--- a/src/Loupe.php
+++ b/src/Loupe.php
@@ -51,6 +51,11 @@ final class Loupe
         $this->engine->deleteDocuments($ids);
     }
 
+    public function deleteAllDocuments(): void
+    {
+        $this->engine->deleteAllDocuments();
+    }
+
     public function getConfiguration(): Configuration
     {
         return $this->engine->getConfiguration();

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -223,6 +223,27 @@ class IndexTest extends TestCase
         ]);
     }
 
+    public function testDeleteAllDocuments(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title', 'overview'])
+            ->withSortableAttributes(['title'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        foreach (range(11, 20) as $id) {
+            $this->assertNotNull($loupe->getDocument($id));
+        }
+
+        // Delete all documents and assert they're gone
+        $loupe->deleteAllDocuments();
+        foreach (range(11, 20) as $id) {
+            $this->assertNull($loupe->getDocument($id));
+        }
+    }
+
     public function testDeleteDocument(): void
     {
         $configuration = Configuration::create()
@@ -263,27 +284,6 @@ class IndexTest extends TestCase
         $this->assertNull($loupe->getDocument(11));
         $this->assertNull($loupe->getDocument(12));
         $this->assertSame('Forrest Gump', $loupe->getDocument(13)['title'] ?? '');
-    }
-
-    public function testDeleteAllDocuments(): void
-    {
-        $configuration = Configuration::create()
-            ->withSearchableAttributes(['title', 'overview'])
-            ->withSortableAttributes(['title'])
-        ;
-
-        $loupe = $this->createLoupe($configuration);
-        $this->indexFixture($loupe, 'movies');
-
-        foreach (range(11, 20) as $id) {
-            $this->assertNotNull($loupe->getDocument($id));
-        }
-
-        // Delete all documents and assert they're gone
-        $loupe->deleteAllDocuments();
-        foreach (range(11, 20) as $id) {
-            $this->assertNull($loupe->getDocument($id));
-        }
     }
 
     public function testDeleteDocumentWhenNotSetUpYet(): void

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -233,11 +233,57 @@ class IndexTest extends TestCase
         $loupe = $this->createLoupe($configuration);
         $this->indexFixture($loupe, 'movies');
 
-        $this->assertSame('Star Wars', $loupe->getDocument(11)['title'] ?? '');
+        $this->assertSame('Star Wars', $loupe->getDocument(11)['title'] ?? null);
+        $this->assertSame('Finding Nemo', $loupe->getDocument(12)['title'] ?? null);
 
         // Delete document and assert it's gone
         $loupe->deleteDocument(11);
+        $this->assertNull($loupe->getDocument(11)['title'] ?? null);
+
+        // Assert the other document is still there
+        $this->assertSame('Finding Nemo', $loupe->getDocument(12)['title'] ?? null);
+    }
+
+    public function testDeleteDocuments(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title', 'overview'])
+            ->withSortableAttributes(['title'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $this->assertSame('Star Wars', $loupe->getDocument(11)['title'] ?? '');
+        $this->assertSame('Finding Nemo', $loupe->getDocument(12)['title'] ?? '');
+        $this->assertSame('Forrest Gump', $loupe->getDocument(13)['title'] ?? '');
+
+        // Delete documents and assert they're gone
+        $loupe->deleteDocuments([11, 12]);
         $this->assertNull($loupe->getDocument(11));
+        $this->assertNull($loupe->getDocument(12));
+        $this->assertSame('Forrest Gump', $loupe->getDocument(13)['title'] ?? '');
+    }
+
+    public function testDeleteAllDocuments(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title', 'overview'])
+            ->withSortableAttributes(['title'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        foreach (range(11, 20) as $id) {
+            $this->assertNotNull($loupe->getDocument($id));
+        }
+
+        // Delete all documents and assert they're gone
+        $loupe->deleteAllDocuments();
+        foreach (range(11, 20) as $id) {
+            $this->assertNull($loupe->getDocument($id));
+        }
     }
 
     public function testDeleteDocumentWhenNotSetUpYet(): void


### PR DESCRIPTION
- Add a method to delete all documents
- Useful when creating an index from scratch in a schedule or cli command
- A previous attempt of deleting and recreating the sqlite file resulted in nasty file permissions issues
- This approach works much better and feels less hacky
- Tests are added