### PR TITLE
Switch to Damerau-Levenshtein

### DIFF
--- a/src/Internal/Levenshtein.php
+++ b/src/Internal/Levenshtein.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal;
 
+use Toflar\StateSetIndex\DamerauLevenshtein;
+
 class Levenshtein
 {
-    public static function levenshtein(string $string1, string $string2, bool $firstCharTypoCountsDouble): int
+    public static function damerauLevenshtein(string $string1, string $string2, bool $firstCharTypoCountsDouble): int
     {
-        $distance = \Toflar\StateSetIndex\Levenshtein::distance($string1, $string2);
+        $distance = DamerauLevenshtein::distance($string1, $string2);
 
         if ($firstCharTypoCountsDouble && mb_substr($string1, 0, 1) !== mb_substr($string2, 0, 1)) {
             $distance++;
@@ -17,13 +19,14 @@ class Levenshtein
         return $distance;
     }
 
-    public static function maxLevenshtein(string $string1, string $string2, int $max, bool $firstCharTypoCountsDouble): bool
+    public static function maxLevenshtein(string $string1, string $string2, int $maxDistance, bool $firstCharTypoCountsDouble): bool
     {
-        // Maybe this can be optimized in the future. We're looking if $string1's distance to $string2 is
-        // more or equal to $max. This means we do not care about the actual distance, just the boolean result.
-        // So we don't have to e.g. count to a distance of 10 if $max is 2, we can early return.
-        // Not sure if worth it, though as implementing it in PHP would be slower than in C so it might end up having
-        // the same performance.
-        return self::levenshtein($string1, $string2, $firstCharTypoCountsDouble) <= $max;
+        $distance = DamerauLevenshtein::distance($string1, $string2, $maxDistance + 1);
+
+        if ($firstCharTypoCountsDouble && mb_substr($string1, 0, 1) !== mb_substr($string2, 0, 1)) {
+            ++$distance;
+        }
+
+        return $distance <= $maxDistance;
     }
 }

--- a/src/Internal/Search/Highlighter/Highlighter.php
+++ b/src/Internal/Search/Highlighter/Highlighter.php
@@ -114,7 +114,7 @@ class Highlighter
                     }
                 } else {
                     foreach ($textToken->allTerms() as $textTerm) {
-                        if (Levenshtein::levenshtein($term, $textTerm, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
+                        if (Levenshtein::damerauLevenshtein($term, $textTerm, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
                             return true;
                         }
                     }
@@ -139,14 +139,14 @@ class Highlighter
         $prefix = implode('', \array_slice($chars, 0, $configuration->getMinTokenLengthForPrefixSearch()));
         $rest = \array_slice($chars, $configuration->getMinTokenLengthForPrefixSearch());
 
-        if (Levenshtein::levenshtein($lastToken->getTerm(), $prefix, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
+        if (Levenshtein::damerauLevenshtein($lastToken->getTerm(), $prefix, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
             return true;
         }
 
         while ($rest !== []) {
             $prefix .= array_shift($rest);
 
-            if (Levenshtein::levenshtein($lastToken->getTerm(), $prefix, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
+            if (Levenshtein::damerauLevenshtein($lastToken->getTerm(), $prefix, $firstCharTypoCountsDouble) <= $levenshteinDistance) {
                 return true;
             }
         }

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -501,7 +501,7 @@ class Searcher
             return implode(' ', $where);
         }
 
-        $states = $this->engine->getStateSetIndex()->findMatchingStates($term, $levenshteinDistance, 2);
+        $states = $this->engine->getStateSetIndex()->findMatchingStates($term, $levenshteinDistance, 1);
 
         // No result possible, we add AND 1=0 to ensure no results
         if ($states === []) {


### PR DESCRIPTION
This PR would enable @ausi's new implementation on the Damerau-Levenshtein algorithm.
For those not familiar with it: Compared to regular Levenshtein, transpositions are counted as the cost of 1 typo as opposed to 2 typos in regular Levenshtein. What's a transposition? Scrambled letters right next to one another: e.g. "huose" instead of "house".

It happens quite often when users type. Hence I'd consider Damerau-Levenshtein to be more suitable for a search engine.
However, the PHP version is quite a bit slower than `levenshtein()` which is a native PHP/C function.

So currently, the benchmark in `bin` is about 20ms slower (140ms instead of 120ms). However, the typos are a bit more UX friendly...so I guess it's a trade-off here at the moment.

I was fiddling around with Damerau-Levenshtein automatons which might improve this a little but I'm not sure.