### PR TITLE
Reworked relevance rankers and fixed proximity ranker

### DIFF
--- a/src/Internal/Search/Ranking/AbstractRanker.php
+++ b/src/Internal/Search/Ranking/AbstractRanker.php
@@ -6,10 +6,5 @@ namespace Loupe\Loupe\Internal\Search\Ranking;
 
 abstract class AbstractRanker
 {
-    /**
-     * @param array<string> $searchableAttributes
-     * @param array<string> $queryTokens
-     * @param array<int, array<int, array{int, string|null}>> $termPositions
-     */
-    abstract public static function calculate(array &$searchableAttributes, array &$queryTokens, array &$termPositions): float;
+    abstract public static function calculate(RankingInfo $rankingInfo): float;
 }

--- a/src/Internal/Search/Ranking/AttributeWeight.php
+++ b/src/Internal/Search/Ranking/AttributeWeight.php
@@ -8,17 +8,22 @@ use Loupe\Loupe\Configuration;
 
 class AttributeWeight extends AbstractRanker
 {
-    public static function calculate(array &$searchableAttributes, array &$queryTokens, array &$termPositions): float
+    public static function calculate(RankingInfo $rankingInfo): float
     {
-        $weights = static::calculateIntrinsicAttributeWeights($searchableAttributes);
+        $weights = static::calculateIntrinsicAttributeWeights($rankingInfo->getSearchableAttributes());
 
         // Group weights by term, making sure to go with the higher weight if multiple attributes are matched
         // So if `title` (1.0) and `summary` (0.8) are matched, the weight of `title` should be used
         $weightsPerTerm = [];
-        foreach ($termPositions as $index => $term) {
-            foreach ($term as [, $attribute]) {
-                if ($attribute && isset($weights[$attribute])) {
-                    $weightsPerTerm[$index] = max($weightsPerTerm[$index] ?? 0, $weights[$attribute]);
+
+        foreach ($rankingInfo->getTermPositions()->getTerms() as $index => $term) {
+            if (!$term->hasMatches()) {
+                continue;
+            }
+
+            foreach ($term->getMatches() as $match) {
+                if (isset($weights[$match->getAttribute()])) {
+                    $weightsPerTerm[$index] = max($weightsPerTerm[$index] ?? 0, $weights[$match->getAttribute()]);
                 }
             }
         }

--- a/src/Internal/Search/Ranking/RankingInfo.php
+++ b/src/Internal/Search/Ranking/RankingInfo.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Ranking;
+
+final class RankingInfo
+{
+    /**
+     * @var array<string>
+     * @var array<string>
+     */
+    private function __construct(
+        private array $rankingRules,
+        private array $searchableAttributes,
+        private TermPositions $termPositions
+    ) {
+    }
+
+    /**
+     * Example: A string with "3:title,8:title,10:title;0;4:summary" would read as follows:
+     * - The query consisted of 3 tokens (terms).
+     * - The first term matched. At positions 3, 8 and 10 in the `title` attribute.
+     * - The second term did not match (position 0).
+     * - The third term matched. At position 4 in the `summary` attribute.
+     *
+     * @param string $termPositions A string of ";" separated per term and "," separated for all the term positions within a document
+     */
+    public static function fromQueryFunction(string $searchableAttributes, string $rankingRules, string $queryTokens, string $termPositions): self
+    {
+        $info = new self(explode(':', $rankingRules), explode(':', $searchableAttributes), TermPositions::fromQueryFunction($termPositions));
+
+        // TODO: Who needs those?
+        $queryTokens = explode(':', $queryTokens);
+
+        return $info;
+    }
+
+    /**
+     * Returns the ranking rules in order as defined in Configuration.
+     *
+     * @return array<string>
+     */
+    public function getRankingRules(): array
+    {
+        return $this->rankingRules;
+    }
+
+    /**
+     * Returns the searchable attributes as defined in Configuration.
+     *
+     * @return array<string>
+     */
+    public function getSearchableAttributes(): array
+    {
+        return $this->searchableAttributes;
+    }
+
+    public function getTermPositions(): TermPositions
+    {
+        return $this->termPositions;
+    }
+}

--- a/src/Internal/Search/Ranking/RankingInfo.php
+++ b/src/Internal/Search/Ranking/RankingInfo.php
@@ -7,8 +7,8 @@ namespace Loupe\Loupe\Internal\Search\Ranking;
 final class RankingInfo
 {
     /**
-     * @var array<string>
-     * @var array<string>
+     * @param array<string> $rankingRules
+     * @param array<string> $searchableAttributes
      */
     private function __construct(
         private array $rankingRules,

--- a/src/Internal/Search/Ranking/TermPositions.php
+++ b/src/Internal/Search/Ranking/TermPositions.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Ranking;
+
+use Loupe\Loupe\Internal\Search\Ranking\TermPositions\Term;
+use Loupe\Loupe\Internal\Search\Ranking\TermPositions\TermMatch;
+
+class TermPositions
+{
+    /**
+     * @var array<string, bool>
+     */
+    private array $matchingAttributes = [];
+
+    private int $totalMatchingTerms = 0;
+
+    private int $totalTermsSearchedFor;
+
+    /**
+     * @param array<Term> $terms
+     */
+    public function __construct(
+        private readonly array $terms
+    ) {
+        $this->totalTermsSearchedFor = \count($this->terms);
+
+        foreach ($this->terms as $term) {
+            if ($term->hasMatches()) {
+                $this->totalMatchingTerms++;
+                foreach ($term->getMatches() as $match) {
+                    $this->matchingAttributes[$match->getAttribute()] = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse an intermediate string representation of term positions and matches attributes
+     *
+     * Example: A string with "3:title,8:title,10:title;0;4:summary" would read as follows:
+     * * - The query consisted of 3 tokens (terms).
+     * * - The first term matched. At positions 3, 8 and 10 in the `title` attribute.
+     * * - The second term did not match (position 0).
+     * * - The third term matched. At position 4 in the `summary` attribute.
+     * *
+     * * @param string $positionsInDocumentPerTerm A string of ";" separated per term and "," separated for all the term positions within a document
+     */
+    public static function fromQueryFunction(string $positionsInDocumentPerTerm): self
+    {
+        $terms = [];
+
+        if ($positionsInDocumentPerTerm === '') {
+            return new self($terms);
+        }
+
+        foreach (explode(';', $positionsInDocumentPerTerm) as $index => $termSearchedFor) {
+            // Document did not match this term
+            if ($termSearchedFor === '0') {
+                $terms[] = new Term([]);
+                continue;
+            }
+
+            $attributePositions = [];
+            $termMatches = [];
+
+            foreach (explode(',', $termSearchedFor) as $positionAttributeCombination) {
+                [$position, $attribute] = explode(':', $positionAttributeCombination);
+                $attributePositions[$attribute][] = (int) $position;
+            }
+
+            foreach ($attributePositions as $attribute => $positions) {
+                $termMatches[] = new TermMatch($attribute, $positions);
+            }
+
+            $terms[] = new Term($termMatches);
+        }
+
+        return new self($terms);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getMatchingAttributes(): array
+    {
+        return array_keys($this->matchingAttributes);
+    }
+
+    /**
+     * @return array<Term>
+     */
+    public function getTerms(): array
+    {
+        return $this->terms;
+    }
+
+    public function getTotalMatchingTerms(): int
+    {
+        return $this->totalMatchingTerms;
+    }
+
+    public function getTotalTermsSearchedFor(): int
+    {
+        return $this->totalTermsSearchedFor;
+    }
+}

--- a/src/Internal/Search/Ranking/TermPositions/Term.php
+++ b/src/Internal/Search/Ranking/TermPositions/Term.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Ranking\TermPositions;
+
+class Term
+{
+    /**
+     * @param array<TermMatch> $termMatches
+     */
+    public function __construct(
+        private array $termMatches
+    ) {
+    }
+
+    /**
+     * @return TermMatch[]
+     */
+    public function getMatches(): array
+    {
+        return $this->termMatches;
+    }
+
+    public function hasMatches(): bool
+    {
+        return !empty($this->termMatches);
+    }
+}

--- a/src/Internal/Search/Ranking/TermPositions/TermMatch.php
+++ b/src/Internal/Search/Ranking/TermPositions/TermMatch.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Ranking\TermPositions;
+
+final class TermMatch
+{
+    /**
+     * @param array<int> $positions
+     */
+    public function __construct(
+        private readonly string $attribute,
+        private array $positions
+    ) {
+        \assert($this->positions !== []);
+        sort($this->positions);
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+
+    public function getFirstPosition(): int
+    {
+        return $this->positions[0];
+    }
+
+    public function getPositionAfter(int $referencePosition): ?int
+    {
+        foreach ($this->positions as $position) {
+            if ($position > $referencePosition) {
+                return $position;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getPositions(): array
+    {
+        return $this->positions;
+    }
+}

--- a/src/Internal/Search/Ranking/WordCount.php
+++ b/src/Internal/Search/Ranking/WordCount.php
@@ -4,26 +4,14 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Search\Ranking;
 
+/**
+ * Ranks based on the number of matching terms vs. number of terms searched for in total.
+ * E.g. if you search for "this is my hobby" then it's better if a document matches all 4 terms instead of just 3.
+ */
 class WordCount extends AbstractRanker
 {
-    public static function calculate(array &$searchableAttributes, array &$queryTokens, array &$termPositions): float
+    public static function calculate(RankingInfo $rankingInfo): float
     {
-        return static::calculateWordCount($termPositions);
-    }
-
-    /**
-     * @param array<int, array<int, array{int, string|null}>> $termPositions
-     */
-    public static function calculateWordCount(array &$termPositions): float
-    {
-        $matchedWords = 0;
-        foreach ($termPositions as $term) {
-            if ((\count($term) === 1 && $term[0][0] === 0)) {
-                continue;
-            }
-            ++$matchedWords;
-        }
-
-        return $matchedWords / \count($termPositions);
+        return $rankingInfo->getTermPositions()->getTotalMatchingTerms() / $rankingInfo->getTermPositions()->getTotalTermsSearchedFor();
     }
 }

--- a/tests/Functional/FunctionalTestTrait.php
+++ b/tests/Functional/FunctionalTestTrait.php
@@ -47,6 +47,7 @@ trait FunctionalTestTrait
     {
         $results = $loupe->search($searchParameters)->toArray();
         unset($results['processingTimeMs']);
+        unset($loupe);
         $this->assertSame($expectedResults, $results);
     }
 }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2157,7 +2157,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.68885,
+                    '_rankingScore' => 0.77169,
                 ],
             ],
             'query' => 'life learning',
@@ -2229,22 +2229,22 @@ class SearchTest extends TestCase
                 [
                     'id' => 4,
                     'content' => 'Book title: life learning',
-                    '_rankingScore' => 0.79116,
+                    '_rankingScore' => 0.84779,
                 ],
                 [
                     'id' => 1,
                     'content' => 'The game of life is a game of everlasting learning',
-                    '_rankingScore' => 0.723,
+                    '_rankingScore' => 0.70358,
                 ],
                 [
                     'id' => 2,
                     'content' => 'The unexamined life is not worth living. Life is life.',
-                    '_rankingScore' => 0.65416,
+                    '_rankingScore' => 0.69559,
                 ],
                 [
                     'id' => 3,
                     'content' => 'Never stop learning',
-                    '_rankingScore' => 0.65416,
+                    '_rankingScore' => 0.69559,
                 ],
             ],
             'query' => 'foobar life learning',
@@ -2303,7 +2303,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 3,
                     'title' => 'Learning to game',
-                    '_rankingScore' => 0.84779,
+                    '_rankingScore' => 0.68798,
                 ],
             ],
             'query' => 'game of life',
@@ -2336,7 +2336,7 @@ class SearchTest extends TestCase
                 [
                     'id' => 3,
                     'title' => 'Learning to game',
-                    '_rankingScore' => 0.80304,
+                    '_rankingScore' => 0.64323,
                 ],
             ],
             'query' => 'game of life',
@@ -2390,7 +2390,7 @@ class SearchTest extends TestCase
                     'id' => 2,
                     'title' => 'Lorem dolor sit amet',
                     'content' => 'Ipsum',
-                    '_rankingScore' => 0.95525,
+                    '_rankingScore' => 0.79543,
                 ],
                 [
                     'id' => 3,

--- a/tests/PhpUnit/Subscriber/AssertStaticCacheIsEmptySubscriber.php
+++ b/tests/PhpUnit/Subscriber/AssertStaticCacheIsEmptySubscriber.php
@@ -13,6 +13,6 @@ class AssertStaticCacheIsEmptySubscriber implements FinishedSubscriber
 {
     public function notify(Finished $event): void
     {
-        Assert::assertTrue(StaticCache::isEmpty(), 'Static cache must be empty in: ' . $event->test()->id());
+        //Assert::assertTrue(StaticCache::isEmpty(), 'Static cache must be empty in: ' . $event->test()->id());
     }
 }

--- a/tests/PhpUnit/Subscriber/AssertStaticCacheIsEmptySubscriber.php
+++ b/tests/PhpUnit/Subscriber/AssertStaticCacheIsEmptySubscriber.php
@@ -13,6 +13,6 @@ class AssertStaticCacheIsEmptySubscriber implements FinishedSubscriber
 {
     public function notify(Finished $event): void
     {
-        //Assert::assertTrue(StaticCache::isEmpty(), 'Static cache must be empty in: ' . $event->test()->id());
+        Assert::assertTrue(StaticCache::isEmpty(), 'Static cache must be empty in: ' . $event->test()->id());
     }
 }

--- a/tests/Unit/Internal/Search/Ranking/AttributeWeightTest.php
+++ b/tests/Unit/Internal/Search/Ranking/AttributeWeightTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Loupe\Tests\Unit\Internal\Search\Sorting;
 
 use Loupe\Loupe\Internal\Search\Ranking\AttributeWeight;
+use Loupe\Loupe\Internal\Search\Ranking\RankingInfo;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -13,53 +14,46 @@ class AttributeWeightTest extends TestCase
     public static function attributeWeightProvider(): \Generator
     {
         yield 'No attributes are weighted' => [
-            [[[1, 'title'], [2, 'summary']]],
-            [],
+            '1:title,2:summary',
+            '',
             1.0,
         ];
 
         yield 'No attributes are matched' => [
-            [[[1, 'title'], [2, 'summary']]],
-            [
-                'unknown_attribute',
-            ],
+            '1:title,2:summary',
+            'unknown_attribute',
             1.0,
         ];
 
         yield 'All attributes are equal' => [
-            [[[1, 'title'], [2, 'summary']]],
-            ['*'],
+            '1:title,2:summary',
+            '*',
             1.0,
         ];
 
         yield 'Attributes are applied when found' => [
-            [[[1, 'title']]],
-            ['title', 'summary'],
+            '1:title',
+            'title:summary',
             1.0,
         ];
 
         yield 'Attributes are applied when found later in list' => [
-            [[[1, 'non_existent'], [2, 'summary']]],
-            ['title', 'summary'],
+            '1:non_existent,2:summary',
+            'title:summary',
             0.8,
         ];
 
         yield 'Terms found in multiple attributes are applied the highest factor' => [
-            [[[1, 'title'], [2, 'summary']]],
-            ['title', 'summary'],
+            '1:title,2:summary',
+            'title:summary',
             1.0,
         ];
     }
 
-    /**
-     * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm
-     * @param array<string> $attributes
-     */
     #[DataProvider('attributeWeightProvider')]
-    public function testAttributeWeightCalculation(array $positionsPerTerm, array $attributes, float $expected): void
+    public function testAttributeWeightCalculation(string $positionsPerTerm, string $searchableAttributes, float $expected): void
     {
-        $queryTokensNotUsed = [];
-        $this->assertSame($expected, AttributeWeight::calculate($attributes, $queryTokensNotUsed, $positionsPerTerm));
+        $this->assertSame($expected, AttributeWeight::calculate(RankingInfo::fromQueryFunction($searchableAttributes, '', '', $positionsPerTerm)));
     }
 
     public function testIntrinsicAttributeWeightCalculation(): void

--- a/tests/Unit/Internal/Search/Ranking/ProximityTest.php
+++ b/tests/Unit/Internal/Search/Ranking/ProximityTest.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Loupe\Loupe\Tests\Unit\Internal\Search\Sorting;
+namespace Loupe\Loupe\Tests\Unit\Internal\Search\Ranking;
 
 use Loupe\Loupe\Internal\Search\Ranking\Proximity;
+use Loupe\Loupe\Internal\Search\Ranking\TermPositions;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -13,54 +14,57 @@ class ProximityTest extends TestCase
     public static function proximityFactorProvider(): \Generator
     {
         yield 'All terms are adjacent' => [
-            [[[1, 'term']], [[2, 'term']], [[3, 'term']]],
+            '1:attribute;2:attribute;3:attribute',
             0.1,
             1.0, // All distances are 1, so result is 1
         ];
 
         yield 'Non-adjacent terms' => [
-            [[[1, 'term']], [[3, 'term']], [[5, 'term']]],
+            '1:attribute;3:attribute;5:attribute',
             0.1,
             (exp(-0.1 * 2) + exp(-0.1 * 2)) / 2,
         ];
 
         yield 'Empty positions' => [
-            [],
+            '',
             0.1,
             1.0, // No pairs, so result is 1 (shouldn't happen anyway)
         ];
 
         yield 'Single term' => [
-            [[[1, 'term']]],
+            '1:attribute',
             0.1,
             1.0, // One match, must be 1
         ];
 
         yield 'Multiple positions per term, only closest must be considered' => [
-            [[[1, 'term'], [4, 'term']], [[6, 'term'], [10, 'term']]],
+            '1:attribute,4:attribute;6:attribute,10:attribute',
             0.1,
             (exp(-0.1 * 5)),
         ];
 
         yield 'Higher decay factor' => [
-            [[[1, 'term']], [[4, 'term']]],
+            '1:attribute;4:attribute',
             0.5,
             exp(-0.5 * 3), // Only one pair, distance is 3
         ];
 
         yield 'Lots of terms but all in the correct order' => [
-            [[[1, 'term'], [7, 'term'], [12, 'term']], [[2, 'term'], [7, 'term']],  [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[4, 'term']], [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[6, 'term']], [[2, 'term'], [7, 'term']], [[3, 'term'], [5, 'term'], [8, 'term'], [19, 'term'], [28, 'term']], [[9, 'term']], [[10, 'term']]],
+            '1:attribute,7:attribute,12:attribute;2:attribute,7:attribute;3:attribute,5:attribute,8:attribute,19:attribute,28:attribute;4:attribute;3:attribute,5:attribute,8:attribute,19:attribute,28:attribute;6:attribute;2:attribute,7:attribute;3:attribute,5:attribute,8:attribute,19:attribute,28:attribute;9:attribute;10:attribute',
             0.1,
             1,
         ];
+
+        yield 'Attributes must be considered' => [
+            '1:attribute;2:other_attribute,3:attribute', // Here we searched for 2 terms and the second matched in "other_attribute" at position 2 and in "attribute" at position 3, so we have to test that the distance is 2 between attribute!
+            0.1,
+            exp(-0.1 * 2), // "other_attribute" is not relevant, the best match is in "attribute" and we have a distance of 2
+        ];
     }
 
-    /**
-     * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm $positionsPerTerm
-     */
     #[DataProvider('proximityFactorProvider')]
-    public function testProximityCalculation(array $positionsPerTerm, float $decayFactor, float $expected): void
+    public function testProximityCalculation(string $positionsPerTerm, float $decayFactor, float $expected): void
     {
-        $this->assertSame($expected, Proximity::calculateProximity($positionsPerTerm, $decayFactor));
+        $this->assertSame($expected, Proximity::calculateWithDecayFactor(TermPositions::fromQueryFunction($positionsPerTerm), $decayFactor));
     }
 }

--- a/tests/Unit/Internal/Search/Ranking/WordCountTest.php
+++ b/tests/Unit/Internal/Search/Ranking/WordCountTest.php
@@ -4,40 +4,39 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Unit\Internal\Search\Sorting;
 
+use Loupe\Loupe\Internal\Search\Ranking\RankingInfo;
 use Loupe\Loupe\Internal\Search\Ranking\WordCount;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class WordCountTest extends TestCase
 {
-    /**
-     * @param array<int, array<int, array{int, string|null}>> $positionsPerTerm $positionsPerTerm
-     */
     #[DataProvider('wordCountFactorProvider')]
-    public function testWordCountCalculation(array $positionsPerTerm, float $expected): void
+    public function testWordCountCalculation(string $positionsPerTerm, float $expected): void
     {
-        $this->assertSame($expected, WordCount::calculateWordCount($positionsPerTerm));
+        $rankingInfo = RankingInfo::fromQueryFunction('', '', '', $positionsPerTerm);
+        $this->assertSame($expected, WordCount::calculate($rankingInfo));
     }
 
     public static function wordCountFactorProvider(): \Generator
     {
         yield 'No terms match' => [
-            [[[0]], [[0]], [[0]]],
+            '0;0;0',
             0,
         ];
 
         yield 'One of three terms matches' => [
-            [[[1, 'title']], [[0]], [[0]]],
+            '1:title;0;0',
             1 / 3,
         ];
 
         yield 'Two of three terms match' => [
-            [[[1, 'title']], [[2, 'summary']], [[0]]],
+            '1:title;2:summary;0',
             2 / 3,
         ];
 
         yield 'All terms match' => [
-            [[[1, 'title']], [[2, 'summary']], [[3, 'summary']]],
+            '1:title;2:summary;3:summary',
             1,
         ];
     }


### PR DESCRIPTION
Reworked the way rankers get their information, it's now all in nice objects making it easier to understand what's going on.

Moreover, I found that the `Proximity` ranker was buggy because it did not consider the attribute. It's best seen in the `SearchTest::testRelevanceAndRankingScoreWithAttributeWeights()`.

Previously, when searching for `game of life` the following document got a relevance score of `0.8034`:
```
[
     'id' => 3,
     'title' => 'Learning to game',
     'content' => 'What life taught me about learning',
]
```

This is nonsense but happened because `game` occurs at position 3 within `title` and `life` at position 2 within `content`. Without distinguishing the different attributes, this results in close proximity.

With this PR, this now gets downgraded to `0.64323`. 

Would love to have a review @daun - maybe you see false-positives in the adjusted tests. Also, the information is now not passed on using references anymore to the rankers. As I said, it should have no negative effect because objects are also references but you might want to run your bench again. For me, this PR is actually quite a bit faster because information can be re-used 😉 I am now at about 105ms instead of 120ms as stated in the `README`. Would love to learn about your results.

TODO:

- [ ] Update `README.md` because Loupe got faster with this PR?