### PR TITLE
Cache sqlite custom function calls

### DIFF
--- a/src/Internal/Levenshtein.php
+++ b/src/Internal/Levenshtein.php
@@ -8,7 +8,7 @@ use Toflar\StateSetIndex\DamerauLevenshtein;
 
 class Levenshtein
 {
-    public static function damerauLevenshtein(string $string1, string $string2, bool $firstCharTypoCountsDouble): int
+    public static function damerauLevenshtein(string $string1, string $string2, int|bool $firstCharTypoCountsDouble): int
     {
         $distance = DamerauLevenshtein::distance($string1, $string2);
 
@@ -19,7 +19,7 @@ class Levenshtein
         return $distance;
     }
 
-    public static function maxLevenshtein(string $string1, string $string2, int $maxDistance, bool $firstCharTypoCountsDouble): bool
+    public static function maxLevenshtein(string $string1, string $string2, int $maxDistance, int|bool $firstCharTypoCountsDouble): bool
     {
         $distance = DamerauLevenshtein::distance($string1, $string2, $maxDistance + 1);
 

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -176,7 +176,7 @@ class Relevance extends AbstractSorter
      *
      * @param string $positionsInDocumentPerTerm A string of ";" separated per term and "," separated for all the term positions within a document
      */
-    public static function fromQuery(string $positionsInDocumentPerTerm, string $totalQueryTokenCount, string $attributeWeights): float
+    public static function fromQuery(string $positionsInDocumentPerTerm, int|string $totalQueryTokenCount, string $attributeWeights): float
     {
         $totalQueryTokenCount = (int) $totalQueryTokenCount;
         $positionsPerTerm = static::parseTermPositions($positionsInDocumentPerTerm);

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -16,9 +16,12 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Geo;
 use Loupe\Loupe\Internal\Levenshtein;
 use Loupe\Loupe\Internal\Search\Sorting\Relevance;
+use Loupe\Loupe\Traits\MemoizationTrait;
 
 final class LoupeFactory
 {
+    use MemoizationTrait;
+
     private const MIN_SQLITE_VERSION = '3.16.0'; // Introduction of Pragma functions
 
     public function create(string $dataDir, Configuration $configuration): Loupe
@@ -154,15 +157,15 @@ final class LoupeFactory
     {
         $functions = [
             'loupe_max_levenshtein' => [
-                'callback' => [Levenshtein::class, 'maxLevenshtein'],
+                'callback' => $this->memoize([Levenshtein::class, 'maxLevenshtein']),
                 'numArgs' => 4,
             ],
             'loupe_geo_distance' => [
-                'callback' => [Geo::class, 'geoDistance'],
+                'callback' => $this->memoize([Geo::class, 'geoDistance']),
                 'numArgs' => 4,
             ],
             'loupe_relevance' => [
-                'callback' => [Relevance::class, 'fromQuery'],
+                'callback' => $this->memoize([Relevance::class, 'fromQuery']),
                 'numArgs' => 3,
             ],
         ];

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Traits;
+
+trait MemoizationTrait
+{
+    /**
+     * @var array<mixed>
+     */
+    private array $memo = [];
+
+    private function memoize(callable $compute): mixed
+    {
+        $namespace = serialize($compute);
+
+        return function() use ($namespace, $compute) {
+            $args = func_get_args();
+            $key = md5($namespace . serialize($args));
+            return $this->memo[$key] ??= call_user_func_array($compute, $args);
+        };
+    }
+}

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Loupe\Loupe\Traits;
 
 trait MemoizationTrait

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -13,12 +13,13 @@ trait MemoizationTrait
 
     private function memoize(callable $compute): callable
     {
-        $namespace = crc32(serialize($compute));
+        $namespace = serialize($compute);
 
-        return function(...$args) use ($namespace, $compute) {
-            $key = crc32($namespace . ':' . serialize($args));
+        return function() use ($namespace, $compute) {
+            $args = func_get_args();
+            $key = $namespace . ':' . implode(':', $args);
             if (!array_key_exists($key, $this->memo)) {
-                $this->memo[$key] = call_user_func($compute, ...$args);
+                $this->memo[$key] = call_user_func_array($compute, $args);
             }
             return $this->memo[$key];
         };

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -15,11 +15,11 @@ trait MemoizationTrait
     {
         $namespace = serialize($compute);
 
-        return function() use ($namespace, $compute) {
-            $args = func_get_args();
+        return function () use ($namespace, $compute) {
+            $args = \func_get_args();
             $key = $namespace . ':' . implode(':', $args);
-            if (!array_key_exists($key, $this->memo)) {
-                $this->memo[$key] = call_user_func_array($compute, $args);
+            if (!\array_key_exists($key, $this->memo)) {
+                $this->memo[$key] = \call_user_func_array($compute, $args);
             }
             return $this->memo[$key];
         };

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -4,22 +4,19 @@ namespace Loupe\Loupe\Traits;
 
 trait MemoizationTrait
 {
-    /**
-     * @var array<string, mixed>
-     */
-    private array $memo = [];
-
     private function memoize(callable $compute): callable
     {
-        $namespace = serialize($compute);
-
-        return function () use ($namespace, $compute) {
+        return function () use ($compute) {
+            /**
+             * @var array<string, mixed>
+             */
+            static $cache = [];
             $args = \func_get_args();
-            $key = $namespace . ':' . implode(':', $args);
-            if (!\array_key_exists($key, $this->memo)) {
-                $this->memo[$key] = \call_user_func_array($compute, $args);
+            $key = implode('--', $args);
+            if (!\array_key_exists($key, $cache)) {
+                $cache[$key] = \call_user_func_array($compute, $args);
             }
-            return $this->memo[$key];
+            return $cache[$key];
         };
     }
 }

--- a/src/Traits/MemoizationTrait.php
+++ b/src/Traits/MemoizationTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Loupe\Loupe\Traits;
 
 trait MemoizationTrait


### PR DESCRIPTION
It appears that SQLite will call a custom function twice when selecting its result as a column and sorting by that column. There's an option of [marking functions as deterministic](https://www.php.net/manual/en/sqlite3.constants.php#constant.sqlite3-deterministic), but the query planner isn't required to honor that "request". In our case, it has no effect on the number of function calls.

What did have an effect (although less than expected) was caching/memoizing the calls on the PHP side.

That brings about a 2-5% increase in query speed depending on complexity and typos.

### Benchmarks

| query | `develop` branch | this pull request |
| :--- | :--- | :--- |
| amakin dkywalker | 162.1 ms ±   1.6 ms | 159.3 ms ±   1.7 ms |
| famly dadd | 688.3 ms ±  13.3 ms | 654.7 ms ±   7.2 ms |
| once twice thrice | 270.1 ms ±  10.4 ms | 256.7 ms ±   5.4 ms |
| lighting | 194.9 ms ±   3.0 ms | 190.5 ms ±   1.9 ms |
