### PR TITLE
Prevent "endless" queries

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -26,13 +26,6 @@ use Loupe\Loupe\SearchResult;
 
 class Searcher
 {
-    /**
-     * If searching for a query that is super broad like "this is taking so long", way too many
-     * documents are going to match so we have to internally limit those matches to prevent
-     * "endless" search queries.
-     */
-    private const MAX_DOCUMENT_MATCHES = 1000;
-
     public const CTE_TERM_DOCUMENT_MATCHES_PREFIX = '_cte_term_document_matches_';
 
     public const CTE_TERM_MATCHES_PREFIX = '_cte_term_matches_';
@@ -40,6 +33,13 @@ class Searcher
     public const DISTANCE_ALIAS = '_distance';
 
     public const RELEVANCE_ALIAS = '_relevance';
+
+    /**
+     * If searching for a query that is super broad like "this is taking so long", way too many
+     * documents are going to match so we have to internally limit those matches to prevent
+     * "endless" search queries.
+     */
+    private const MAX_DOCUMENT_MATCHES = 1000;
 
     /**
      * @var array<string, array{cols: array<string>, sql: string}>


### PR DESCRIPTION
Fixes https://github.com/loupe-php/loupe/issues/134.

I have accidentally pushed this already in https://github.com/loupe-php/loupe/pull/136/files#diff-60e811f23f79f3d9ec47e6aa6599834bd758f7063de8dd1be2b9ae821d2615ea but here's the finalized version.

Tested using `php bin/bench/search.php -q="this is taking so long"`.
Previously: 31283.11
Now: 1235.46

Search results are still "relevant" but again. What does "relevant" even mean with such a query 😊 