### PR TITLE
Fix tokenization of hyphenated compound words

### DIFF
--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -82,6 +82,7 @@ class Tokenizer
 
         return $result;
     }
+
     private function doTokenize(string $string, ?string $language, ?int $maxTokens = null): TokenCollection
     {
         $iterator = \IntlRuleBasedBreakIterator::createWordInstance($language); // @phpstan-ignore-line - null is allowed

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -82,7 +82,6 @@ class Tokenizer
 
         return $result;
     }
-
     private function doTokenize(string $string, ?string $language, ?int $maxTokens = null): TokenCollection
     {
         $iterator = \IntlRuleBasedBreakIterator::createWordInstance($language); // @phpstan-ignore-line - null is allowed
@@ -93,11 +92,16 @@ class Tokenizer
         $position = 0;
         $phrase = false;
         $negated = false;
+        $status = null;
+        $previousStatus = null;
 
         foreach ($iterator->getPartsIterator() as $term) {
-            if ($term === '-') {
-                $position++;
+            $previousStatus = $status;
+            $status = $iterator->getRuleStatus();
+
+            if ($term === '-' && !$previousStatus) {
                 $negated = true;
+                $position++;
                 continue;
             }
 
@@ -110,7 +114,7 @@ class Tokenizer
                 continue;
             }
 
-            if ($iterator->getRuleStatus() === \IntlBreakIterator::WORD_NONE) {
+            if ($status === \IntlBreakIterator::WORD_NONE) {
                 $position += mb_strlen($term, 'UTF-8');
                 continue;
             }

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -169,7 +169,7 @@ class Tokenizer
 
     private function isWhitespace(?int $status, string $token): bool
     {
-        return ($status === null || ($status >= \IntlBreakIterator::WORD_NONE && $status < \IntlBreakIterator::WORD_NONE_LIMIT)) && mb_trim($token) === '';
+        return ($status === null || ($status >= \IntlBreakIterator::WORD_NONE && $status < \IntlBreakIterator::WORD_NONE_LIMIT)) && trim($token) === '';
     }
 
     private function isWord(?int $status): bool

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -152,16 +152,6 @@ class Tokenizer
         return $collection;
     }
 
-    private function isWhitespace(?int $status, string $token): bool
-    {
-        return ($status === null || ($status >= \IntlBreakIterator::WORD_NONE && $status < \IntlBreakIterator::WORD_NONE_LIMIT)) && mb_trim($token) === '';
-    }
-
-    private function isWord(?int $status): bool
-    {
-        return $status >= \IntlBreakIterator::WORD_NONE_LIMIT;
-    }
-
     private function getStemmerForLanguage(string $language): ?Stemmer
     {
         if (isset($this->stemmers[$language])) {
@@ -175,6 +165,16 @@ class Tokenizer
         }
 
         return $this->stemmers[$language] = $stemmer;
+    }
+
+    private function isWhitespace(?int $status, string $token): bool
+    {
+        return ($status === null || ($status >= \IntlBreakIterator::WORD_NONE && $status < \IntlBreakIterator::WORD_NONE_LIMIT)) && mb_trim($token) === '';
+    }
+
+    private function isWord(?int $status): bool
+    {
+        return $status >= \IntlBreakIterator::WORD_NONE_LIMIT;
     }
 
     private function stem(string $term, string $language): ?string

--- a/tests/Functional/IndexData/departments.json
+++ b/tests/Functional/IndexData/departments.json
@@ -58,5 +58,15 @@
         "colors": ["Green"],
         "age": 18,
         "isActive": false
+    },
+    {
+        "id": 7,
+        "firstname": "Thomas",
+        "lastname": "Müller-Lüdenscheidt",
+        "gender": "male",
+        "departments": ["Facility-Management"],
+        "colors": ["Magenta"],
+        "age": 96,
+        "isActive": false
     }
 ]

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -69,6 +69,10 @@ class SearchTest extends TestCase
                     'firstname' => 'Sandra',
                 ],
                 [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
+                ],
+                [
                     'id' => 2,
                     'firstname' => 'Uta',
                 ],
@@ -103,6 +107,10 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'firstname' => 'Sandra',
+                ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
                 ],
                 [
                     'id' => 2,
@@ -147,6 +155,10 @@ class SearchTest extends TestCase
                     'id' => 1,
                     'firstname' => 'Sandra',
                 ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
+                ],
             ],
         ];
 
@@ -183,6 +195,10 @@ class SearchTest extends TestCase
                     'id' => 5,
                     'firstname' => 'Marko',
                 ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
+                ],
             ],
         ];
 
@@ -192,6 +208,10 @@ class SearchTest extends TestCase
                 [
                     'id' => 6,
                     'firstname' => 'Huckleberry',
+                ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
                 ],
             ],
         ];
@@ -557,6 +577,10 @@ class SearchTest extends TestCase
                     'id' => 1,
                     'firstname' => 'Sandra',
                 ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
+                ],
             ],
         ];
 
@@ -592,6 +616,10 @@ class SearchTest extends TestCase
                 [
                     'id' => 5,
                     'firstname' => 'Marko',
+                ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
                 ],
             ],
         ];
@@ -664,6 +692,79 @@ class SearchTest extends TestCase
         ];
     }
 
+    public static function negatedQueryProvider(): \Generator
+    {
+        yield 'Searching for "-Huckleberry" should return all except him' => [
+            '-huckleberry',
+            [
+                [
+                    'firstname' => 'Alexander',
+                    'lastname' => 'Abendroth',
+                ],
+                [
+                    'firstname' => 'Jonas',
+                    'lastname' => 'Kalb',
+                ],
+                [
+                    'firstname' => 'Marko',
+                    'lastname' => 'Gerste',
+                ],
+                [
+                    'firstname' => 'Sandra',
+                    'lastname' => 'Maier',
+                ],
+                [
+                    'firstname' => 'Thomas',
+                    'lastname' => 'Müller-Lüdenscheidt',
+                ],
+                [
+                    'firstname' => 'Uta',
+                    'lastname' => 'Koertig',
+                ],
+            ],
+        ];
+
+        yield 'Searching for "-Müller-Lüdenscheidt" should return all except "Müller-Lüdenscheidt"' => [
+            '-Müller-Lüdenscheidt',
+            [
+                [
+                    'firstname' => 'Alexander',
+                    'lastname' => 'Abendroth',
+                ],
+                [
+                    'firstname' => 'Huckleberry',
+                    'lastname' => 'Finn',
+                ],
+                [
+                    'firstname' => 'Jonas',
+                    'lastname' => 'Kalb',
+                ],
+                [
+                    'firstname' => 'Marko',
+                    'lastname' => 'Gerste',
+                ],
+                [
+                    'firstname' => 'Sandra',
+                    'lastname' => 'Maier',
+                ],
+                [
+                    'firstname' => 'Uta',
+                    'lastname' => 'Koertig',
+                ],
+            ],
+        ];
+
+        yield 'Searching for "Müller-Lüdenscheidt" should return "Müller-Lüdenscheidt"' => [
+            'Müller-Lüdenscheidt',
+            [
+                [
+                    'firstname' => 'Thomas',
+                    'lastname' => 'Müller-Lüdenscheidt',
+                ],
+            ],
+        ];
+    }
+
     public static function nullFilterProvider(): \Generator
     {
         yield 'IS NULL on multiple attribute' => [
@@ -694,6 +795,10 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'firstname' => 'Sandra',
+                ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
                 ],
                 [
                     'id' => 2,
@@ -730,6 +835,10 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'firstname' => 'Sandra',
+                ],
+                [
+                    'id' => 7,
+                    'firstname' => 'Thomas',
                 ],
                 [
                     'id' => 2,
@@ -2106,6 +2215,9 @@ class SearchTest extends TestCase
                     'firstname' => 'Sandra',
                 ],
                 [
+                    'firstname' => 'Thomas',
+                ],
+                [
                     'firstname' => 'Uta',
                 ],
             ],
@@ -2113,7 +2225,7 @@ class SearchTest extends TestCase
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,
-            'totalHits' => 6,
+            'totalHits' => 7,
         ]);
 
         $searchParameters = $searchParameters->withSort(['firstname:desc']);
@@ -2122,6 +2234,9 @@ class SearchTest extends TestCase
             'hits' => [
                 [
                     'firstname' => 'Uta',
+                ],
+                [
+                    'firstname' => 'Thomas',
                 ],
                 [
                     'firstname' => 'Sandra',
@@ -2143,7 +2258,7 @@ class SearchTest extends TestCase
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,
-            'totalHits' => 6,
+            'totalHits' => 7,
         ]);
     }
 
@@ -2227,6 +2342,30 @@ class SearchTest extends TestCase
         ;
 
         $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
+    }
+
+    /**
+     * @param array<mixed> $expectedResults
+     */
+    #[DataProvider('negatedQueryProvider')]
+    public function testWithNegation(string $query, array $expectedResults): void
+    {
+        $loupe = $this->setupLoupeWithDepartmentsFixture();
+
+        $searchParameters = SearchParameters::create()
+            ->withAttributesToRetrieve(['firstname', 'lastname'])
+            ->withSort(['firstname:asc'])
+            ->withQuery($query)
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => $expectedResults,
+            'query' => $query,
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => \count($expectedResults) === 0 ? 0 : 1,
+            'totalHits' => \count($expectedResults),
+        ]);
     }
 
     public function testWithoutSetup(): void

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -93,6 +93,35 @@ class TokenizerTest extends TestCase
         ], $tokens->allNegatedTermsWithVariants());
     }
 
+    public function testNegatedWordPartTokens(): void
+    {
+        $tokenizer = $this->createTokenizer();
+        $tokens = $tokenizer->tokenize('Hallo, mein Name-ist-Hase und -ich weiß von 64-bit-Dingen.');
+
+        $this->assertSame([
+            'hallo',
+            'mein',
+            'name',
+            'nam',
+            'ist',
+            'hase',
+            'has',
+            'und',
+            'ich',
+            'weiß',
+            'weiss',
+            'von',
+            '64',
+            'bit',
+            'dingen',
+            'ding',
+        ], $tokens->allTermsWithVariants());
+
+        $this->assertSame([
+            'ich',
+        ], $tokens->allNegatedTermsWithVariants());
+    }
+
     /**
      * @param array<string> $languages
      * @param array<string> $expectedTokens

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -93,40 +93,6 @@ class TokenizerTest extends TestCase
         ], $tokens->allNegatedTermsWithVariants());
     }
 
-    public function testNegatedWordPartTokens(): void
-    {
-        $tokenizer = $this->createTokenizer();
-        $tokens = $tokenizer->tokenize('Hallo, mein -Name-ist-Hase und -ich weiß von 64-bit-Dingen.');
-
-        $this->assertSame([
-            'hallo',
-            'mein',
-            'name',
-            'nam',
-            'ist',
-            'hase',
-            'has',
-            'und',
-            'ich',
-            'weiß',
-            'weiss',
-            'von',
-            '64',
-            'bit',
-            'dingen',
-            'ding',
-        ], $tokens->allTermsWithVariants());
-
-        $this->assertSame([
-            'name',
-            'nam',
-            'ist',
-            'hase',
-            'has',
-            'ich',
-        ], $tokens->allNegatedTermsWithVariants());
-    }
-
     public function testNegatedWordPartPhraseTokens(): void
     {
         $tokenizer = $this->createTokenizer();
@@ -159,6 +125,40 @@ class TokenizerTest extends TestCase
             'has',
             'ich',
             'weiß',
+        ], $tokens->allNegatedTermsWithVariants());
+    }
+
+    public function testNegatedWordPartTokens(): void
+    {
+        $tokenizer = $this->createTokenizer();
+        $tokens = $tokenizer->tokenize('Hallo, mein -Name-ist-Hase und -ich weiß von 64-bit-Dingen.');
+
+        $this->assertSame([
+            'hallo',
+            'mein',
+            'name',
+            'nam',
+            'ist',
+            'hase',
+            'has',
+            'und',
+            'ich',
+            'weiß',
+            'weiss',
+            'von',
+            '64',
+            'bit',
+            'dingen',
+            'ding',
+        ], $tokens->allTermsWithVariants());
+
+        $this->assertSame([
+            'name',
+            'nam',
+            'ist',
+            'hase',
+            'has',
+            'ich',
         ], $tokens->allNegatedTermsWithVariants());
     }
 

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -96,7 +96,7 @@ class TokenizerTest extends TestCase
     public function testNegatedWordPartTokens(): void
     {
         $tokenizer = $this->createTokenizer();
-        $tokens = $tokenizer->tokenize('Hallo, mein Name-ist-Hase und -ich weiß von 64-bit-Dingen.');
+        $tokens = $tokenizer->tokenize('Hallo, mein -Name-ist-Hase und -ich weiß von 64-bit-Dingen.');
 
         $this->assertSame([
             'hallo',
@@ -118,6 +118,10 @@ class TokenizerTest extends TestCase
         ], $tokens->allTermsWithVariants());
 
         $this->assertSame([
+            'name',
+            'ist',
+            'hase',
+            'has',
             'ich',
         ], $tokens->allNegatedTermsWithVariants());
     }

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -119,10 +119,46 @@ class TokenizerTest extends TestCase
 
         $this->assertSame([
             'name',
+            'nam',
             'ist',
             'hase',
             'has',
             'ich',
+        ], $tokens->allNegatedTermsWithVariants());
+    }
+
+    public function testNegatedWordPartPhraseTokens(): void
+    {
+        $tokenizer = $this->createTokenizer();
+        $tokens = $tokenizer->tokenize('-Hallo, mein -Name-ist-Hase und -"ich weiß" von 64-bit-Dingen.');
+
+        $this->assertSame([
+            'hallo',
+            'mein',
+            'name',
+            'nam',
+            'ist',
+            'hase',
+            'has',
+            'und',
+            'ich',
+            'weiß',
+            'von',
+            '64',
+            'bit',
+            'dingen',
+            'ding',
+        ], $tokens->allTermsWithVariants());
+
+        $this->assertSame([
+            'hallo',
+            'name',
+            'nam',
+            'ist',
+            'hase',
+            'has',
+            'ich',
+            'weiß',
         ], $tokens->allNegatedTermsWithVariants());
     }
 


### PR DESCRIPTION
- Make sure we're only marking words as negated if they aren't part of compound words
- Added tests to avoid regressions
- Fixes #114 