### PR TITLE
Attribute ranking order

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,6 +14,8 @@ final class Configuration
 
     public const MAX_ATTRIBUTE_NAME_LENGTH = 64;
 
+    public const ATTRIBUTE_RANKING_ORDER_FACTOR = 0.8;
+
     /**
      * @var array<string>
      */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -223,7 +223,8 @@ final class Configuration
             self::validateAttributeNames($searchableAttributes);
         }
 
-        sort($searchableAttributes);
+        // Do not sort searchable attributes as their order is relevant for ranking
+        // sort($searchableAttributes);
 
         $clone = clone $this;
         $clone->searchableAttributes = $searchableAttributes;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -12,9 +12,9 @@ final class Configuration
 {
     public const ATTRIBUTE_NAME_RGXP = '[a-zA-Z\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*';
 
-    public const MAX_ATTRIBUTE_NAME_LENGTH = 64;
-
     public const ATTRIBUTE_RANKING_ORDER_FACTOR = 0.8;
+
+    public const MAX_ATTRIBUTE_NAME_LENGTH = 64;
 
     /**
      * @var array<string>

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -129,11 +129,11 @@ class Relevance extends AbstractSorter
             []
         );
 
-        $matchedAttributeWeights = array_map(fn ($attribute) => $attributeWeights[$attribute] ?? null, array_unique($matchedAttributes));
+        $matchedAttributeWeights = array_map(fn ($attribute) => $attributeWeights[$attribute] ?? 1, $matchedAttributes);
         $matchedAttributeWeights = array_filter($matchedAttributeWeights, fn ($weight) => $weight !== 1);
 
         return count($matchedAttributeWeights) ?
-            (array_sum($matchedAttributeWeights) / count($matchedAttributeWeights))
+            (array_sum($matchedAttributeWeights) / count($positionsPerTerm))
             : 1;
     }
 

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -11,7 +11,7 @@ use Loupe\Loupe\Internal\Search\Searcher;
 class Relevance extends AbstractSorter
 {
     /**
-     * @var array<string, array<string, float>> $attributeWeightValuesCache
+     * @var array<string, array<string, float>>
      */
     protected static array $attributeWeightValuesCache = [];
 

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -129,7 +129,8 @@ class Relevance extends AbstractSorter
             []
         );
 
-        $matchedAttributeWeights = array_filter(array_map(fn ($attribute) => $attributeWeights[$attribute] ?? 1, $matchedAttributes));
+        $matchedAttributeWeights = array_map(fn ($attribute) => $attributeWeights[$attribute] ?? null, array_unique($matchedAttributes));
+        $matchedAttributeWeights = array_filter($matchedAttributeWeights, fn ($weight) => $weight !== 1);
 
         return count($matchedAttributeWeights) ?
             (array_sum($matchedAttributeWeights) / count($matchedAttributeWeights))

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -67,7 +67,7 @@ class Relevance extends AbstractSorter
 
     /**
      * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm
-     * @param array<string, int> $attributeWeights
+     * @param array<string, float> $attributeWeights
      */
     public static function calculateAttributeWeightFactor(array $positionsPerTerm, array $attributeWeights): float
     {

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -95,12 +95,11 @@ class Relevance extends AbstractSorter
         // Assign decreasing weights to each attribute
         // ['title', 'summary', 'body] → ['title' => 1, 'summary' => 0.8, 'body' => 0.8 ^ 2]
         $weight = 1;
-        $factor = Configuration::ATTRIBUTE_RANKING_ORDER_FACTOR;
         return array_reduce(
             $searchableAttributes,
-            function ($result, $attribute) use (&$weight, $factor) {
+            function ($result, $attribute) use (&$weight) {
                 $result[$attribute] = round($weight, 2);
-                $weight *= $factor;
+                $weight *= 0.8;
                 return $result;
             },
             []

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -28,7 +28,7 @@ class Relevance extends AbstractSorter
             // for the relevance split. Otherwise, the relevance calculation cannot know which of the documents did not match
             // because it's just a ";" separated list.
             $positionsPerDocument[] = sprintf(
-                "SELECT (SELECT COALESCE(group_concat(DISTINCT position), '0') FROM %s WHERE %s.id=document) AS %s",
+                "SELECT (SELECT COALESCE(group_concat(DISTINCT position || ':' || attribute), '0') FROM %s WHERE %s.id=document) AS %s",
                 $searcher->getCTENameForToken(Searcher::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token),
                 $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
                 Searcher::RELEVANCE_ALIAS . '_per_term',
@@ -39,11 +39,14 @@ class Relevance extends AbstractSorter
             return;
         }
 
+        $weights = $searcher->getSearchParameters()->getAttributeWeights();
+
         $select = sprintf(
-            "loupe_relevance((SELECT group_concat(%s, ';') FROM (%s)), %s) AS %s",
+            "loupe_relevance((SELECT group_concat(%s, ';') FROM (%s)), %s, '%s') AS %s",
             Searcher::RELEVANCE_ALIAS . '_per_term',
             implode(' UNION ALL ', $positionsPerDocument),
             $searcher->getTokens()->count(),
+            implode(';', array_map(fn($attr, $weight) => "{$attr}:{$weight}", array_keys($weights), $weights)),
             Searcher::RELEVANCE_ALIAS,
         );
 
@@ -71,13 +74,15 @@ class Relevance extends AbstractSorter
 
         foreach ($positionsPerTerm as $positions) {
             if ($positionPrev === null) {
-                $positionPrev = $positions[0];
+                [$position] = $positions[0];
+                $positionPrev = $position;
                 continue;
             }
 
             $distance = 0;
 
-            foreach ($positions as $position) {
+            foreach ($positions as $positionAndAttribute) {
+                [$position] = $positionAndAttribute;
                 if ($position > $positionPrev) {
                     $distance = $position - $positionPrev;
                     $positionPrev = $position;
@@ -98,34 +103,71 @@ class Relevance extends AbstractSorter
     }
 
     /**
-     * Example: A string with "3,8,10;0;4" would read as follows:
+     * @param array<int, array<int>> $positionsPerTerm
+     */
+    public static function calculateMatchCountFactor(array $positionsPerTerm, int $totalQueryTokenCount): float
+    {
+        $matchedTokens = array_filter($positionsPerTerm, function ($termArray) {
+            return !(\count($termArray) === 1 && $termArray[0][0] === 0);
+        });
+
+        return \count($matchedTokens) / $totalQueryTokenCount;
+    }
+
+    public static function calculateAttributeWeightFactor(array $positionsPerTerm, array $attributeWeights): float
+    {
+        $matchedAttributes = array_filter(array_map(fn ($term) => $term[0][1], $positionsPerTerm));
+        $matchedAttributeWeights = array_map(fn ($attribute) => $attributeWeights[$attribute] ?? 1, $matchedAttributes);
+
+        return array_sum($matchedAttributeWeights) / count($matchedAttributes);
+    }
+
+    /**
+     * Example: A string with "3:title,8:title,10:title;0;4:summary" would read as follows:
      * - The query consisted of 3 tokens (terms).
-     * - The first term matched. At positions 3, 8 and 10.
+     * - The first term matched. At positions 3, 8 and 10 in the `title` attribute.
      * - The second term did not match (position 0).
-     * - The third term matched. At position 4
+     * - The third term matched. At position 4 in the `summary` attribute.
      *
      * @param string $positionsInDocumentPerTerm A string of ";" separated per term and "," separated for all the term positions within a document
      */
-    public static function fromQuery(string $positionsInDocumentPerTerm, string $totalQueryTokenCount): float
+    public static function fromQuery(string $positionsInDocumentPerTerm, string $totalQueryTokenCount, string $attributeWeights): float
     {
+        ray($positionsInDocumentPerTerm, $totalQueryTokenCount, $attributeWeights);
+
         /**
-         * 1st: Number of query terms that match in a document.
-         * 2nd: Proximity of the words
+         * 1st: Number of query terms that match in a document
+         * 2nd: Weight of attributes matched
+         * 3rd: Proximity of the words
          */
-        static $relevanceWeights = [2, 1]; // Higher weight means more importance
-        static $totalWeight = 3; // Must be the sum of the above
+        static $relevanceWeights = [2, 1, 1]; // Higher weight means more importance
+        static $totalWeight = array_sum($relevanceWeights);
 
         $relevanceFactors = [];
         $totalQueryTokenCount = (int) $totalQueryTokenCount;
-        $positionsPerTerm = array_map(fn ($term) => array_map('intval', explode(',', $term)), explode(';', $positionsInDocumentPerTerm));
+        $positionsPerTerm = array_map(
+            fn ($term) => array_map(
+                fn ($position) => array_pad(explode(':', $position), 2, null),
+                explode(',', $term)
+            ),
+            explode(';', $positionsInDocumentPerTerm)
+        );
+        $attributeWeights = array_reduce(
+            explode(';', $attributeWeights),
+            function ($result, $item) {
+                [$key, $value] = explode(':', $item);
+                return [...$result, $key => (int) $value];
+            },
+            []
+        );
 
-        // 1st: Number of query terms that match in a document.
-        $totalMatchedTokens = \count(array_filter($positionsPerTerm, function ($termArray) {
-            return !(\count($termArray) === 1 && $termArray[0] === 0);
-        }));
-        $relevanceFactors[] = $totalMatchedTokens / $totalQueryTokenCount;
+        // 1st: Number of query terms that match in a document
+        $relevanceFactors[] =  self::calculateMatchCountFactor($positionsPerTerm, $totalQueryTokenCount);
 
-        // 2nd: Proximity
+        // 2nd: Weight of attributes matched
+        $relevanceFactors[] = self::calculateAttributeWeightFactor($positionsPerTerm, $attributeWeights);
+
+        // 3rd: Proximity of the words
         $relevanceFactors[] = self::calculateProximityFactor($positionsPerTerm);
 
         // Calculate weighted average

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -10,6 +10,9 @@ use Loupe\Loupe\Internal\Search\Searcher;
 
 class Relevance extends AbstractSorter
 {
+    /**
+     * @var array<string, array<string, float>> $attributeWeightValuesCache
+     */
     protected static array $attributeWeightValuesCache = [];
 
     public function __construct(

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -41,7 +41,7 @@ class Relevance extends AbstractSorter
         }
 
         $searchableAttributes = $engine->getConfiguration()->getSearchableAttributes();
-        $weights = $this->calculateIntrinsicAttributeWeights($searchableAttributes);
+        $weights = static::calculateIntrinsicAttributeWeights($searchableAttributes);
 
         $select = sprintf(
             "loupe_relevance((SELECT group_concat(%s, ';') FROM (%s)), %s, '%s') AS %s",

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Search\Sorting;
 
-use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\Search\Searcher;

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Search\Sorting;
 
+use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\Search\Searcher;
@@ -103,7 +104,7 @@ class Relevance extends AbstractSorter
             $searchableAttributes,
             function ($result, $attribute) use (&$weight) {
                 $result[$attribute] = round($weight, 2);
-                $weight *= 0.8;
+                $weight *= Configuration::ATTRIBUTE_RANKING_ORDER_FACTOR;
                 return $result;
             },
             []

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -178,8 +178,6 @@ class Relevance extends AbstractSorter
         $positionsPerTerm = static::parseTermPositions($positionsInDocumentPerTerm);
         $attributeWeightValues = static::parseAttributeWeights($attributeWeights);
 
-        ray($attributeWeights);
-
         // Higher weight means more importance
         $relevanceWeights = [
             2, // 1st: Number of query terms that match in a document

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -178,7 +178,7 @@ class Relevance extends AbstractSorter
         $relevanceWeights = [
             2, // 1st: Number of query terms that match in a document
             1, // 2nd: Proximity of the words
-            1, // 3rd: Weight of attributes matched
+            1, // 3rd: Weight of attributes matched (use 1 as they are already weighted)
         ];
 
         $relevanceFactors = [
@@ -188,7 +188,7 @@ class Relevance extends AbstractSorter
             // 2nd: Proximity of the words
             self::calculateProximityFactor($positionsPerTerm),
 
-            // 3rd: Weight of attributes matched
+            // 3rd: Weight of attributes matched (use 1 as they are already weighted)
             self::calculateAttributeWeightFactor($positionsPerTerm, $attributeWeightValues),
         ];
 

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -11,6 +11,8 @@ use Loupe\Loupe\Internal\Search\Searcher;
 
 class Relevance extends AbstractSorter
 {
+    protected static array $attributeWeightValuesCache = [];
+
     public function __construct(
         private Direction $direction
     ) {
@@ -219,7 +221,11 @@ class Relevance extends AbstractSorter
      */
     protected static function parseAttributeWeights(string $attributeWeights): array
     {
-        return array_reduce(
+        if (isset(static::$attributeWeightValuesCache[$attributeWeights])) {
+            return static::$attributeWeightValuesCache[$attributeWeights];
+        }
+
+        $weightValues = array_reduce(
             array_filter(explode(';', $attributeWeights)),
             function ($result, $item) {
                 [$key, $value] = explode(':', $item);
@@ -229,6 +235,10 @@ class Relevance extends AbstractSorter
             },
             []
         );
+
+        static::$attributeWeightValuesCache[$attributeWeights] = $weightValues;
+
+        return $weightValues;
     }
 
     /**

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -123,8 +123,13 @@ class Relevance extends AbstractSorter
 
     public static function calculateAttributeWeightFactor(array $positionsPerTerm, array $attributeWeights): float
     {
-        $matchedAttributes = array_unique(array_filter(array_map(fn ($term) => $term[0][1], $positionsPerTerm)));
-        $matchedAttributeWeights = array_filter(array_map(fn ($attribute) => $attributeWeights[$attribute] ?? null, $matchedAttributes));
+        $matchedAttributes = array_reduce(
+            $positionsPerTerm,
+            fn ($result, $term) => array_merge($result, array_map(fn ($position) => $position[1], $term)),
+            []
+        );
+
+        $matchedAttributeWeights = array_filter(array_map(fn ($attribute) => $attributeWeights[$attribute] ?? 1, $matchedAttributes));
 
         return count($matchedAttributeWeights) ?
             (array_sum($matchedAttributeWeights) / count($matchedAttributeWeights))
@@ -165,7 +170,7 @@ class Relevance extends AbstractSorter
         );
 
         // Higher weight means more importance
-        static $relevanceWeights = [
+        $relevanceWeights = [
             3, // 1st: Number of query terms that match in a document
             2, // 2nd: Proximity of the words
             1, // 3rd: Weight of attributes matched

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -130,9 +130,6 @@ class Relevance extends AbstractSorter
         $positionPrev = null;
 
         foreach ($positionsPerTerm as $positions) {
-            // Account for old format without attribute: [1,2,3;4,5] → [[1,null],[2,null],[3,null];[4,null],[5,null]]
-            $positions = array_map(fn ($position) => !\is_array($position) ? [$position, null] : $position, $positions);
-
             if ($positionPrev === null) {
                 [$position] = $positions[0];
                 $positionPrev = $position;

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -163,7 +163,7 @@ final class LoupeFactory
             ],
             'loupe_relevance' => [
                 'callback' => [Relevance::class, 'fromQuery'],
-                'numArgs' => 2,
+                'numArgs' => 3,
             ],
         ];
 

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -28,7 +28,7 @@ final class SearchParameters
     /**
      * @var array<string, int>
      */
-    private array $attributeWeights = ['title' => 10];
+    private array $attributeWeights = ['title' => 2];
 
     private string $filter = '';
 

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -224,6 +224,11 @@ final class SearchParameters
      */
     public function withAttributeWeights(array $attributeWeights): self
     {
+        $attributeWeights = array_map(
+            fn ($weight) => ((int) $weight) ?: 1,
+            $attributeWeights
+        );
+
         $clone = clone $this;
         $clone->attributeWeights = $attributeWeights;
 

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -25,11 +25,6 @@ final class SearchParameters
      */
     private array $attributesToSearchOn = ['*'];
 
-    /**
-     * @var array<string, int>
-     */
-    private array $attributeWeights = [];
-
     private string $filter = '';
 
     private string $highlightEndTag = '</em>';
@@ -91,14 +86,6 @@ final class SearchParameters
         return $this->attributesToSearchOn;
     }
 
-    /**
-     * @return array<string, int>
-     */
-    public function getAttributeWeights(): array
-    {
-        return $this->attributeWeights;
-    }
-
     public function getFilter(): string
     {
         return $this->filter;
@@ -116,7 +103,6 @@ final class SearchParameters
         $hash[] = json_encode($this->getHighlightEndTag());
         $hash[] = json_encode($this->getAttributesToRetrieve());
         $hash[] = json_encode($this->getAttributesToSearchOn());
-        $hash[] = json_encode($this->getAttributeWeights());
         $hash[] = json_encode($this->getFilter());
         $hash[] = json_encode($this->getHitsPerPage());
         $hash[] = json_encode($this->getPage());
@@ -215,22 +201,6 @@ final class SearchParameters
 
         $clone = clone $this;
         $clone->attributesToSearchOn = $attributesToSearchOn;
-
-        return $clone;
-    }
-
-    /**
-     * @param array<string, int> $attributeWeights
-     */
-    public function withAttributeWeights(array $attributeWeights): self
-    {
-        $attributeWeights = array_map(
-            fn ($weight) => ((int) $weight) ?: 1,
-            $attributeWeights
-        );
-
-        $clone = clone $this;
-        $clone->attributeWeights = $attributeWeights;
 
         return $clone;
     }

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -28,7 +28,7 @@ final class SearchParameters
     /**
      * @var array<string, int>
      */
-    private array $attributeWeights = ['title' => 2];
+    private array $attributeWeights = [];
 
     private string $filter = '';
 

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -25,6 +25,11 @@ final class SearchParameters
      */
     private array $attributesToSearchOn = ['*'];
 
+    /**
+     * @var array<string, int>
+     */
+    private array $attributeWeights = ['title' => 10];
+
     private string $filter = '';
 
     private string $highlightEndTag = '</em>';
@@ -86,6 +91,14 @@ final class SearchParameters
         return $this->attributesToSearchOn;
     }
 
+    /**
+     * @return array<string, int>
+     */
+    public function getAttributeWeights(): array
+    {
+        return $this->attributeWeights;
+    }
+
     public function getFilter(): string
     {
         return $this->filter;
@@ -103,6 +116,7 @@ final class SearchParameters
         $hash[] = json_encode($this->getHighlightEndTag());
         $hash[] = json_encode($this->getAttributesToRetrieve());
         $hash[] = json_encode($this->getAttributesToSearchOn());
+        $hash[] = json_encode($this->getAttributeWeights());
         $hash[] = json_encode($this->getFilter());
         $hash[] = json_encode($this->getHitsPerPage());
         $hash[] = json_encode($this->getPage());
@@ -201,6 +215,17 @@ final class SearchParameters
 
         $clone = clone $this;
         $clone->attributesToSearchOn = $attributesToSearchOn;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, int> $attributeWeights
+     */
+    public function withAttributeWeights(array $attributeWeights): self
+    {
+        $clone = clone $this;
+        $clone->attributeWeights = $attributeWeights;
 
         return $clone;
     }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1832,7 +1832,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 22,
                     'title' => 'Pirates of the Caribbean: The Curse of the Black Pearl',
-                    '_rankingScore' => 0.79194,
+                    '_rankingScore' => 1.0,
                 ],
             ],
             'query' => 'Pirates of the Caribbean: The Curse of the Black Pearl',

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2023,7 +2023,9 @@ class SearchTest extends TestCase
         $searchParameters = SearchParameters::create()
             ->withQuery('life game')
             ->withAttributesToRetrieve(['id', 'title'])
-            ->withAttributeWeights(['title' => 10])
+            ->withAttributeWeights([
+                'title' => 10,
+            ])
             ->withShowRankingScore(true)
         ;
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2052,7 +2052,6 @@ class SearchTest extends TestCase
             'totalHits' => 3,
         ]);
 
-
         $configurationWithAttributes = Configuration::create()
             ->withSearchableAttributes(['title', 'content'])
             ->withSortableAttributes(['title', 'content'])

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1968,7 +1968,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 4,
                     'content' => 'Book title: life learning',
-                    '_rankingScore' =>  0.78904,
+                    '_rankingScore' => 0.78904,
                 ],
                 [
                     'id' => 1,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2023,9 +2023,6 @@ class SearchTest extends TestCase
         $searchParameters = SearchParameters::create()
             ->withQuery('life game')
             ->withAttributesToRetrieve(['id', 'title'])
-            ->withAttributeWeights([
-                'title' => 10,
-            ])
             ->withShowRankingScore(true)
         ;
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1891,12 +1891,12 @@ class SearchTest extends TestCase
                 [
                     'id' => 2,
                     'content' => 'The unexamined life is not worth living. Life is life.',
-                    '_rankingScore' => 0.66667,
+                    '_rankingScore' => 0.75,
                 ],
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.58027,
+                    '_rankingScore' => 0.66361,
                 ],
             ],
             'query' => 'life learning',
@@ -1968,22 +1968,22 @@ class SearchTest extends TestCase
                 [
                     'id' => 4,
                     'content' => 'Book title: life learning',
-                    '_rankingScore' => 0.71872,
+                    '_rankingScore' => 0.77428,
                 ],
                 [
                     'id' => 1,
                     'content' => 'The game of life is a game of everlasting learning',
-                    '_rankingScore' => 0.64763,
+                    '_rankingScore' => 0.70319,
                 ],
                 [
                     'id' => 2,
                     'content' => 'The unexamined life is not worth living. Life is life.',
-                    '_rankingScore' => 0.51236,
+                    '_rankingScore' => 0.62347,
                 ],
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.51236,
+                    '_rankingScore' => 0.62347,
                 ],
             ],
             'query' => 'foobar life learning',

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2042,7 +2042,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 2,
                     'title' => 'Everlasting learning',
-                    '_rankingScore' => 0.83333,
+                    '_rankingScore' => 1.0,
                 ],
             ],
             'query' => 'life game',

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2065,7 +2065,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'title' => 'Game of life',
-                    '_rankingScore' => 0.95,
+                    '_rankingScore' => 1.0,
                 ],
                 [
                     'id' => 2,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1832,7 +1832,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 22,
                     'title' => 'Pirates of the Caribbean: The Curse of the Black Pearl',
-                    '_rankingScore' => 1.0,
+                    '_rankingScore' => 0.79194,
                 ],
             ],
             'query' => 'Pirates of the Caribbean: The Curse of the Black Pearl',
@@ -1886,7 +1886,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'content' => 'The game of life is a game of everlasting learning',
-                    '_rankingScore' => 0.8496,
+                    '_rankingScore' => 0.8872,
                 ],
                 [
                     'id' => 2,
@@ -1896,7 +1896,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.66361,
+                    '_rankingScore' => 0.6852,
                 ],
             ],
             'query' => 'life learning',
@@ -1919,7 +1919,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'content' => 'The game of life is a game of everlasting learning',
-                    '_rankingScore' => 0.8496,
+                    '_rankingScore' => 0.8872,
                 ],
             ],
             'query' => 'life learning',
@@ -1968,22 +1968,22 @@ class SearchTest extends TestCase
                 [
                     'id' => 4,
                     'content' => 'Book title: life learning',
-                    '_rankingScore' => 0.77428,
+                    '_rankingScore' =>  0.78904,
                 ],
                 [
                     'id' => 1,
                     'content' => 'The game of life is a game of everlasting learning',
-                    '_rankingScore' => 0.70319,
+                    '_rankingScore' => 0.73572,
                 ],
                 [
                     'id' => 2,
                     'content' => 'The unexamined life is not worth living. Life is life.',
-                    '_rankingScore' => 0.62347,
+                    '_rankingScore' => 0.63427,
                 ],
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.62347,
+                    '_rankingScore' => 0.63427,
                 ],
             ],
             'query' => 'foobar life learning',
@@ -2021,7 +2021,7 @@ class SearchTest extends TestCase
         ]);
 
         $searchParameters = SearchParameters::create()
-            ->withQuery('life game')
+            ->withQuery('game of life')
             ->withAttributesToRetrieve(['id', 'title'])
             ->withShowRankingScore(true)
         ;
@@ -2031,20 +2031,20 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'title' => 'Game of life',
-                    '_rankingScore' => 2.5,
-                ],
-                [
-                    'id' => 3,
-                    'title' => 'Learning to game',
-                    '_rankingScore' => 1.66667,
+                    '_rankingScore' => 0.95,
                 ],
                 [
                     'id' => 2,
                     'title' => 'Everlasting learning',
-                    '_rankingScore' => 1.0,
+                    '_rankingScore' => 0.878,
+                ],
+                [
+                    'id' => 3,
+                    'title' => 'Learning to game',
+                    '_rankingScore' => 0.78333,
                 ],
             ],
-            'query' => 'life game',
+            'query' => 'game of life',
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -115,7 +115,11 @@ class RelevanceTest extends TestCase
         );
 
         $this->assertSame(
-            ['title' => 1.0, 'summary' => 0.8, 'body' => 0.64],
+            [
+                'title' => 1.0,
+                'summary' => 0.8,
+                'body' => 0.64,
+            ],
             Relevance::calculateIntrinsicAttributeWeights(['title', 'summary', 'body'])
         );
     }

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -55,6 +55,49 @@ class RelevanceTest extends TestCase
         ];
     }
 
+    public static function attributeWeightProvider(): \Generator
+    {
+        yield 'No attributes are weighted' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [],
+            1.0,
+        ];
+
+        yield 'No attributes are matched' => [
+            [[[1, 'title'], [2, 'summary']]],
+            ['unknown_attribute' => 5],
+            1.0,
+        ];
+
+        yield 'All attributes are equal' => [
+            [[[1, 'title'], [2, 'summary']]],
+            ['title' => 1, 'summary' => 1],
+            1.0,
+        ];
+
+        yield 'Attribute weighs double against attribute' => [
+            [[[1, 'title'], [2, 'summary']]],
+            ['title' => 2],
+            1.5,
+        ];
+
+        yield 'Attribute weighs double against multiple attributes' => [
+            [[[1, 'title'], [2, 'summary'], [2, 'content']]],
+            ['summary' => 2],
+            1.3333333333333333,
+        ];
+    }
+
+    /**
+     * @param array<int, array<int>> $positionsPerTerm
+     * @param array<string, int> $attributeWeights
+     */
+    #[DataProvider('attributeWeightProvider')]
+    public function testCalculateAttributeWeight(array $positionsPerTerm, array $attributeWeights, float $expected): void
+    {
+        $this->assertSame($expected, Relevance::calculateAttributeWeightFactor($positionsPerTerm, $attributeWeights));
+    }
+
     /**
      * @param array<int, array<int>> $positionsPerTerm
      */

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -102,9 +102,22 @@ class RelevanceTest extends TestCase
      * @param array<string, int> $attributeWeights
      */
     #[DataProvider('attributeWeightProvider')]
-    public function testCalculateAttributeWeight(array $positionsPerTerm, array $attributeWeights, float $expected): void
+    public function testCalculateAttributeWeightFactor(array $positionsPerTerm, array $attributeWeights, float $expected): void
     {
         $this->assertSame($expected, Relevance::calculateAttributeWeightFactor($positionsPerTerm, $attributeWeights));
+    }
+
+    public function testCalculateIntrinsicAttributeWeights(): void
+    {
+        $this->assertSame(
+            [],
+            Relevance::calculateIntrinsicAttributeWeights(['*'])
+        );
+
+        $this->assertSame(
+            ['title' => 1.0, 'summary' => 0.8, 'body' => 0.64],
+            Relevance::calculateIntrinsicAttributeWeights(['title', 'summary', 'body'])
+        );
     }
 
     /**

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -98,7 +98,7 @@ class RelevanceTest extends TestCase
     }
 
     /**
-     * @param array<int, array<int>> $positionsPerTerm
+     * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm $positionsPerTerm
      * @param array<string, int> $attributeWeights
      */
     #[DataProvider('attributeWeightProvider')]
@@ -108,7 +108,7 @@ class RelevanceTest extends TestCase
     }
 
     /**
-     * @param array<int, array<int>> $positionsPerTerm
+     * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm $positionsPerTerm
      */
     #[DataProvider('proximityFactorProvider')]
     public function testCalculateProximityFactor(array $positionsPerTerm, float $decayFactor, float $expected): void

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -21,7 +21,7 @@ class RelevanceTest extends TestCase
         yield 'No attributes are matched' => [
             [[[1, 'title'], [2, 'summary']]],
             [
-                'unknown_attribute' => 5,
+                'unknown_attribute' => 0.5,
             ],
             1.0,
         ];
@@ -35,20 +35,31 @@ class RelevanceTest extends TestCase
             1.0,
         ];
 
-        yield 'Attribute weighs double against attribute' => [
-            [[[1, 'title'], [2, 'summary']]],
+        yield 'Attributes are applied when found' => [
+            [[[1, 'title']]],
             [
-                'title' => 2,
+                'title' => 1,
+                'summary' => 0.8,
             ],
-            2.0,
+            1.0,
         ];
 
-        yield 'Attribute weighs triple against multiple attributes' => [
-            [[[1, 'title'], [2, 'summary'], [2, 'content']]],
+        yield 'Attributes are applied when found later in list' => [
+            [[[1, 'non_existent'], [2, 'summary']]],
             [
-                'summary' => 3,
+                'title' => 1,
+                'summary' => 0.8,
             ],
-            3.0,
+            0.8,
+        ];
+
+        yield 'Terms found in multiple attributes are applied the highest factor' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [
+                'title' => 1,
+                'summary' => 0.8,
+            ],
+            1.0,
         ];
     }
 

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -55,13 +55,13 @@ class RelevanceTest extends TestCase
     public static function proximityFactorProvider(): \Generator
     {
         yield 'All terms are adjacent' => [
-            [[1], [2], [3]],
+            [[[1, 'term']], [[2, 'term']], [[3, 'term']]],
             0.1,
             1.0, // All distances are 1, so result is 1
         ];
 
         yield 'Non-adjacent terms' => [
-            [[1], [3], [5]],
+            [[[1, 'term']], [[3, 'term']], [[5, 'term']]],
             0.1,
             (exp(-0.1 * 2) + exp(-0.1 * 2)) / 2,
         ];
@@ -73,25 +73,25 @@ class RelevanceTest extends TestCase
         ];
 
         yield 'Single term' => [
-            [[1]],
+            [[[1, 'term']]],
             0.1,
             1.0, // One match, must be 1
         ];
 
         yield 'Multiple positions per term, only closest must be considered' => [
-            [[1, 4], [6, 10]],
+            [[[1, 'term'], [4, 'term']], [[6, 'term'], [10, 'term']]],
             0.1,
             (exp(-0.1 * 5)),
         ];
 
         yield 'Higher decay factor' => [
-            [[1], [4]],
+            [[[1, 'term']], [[4, 'term']]],
             0.5,
             exp(-0.5 * 3), // Only one pair, distance is 3
         ];
 
         yield 'Lots of terms but all in the correct order' => [
-            [[1, 7, 12], [2, 7],  [3, 5, 8, 19, 28], [4], [3, 5, 8, 19, 28], [6], [2, 7], [3, 5, 8, 19, 28], [9], [10]],
+            [[[1, 'term'], [7, 'term'], [12, 'term']], [[2, 'term'], [7, 'term']],  [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[4, 'term']], [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[6, 'term']], [[2, 'term'], [7, 'term']], [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[9, 'term']], [[10, 'term']]],
             0.1,
             1,
         ];

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -78,13 +78,13 @@ class RelevanceTest extends TestCase
         yield 'Attribute weighs double against attribute' => [
             [[[1, 'title'], [2, 'summary']]],
             ['title' => 2],
-            1.5,
+            2.0,
         ];
 
-        yield 'Attribute weighs double against multiple attributes' => [
+        yield 'Attribute weighs triple against multiple attributes' => [
             [[[1, 'title'], [2, 'summary'], [2, 'content']]],
-            ['summary' => 2],
-            1.3333333333333333,
+            ['summary' => 3],
+            3.0,
         ];
     }
 

--- a/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
+++ b/tests/Unit/Internal/Search/Sorting/RelevanceTest.php
@@ -10,6 +10,48 @@ use PHPUnit\Framework\TestCase;
 
 class RelevanceTest extends TestCase
 {
+    public static function attributeWeightProvider(): \Generator
+    {
+        yield 'No attributes are weighted' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [],
+            1.0,
+        ];
+
+        yield 'No attributes are matched' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [
+                'unknown_attribute' => 5,
+            ],
+            1.0,
+        ];
+
+        yield 'All attributes are equal' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [
+                'title' => 1,
+                'summary' => 1,
+            ],
+            1.0,
+        ];
+
+        yield 'Attribute weighs double against attribute' => [
+            [[[1, 'title'], [2, 'summary']]],
+            [
+                'title' => 2,
+            ],
+            2.0,
+        ];
+
+        yield 'Attribute weighs triple against multiple attributes' => [
+            [[[1, 'title'], [2, 'summary'], [2, 'content']]],
+            [
+                'summary' => 3,
+            ],
+            3.0,
+        ];
+    }
+
     public static function proximityFactorProvider(): \Generator
     {
         yield 'All terms are adjacent' => [
@@ -52,39 +94,6 @@ class RelevanceTest extends TestCase
             [[1, 7, 12], [2, 7],  [3, 5, 8, 19, 28], [4], [3, 5, 8, 19, 28], [6], [2, 7], [3, 5, 8, 19, 28], [9], [10]],
             0.1,
             1,
-        ];
-    }
-
-    public static function attributeWeightProvider(): \Generator
-    {
-        yield 'No attributes are weighted' => [
-            [[[1, 'title'], [2, 'summary']]],
-            [],
-            1.0,
-        ];
-
-        yield 'No attributes are matched' => [
-            [[[1, 'title'], [2, 'summary']]],
-            ['unknown_attribute' => 5],
-            1.0,
-        ];
-
-        yield 'All attributes are equal' => [
-            [[[1, 'title'], [2, 'summary']]],
-            ['title' => 1, 'summary' => 1],
-            1.0,
-        ];
-
-        yield 'Attribute weighs double against attribute' => [
-            [[[1, 'title'], [2, 'summary']]],
-            ['title' => 2],
-            2.0,
-        ];
-
-        yield 'Attribute weighs triple against multiple attributes' => [
-            [[[1, 'title'], [2, 'summary'], [2, 'content']]],
-            ['summary' => 3],
-            3.0,
         ];
     }
 


### PR DESCRIPTION
(Sorry for spamming you with pull requests, but it's just too much fun 🤠)

Add a new relevance factor: attribute ranking order. Give slight precedence to matches that appear early in the list of searchable attributes. This will naturally rank matches in the `title` higher, assuming `title` appears first in the list.

The behavior is modeled on Meilisearch. When searchable attributes are not configured (`['*']`), attribute order is ignored. When they are configured, they are ranked in order of appearance: `['title', 'summary']` will slightly prefer `title` matches. The factor is currently `0.8`, I'm seeing reasonable results with that. The factor below `1` technically downranks matches in later attributes, rather than uprank earlier attributes, but this way we don't get final relevance scores above `1`.

See the Meilisearch docs on [Attribute ranking order](https://www.meilisearch.com/docs/learn/relevancy/attribute_ranking_order) for details.

## Usage

### No intrinsic ranking

```php
Configuration::create()->withSearchableAttributes(['*'])
```

### Intrinsic ranking by order

```php
# Prefer matches by order of appearance in this list: `title` > `summary` > `body`

Configuration::create()->withSearchableAttributes(['title', 'summary', 'body'])
```

## Example matches

Example rankings when searching for **`game of life`**. The first relevance column uses `['*']` as searchable attributes, the second relevance column uses `['title', 'content']`

| Title | Content | Without attribute order | With attribute order |
|-------|---------|----------------|-------------|
| **Game of life** | A thing with everlasting learning | 1.0 | 1.0 |
| Everlasting learning | The unexamined **game of life** | 1.0 | 0.88 |
| Learning to **game** | What **life** taught me about learning | 0.83 | 0.78 |
