### PR TITLE
Implemented support for sorting on array attributes with aggregates

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -130,6 +130,44 @@ $searchParameters = \Loupe\Loupe\SearchParameters::create()
 ;
 ```
 
+### Sorting on array attributes
+
+Sometimes you want to sort by an array attribute, in which case, you need to use an aggregate function. Let's say you
+have two documents with an array of numbers:
+
+```php
+[
+    ['id' => 1, ['numbers' => [2, 3, 4, 5]]],
+    ['id' => 2, ['numbers' => [1, 3, 4, 5]]],
+]
+```
+
+In order to be able to properly sort by those, you need to tell Loupe which one of those to use. Let's say you want
+to sort by the lowest of them:
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withSort(['min(numbers):asc'])
+;
+```
+
+Also note that Loupe will apply filters as well. So in case you used the sorting in combination with the filter like so:
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withFilter('numbers >= 2 AND numbers <= 4')
+    ->withSort(['min(numbers):asc'])
+;
+```
+
+Loupe will return document ID 1 before document ID 2 even though document ID 2 has the lowest number `1` as attribute value.
+But as you are not interested in these values according to your filter, Loupe will order accordingly.
+
+Currently, you can use the following aggregate functions:
+
+* `min(<attribute>)`
+* `max(<attribute>)`
+
 ## Pagination
 
 When searching Loupe, it will always return the current `page`, `totalPages` as well as `totalHits` in its search 

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -8,11 +8,6 @@ use Loupe\Loupe\Configuration;
 
 class InvalidConfigurationException extends \InvalidArgumentException implements LoupeExceptionInterface
 {
-    public static function becauseAttributeNotSortable(string $attributeName): self
-    {
-        return new self(sprintf('Cannot sort on this type of attribute value for attribute "%s".', $attributeName));
-    }
-
     public static function becauseCouldNotCreateDataDir(string $folder): self
     {
         return new self(

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -68,13 +68,7 @@ class IndexInfo
                 continue;
             }
 
-            $loupeType = LoupeTypes::getTypeFromValue($attributeValue);
-
-            if (\in_array($attributeName, $sortableAttributes, true) && !LoupeTypes::isSingleType($loupeType)) {
-                throw InvalidConfigurationException::becauseAttributeNotSortable($attributeName);
-            }
-
-            $documentSchema[$attributeName] = $loupeType;
+            $documentSchema[$attributeName] = LoupeTypes::getTypeFromValue($attributeValue);
         }
 
         $this->updateDocumentSchema($documentSchema);

--- a/src/Internal/LoupeTypes.php
+++ b/src/Internal/LoupeTypes.php
@@ -195,6 +195,15 @@ class LoupeTypes
         ], true);
     }
 
+    public static function isMultiType(string $type): bool
+    {
+        return \in_array($type, [
+            self::TYPE_ARRAY_EMPTY,
+            self::TYPE_ARRAY_NUMBER,
+            self::TYPE_STRING,
+        ], true);
+    }
+
     public static function isSingleType(string $type): bool
     {
         // The Geo type is not exactly a single type, but it has to be treated as such

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\FilterBuilder;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Location\Bounds;
+use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
+use Loupe\Loupe\Internal\Filter\Ast\Filter;
+use Loupe\Loupe\Internal\Filter\Ast\GeoBoundingBox;
+use Loupe\Loupe\Internal\Filter\Ast\GeoDistance;
+use Loupe\Loupe\Internal\Filter\Ast\Group;
+use Loupe\Loupe\Internal\Filter\Ast\MultiAttributeFilter;
+use Loupe\Loupe\Internal\Filter\Ast\Node;
+use Loupe\Loupe\Internal\Index\IndexInfo;
+use Loupe\Loupe\Internal\LoupeTypes;
+use Loupe\Loupe\Internal\Search\Searcher;
+use Loupe\Loupe\Internal\Search\Sorting\Aggregate;
+
+class FilterBuilder
+{
+    private ?string $multiAttributeName = null;
+
+    public function __construct(
+        private Engine $engine,
+        private Searcher $searcher,
+        private QueryBuilder $globalQueryBuilder
+    ) {
+    }
+
+    public function buildForDocument(): QueryBuilder
+    {
+        $whereStatement = [];
+
+        $this->handleFilterAstNode($this->searcher->getFilterAst()->getRoot(), $whereStatement);
+
+        return $this->globalQueryBuilder->andWhere(implode(' ', $whereStatement));
+    }
+
+    public function buildForMultiAttribute(string $attribute, Aggregate $aggregate): QueryBuilder
+    {
+        $this->multiAttributeName = $attribute;
+        $column = $this->getMultiAttributeColumnForAttribute($attribute);
+
+        // Build the subquery, SELECT our aggregate and joining the multi attributes on our attribute name.
+        $qb = $this->engine->getConnection()->createQueryBuilder();
+        $qb->select($aggregate->buildSql($column));
+        $this->addMultiAttributeFromAndJoinToQueryBuilder($qb, $attribute);
+
+        // Now filter only the ones that belong to our document
+        $qb->andWhere(sprintf(
+            '%s.document=%s.id',
+            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
+            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
+        ));
+
+        $whereStatement = [];
+        $this->handleFilterAstNode($this->searcher->getFilterAst()->getRoot(), $whereStatement);
+
+        $qb->andWhere(implode(' ', $whereStatement));
+
+        return $qb;
+    }
+
+    private function addMultiAttributeFromAndJoinToQueryBuilder(QueryBuilder $queryBuilder, string $attributeName): void
+    {
+        $queryBuilder->from(
+            IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,
+            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS)
+        )
+            ->innerJoin(
+                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
+                IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES,
+                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
+                sprintf(
+                    '%s.attribute=%s AND %s.id = %s.attribute',
+                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
+                    $this->globalQueryBuilder->createNamedParameter($attributeName),
+                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
+                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
+                )
+            );
+    }
+
+    /**
+     * @return array<string|float>
+     */
+    private function createGeoBoundingBoxWhereStatement(string $documentAlias, GeoBoundingBox|GeoDistance $node, Bounds $bounds): array
+    {
+        $whereStatement = [];
+
+        // Prevent nullable
+        $nullTerm = $this->globalQueryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = '!=';
+        $whereStatement[] = $nullTerm;
+
+        $whereStatement[] = 'AND';
+
+        // Longitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getWest();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getEast();
+
+        $whereStatement[] = 'AND';
+
+        // Latitude
+        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
+        $whereStatement[] = 'BETWEEN';
+        $whereStatement[] = $bounds->getSouth();
+        $whereStatement[] = 'AND';
+        $whereStatement[] = $bounds->getNorth();
+
+        return $whereStatement;
+    }
+
+    /**
+     * @param array<string|float> $positiveMultiWheres
+     * @param array<string|float> $negativeMultiWheres
+     */
+    private function createSubQueryForMultiAttribute(string $attribute, array $positiveMultiWheres, array $negativeMultiWheres): string
+    {
+        $tableAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS);
+
+        if ($this->multiAttributeName) {
+            $select = $tableAlias . '.attribute';
+        } else {
+            $select = $tableAlias . '.document';
+        }
+
+        $qb = $this->engine->getConnection()
+            ->createQueryBuilder();
+        $qb->select($select);
+
+        $this->addMultiAttributeFromAndJoinToQueryBuilder($qb, $attribute);
+
+        $qb->groupBy($select);
+
+        if ($positiveMultiWheres !== []) {
+            $qb->andHaving(sprintf('COUNT(CASE WHEN %s THEN 1 ELSE NULL END) > 0', implode(' ', $positiveMultiWheres)));
+        }
+
+        if ($negativeMultiWheres !== []) {
+            $qb->andHaving(sprintf('COUNT(CASE WHEN %s THEN 1 ELSE NULL END) = 0', implode(' ', $negativeMultiWheres)));
+        }
+
+        return $qb->getSQL();
+    }
+
+    private function getMultiAttributeColumnForAttribute(string $attribute): string
+    {
+        $isFloatType = LoupeTypes::isFloatType($this->engine->getIndexInfo()->getLoupeTypeForAttribute($attribute));
+        return $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES) . '.' . ($isFloatType ? 'numeric_value' : 'string_value');
+    }
+
+    /**
+     * @param array<string|float> $whereStatement
+     */
+    private function handleFilterAstNode(Node $node, array &$whereStatement): void
+    {
+        $documentAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+
+        if ($node instanceof Group) {
+            $groupWhere = [];
+            foreach ($node->getChildren() as $child) {
+                $this->handleFilterAstNode($child, $groupWhere);
+            }
+
+            if ($groupWhere !== []) {
+                $whereStatement[] = '(';
+                $whereStatement[] = implode(' ', $groupWhere);
+                $whereStatement[] = ')';
+            }
+        }
+
+        if ($node instanceof MultiAttributeFilter) {
+            // Ignore if not in question
+            if ($this->multiAttributeName && $this->multiAttributeName !== $node->attribute) {
+                return;
+            }
+
+            $positiveMultiWheres = [];
+            $negativeMultiWheres = [];
+            foreach ($node->getChildren() as $child) {
+                // Multi filterable attributes need special handling
+                if ($child instanceof Filter && \in_array($node->attribute, $this->engine->getIndexInfo()->getMultiFilterableAttributes(), true)) {
+                    // Ignore if not in question
+                    if ($this->multiAttributeName && $this->multiAttributeName !== $node->attribute) {
+                        continue;
+                    }
+
+                    $column = $this->getMultiAttributeColumnForAttribute($node->attribute);
+
+                    $positiveMultiWheres[] = $child->operator->buildSql(
+                        $this->engine->getConnection(),
+                        $column,
+                        $child->value
+                    );
+
+                    // If the operator is negative, we have to add a second where. This is because if the users write
+                    // $loupe->withFilter("multiattribute NOT IN ('foo', 'bar')") they want NEITHER of the attribute
+                    // values to be part of the result set. But because we store multi attributes in a separate table,
+                    // we first have to ensure the document has at least one allowed value AND then ensure the document
+                    //does NOT have ANY forbidden value
+                    if ($child->operator->isNegative()) {
+                        $negativeMultiWheres[] = $child->operator->opposite()->buildSql(
+                            $this->engine->getConnection(),
+                            $column,
+                            $child->value
+                        );
+                    }
+                } else {
+                    $this->handleFilterAstNode($child, $positiveMultiWheres);
+                }
+            }
+
+            if ($this->multiAttributeName) {
+                $multiAttributeAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES);
+                $whereStatement[] = $multiAttributeAlias . '.id IN (';
+            } else {
+                $whereStatement[] = $documentAlias . '.id IN (';
+            }
+
+            $whereStatement[] = $this->createSubQueryForMultiAttribute($node->attribute, $positiveMultiWheres, $negativeMultiWheres);
+            $whereStatement[] = ')';
+        }
+
+        if ($node instanceof Filter) {
+            // Ignore if not in question
+            if ($this->multiAttributeName && $this->multiAttributeName !== $node->attribute) {
+                return;
+            }
+
+            $operator = $node->operator;
+
+            // Not existing attributes need be handled as no match if positive and as match if negative
+            if (!\in_array($node->attribute, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
+                $whereStatement[] = $operator->isNegative() ? '1 = 1' : '1 = 0';
+            } else {
+                $attribute = $node->attribute;
+
+                if ($attribute === $this->engine->getConfiguration()->getPrimaryKey()) {
+                    $attribute = 'user_id';
+                }
+
+                $whereStatement[] = $operator->buildSql(
+                    $this->engine->getConnection(),
+                    $documentAlias . '.' . $attribute,
+                    $node->value
+                );
+            }
+        }
+
+        if ($node instanceof GeoDistance) {
+            // Not existing attributes need be handled as no match
+            if (!\in_array($node->attributeName, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
+                $whereStatement[] = '1 = 0';
+                return;
+            }
+
+            // Add the distance to the select query, so it's also part of the result
+            $distanceSelectAlias = $this->searcher->addGeoDistanceSelectToQueryBuilder($node->attributeName, $node->lat, $node->lng);
+
+            // Start a group
+            $whereStatement[] = '(';
+
+            // Improve performance by drawing a BBOX around our coordinates to reduce the result set considerably before
+            // the actual distance is compared. This can use indexes.
+            // We use floor() and ceil() respectively to ensure we get matches as the BearingSpherical calculation of the
+            // BBOX may not be as precise so when searching for the e.g. 3rd decimal floating point, we might exclude
+            // locations we shouldn't.
+            $bounds = $node->getBbox();
+
+            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
+
+            // And now calculate the real distance to filter out the ones that are within the BBOX (which is a square)
+            // but not within the radius (which is a circle).
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $distanceSelectAlias;
+            $whereStatement[] = '<=';
+            $whereStatement[] = $node->distance;
+
+            // End group
+            $whereStatement[] = ')';
+        }
+
+        if ($node instanceof GeoBoundingBox) {
+            // Not existing attributes need be handled as no match
+            if (!\in_array($node->attributeName, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
+                $whereStatement[] = '1 = 0';
+                return;
+            }
+
+            // Start a group GeoDistance BBOX
+            $whereStatement[] = '(';
+
+            // Same like above for
+            $bounds = $node->getBbox();
+
+            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
+
+            // End group
+            $whereStatement[] = ')';
+        }
+
+        if ($node instanceof Concatenator) {
+            $whereStatement[] = $node->getConcatenator();
+        }
+    }
+}

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -59,6 +59,10 @@ class FilterBuilder
         $whereStatement = [];
         $this->handleFilterAstNode($this->searcher->getFilterAst()->getRoot(), $whereStatement);
 
+        if ($whereStatement === []) {
+            return $qb;
+        }
+
         $qb->andWhere(implode(' ', $whereStatement));
 
         return $qb;

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -197,7 +197,10 @@ class FilterBuilder
                         continue;
                     }
 
-                    $column = $this->getMultiAttributeColumnForAttribute($node->attribute);
+                    $isFloatType = LoupeTypes::isFloatType(LoupeTypes::getTypeFromValue($child->value));
+
+                    $column = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES) . '.' .
+                        ($isFloatType ? 'numeric_value' : 'string_value');
 
                     $positiveMultiWheres[] = $child->operator->buildSql(
                         $this->engine->getConnection(),

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -7,19 +7,11 @@ namespace Loupe\Loupe\Internal\Search;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
-use Location\Bounds;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Ast\Ast;
-use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
-use Loupe\Loupe\Internal\Filter\Ast\Filter;
-use Loupe\Loupe\Internal\Filter\Ast\GeoBoundingBox;
-use Loupe\Loupe\Internal\Filter\Ast\GeoDistance;
-use Loupe\Loupe\Internal\Filter\Ast\Group;
-use Loupe\Loupe\Internal\Filter\Ast\MultiAttributeFilter;
-use Loupe\Loupe\Internal\Filter\Ast\Node;
 use Loupe\Loupe\Internal\Filter\Parser;
 use Loupe\Loupe\Internal\Index\IndexInfo;
-use Loupe\Loupe\Internal\LoupeTypes;
+use Loupe\Loupe\Internal\Search\FilterBuilder\FilterBuilder;
 use Loupe\Loupe\Internal\Tokenizer\Token;
 use Loupe\Loupe\Internal\Tokenizer\TokenCollection;
 use Loupe\Loupe\Internal\Util;
@@ -95,26 +87,6 @@ class Searcher
         $this->geoDistanceSelectsAdded[$alias] = true;
 
         return $alias;
-    }
-
-    public function addMultiAttributeFromAndJoinToQueryBuilder(QueryBuilder $queryBuilder, string $attributeName): void
-    {
-        $queryBuilder->from(
-            IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,
-            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS)
-        )
-            ->innerJoin(
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES,
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-                sprintf(
-                    '%s.attribute=%s AND %s.id = %s.attribute',
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-                    $this->queryBuilder->createNamedParameter($attributeName),
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                )
-            );
     }
 
     public function fetchResult(): SearchResult
@@ -379,44 +351,6 @@ class Searcher
     }
 
     /**
-     * @return array<string|float>
-     */
-    private function createGeoBoundingBoxWhereStatement(string $documentAlias, GeoBoundingBox|GeoDistance $node, Bounds $bounds): array
-    {
-        $whereStatement = [];
-
-        // Prevent nullable
-        $nullTerm = $this->queryBuilder->createNamedParameter(LoupeTypes::VALUE_NULL);
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-        $whereStatement[] = '!=';
-        $whereStatement[] = $nullTerm;
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-        $whereStatement[] = '!=';
-        $whereStatement[] = $nullTerm;
-
-        $whereStatement[] = 'AND';
-
-        // Longitude
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lng';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getWest();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getEast();
-
-        $whereStatement[] = 'AND';
-
-        // Latitude
-        $whereStatement[] = $documentAlias . '.' . $node->attributeName . '_geo_lat';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getSouth();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getNorth();
-
-        return $whereStatement;
-    }
-
-    /**
      * @param array<int> $states
      */
     private function createStatesMatchWhere(array $states, string $table, string $term, int $levenshteinDistance, string $termColumnName): string
@@ -463,33 +397,6 @@ class Searcher
         );
 
         return implode(' ', $where);
-    }
-
-    /**
-     * @param array<string> $positiveMultiWheres
-     * @param array<string> $negativeMultiWheres
-     */
-    private function createSubQueryForMultiAttribute(string $attribute, array $positiveMultiWheres, array $negativeMultiWheres): string
-    {
-        $select = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS) . '.document';
-
-        $qb = $this->engine->getConnection()
-            ->createQueryBuilder();
-        $qb->select($select);
-
-        $this->addMultiAttributeFromAndJoinToQueryBuilder($qb, $attribute);
-
-        $qb->groupBy($select);
-
-        if ($positiveMultiWheres !== []) {
-            $qb->andHaving(sprintf('COUNT(CASE WHEN %s THEN 1 ELSE NULL END) > 0', implode(' ', $positiveMultiWheres)));
-        }
-
-        if ($negativeMultiWheres !== []) {
-            $qb->andHaving(sprintf('COUNT(CASE WHEN %s THEN 1 ELSE NULL END) = 0', implode(' ', $negativeMultiWheres)));
-        }
-
-        return $qb->getSQL();
     }
 
     private function createTermDocumentMatchesCTECondition(Token $token): ?string
@@ -616,149 +523,8 @@ class Searcher
             return;
         }
 
-        $whereStatement = [];
-
-        $this->handleFilterAstNode($this->getFilterAst()->getRoot(), $whereStatement);
-
-        $this->queryBuilder->andWhere(implode(' ', $whereStatement));
-    }
-
-    /**
-     * @param array<string|float> $whereStatement
-     */
-    private function handleFilterAstNode(Node $node, array &$whereStatement): void
-    {
-        $documentAlias = $this->engine->getIndexInfo()
-            ->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
-
-        if ($node instanceof Group) {
-            $groupWhere = [];
-            foreach ($node->getChildren() as $child) {
-                $this->handleFilterAstNode($child, $groupWhere);
-            }
-
-            if ($groupWhere !== []) {
-                $whereStatement[] = '(';
-                $whereStatement[] = implode(' ', $groupWhere);
-                $whereStatement[] = ')';
-            }
-        }
-
-        if ($node instanceof MultiAttributeFilter) {
-            $positiveMultiWheres = [];
-            $negativeMultiWheres = [];
-            foreach ($node->getChildren() as $child) {
-                // Multi filterable attributes need special handling
-                if ($child instanceof Filter && \in_array($node->attribute, $this->engine->getIndexInfo()->getMultiFilterableAttributes(), true)) {
-                    $isFloatType = LoupeTypes::isFloatType(LoupeTypes::getTypeFromValue($child->value));
-
-                    $column = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES) . '.' .
-                        ($isFloatType ? 'numeric_value' : 'string_value');
-
-                    $positiveMultiWheres[] = $child->operator->buildSql(
-                        $this->engine->getConnection(),
-                        $column,
-                        $child->value
-                    );
-
-                    // If the operator is negative, we have to add a second where. This is because if the users write
-                    // $loupe->withFilter("multiattribute NOT IN ('foo', 'bar')") they want NEITHER of the attribute
-                    // values to be part of the result set. But because we store multi attributes in a separate table,
-                    // we first have to ensure the document has at least one allowed value AND then ensure the document
-                    //does NOT have ANY forbidden value
-                    if ($child->operator->isNegative()) {
-                        $negativeMultiWheres[] = $child->operator->opposite()->buildSql(
-                            $this->engine->getConnection(),
-                            $column,
-                            $child->value
-                        );
-                    }
-                } else {
-                    $this->handleFilterAstNode($child, $positiveMultiWheres);
-                }
-            }
-
-            $whereStatement[] = $documentAlias . '.id IN (';
-            $whereStatement[] = $this->createSubQueryForMultiAttribute($node->attribute, $positiveMultiWheres, $negativeMultiWheres);
-            $whereStatement[] = ')';
-        }
-
-        if ($node instanceof Filter) {
-            $operator = $node->operator;
-
-            // Not existing attributes need be handled as no match if positive and as match if negative
-            if (!\in_array($node->attribute, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
-                $whereStatement[] = $operator->isNegative() ? '1 = 1' : '1 = 0';
-            } else {
-                $attribute = $node->attribute;
-
-                if ($attribute === $this->engine->getConfiguration()->getPrimaryKey()) {
-                    $attribute = 'user_id';
-                }
-
-                $whereStatement[] = $operator->buildSql(
-                    $this->engine->getConnection(),
-                    $documentAlias . '.' . $attribute,
-                    $node->value
-                );
-            }
-        }
-
-        if ($node instanceof GeoDistance) {
-            // Not existing attributes need be handled as no match
-            if (!\in_array($node->attributeName, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
-                $whereStatement[] = '1 = 0';
-                return;
-            }
-
-            // Add the distance to the select query, so it's also part of the result
-            $distanceSelectAlias = $this->addGeoDistanceSelectToQueryBuilder($node->attributeName, $node->lat, $node->lng);
-
-            // Start a group
-            $whereStatement[] = '(';
-
-            // Improve performance by drawing a BBOX around our coordinates to reduce the result set considerably before
-            // the actual distance is compared. This can use indexes.
-            // We use floor() and ceil() respectively to ensure we get matches as the BearingSpherical calculation of the
-            // BBOX may not be as precise so when searching for the e.g. 3rd decimal floating point, we might exclude
-            // locations we shouldn't.
-            $bounds = $node->getBbox();
-
-            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
-
-            // And now calculate the real distance to filter out the ones that are within the BBOX (which is a square)
-            // but not within the radius (which is a circle).
-            $whereStatement[] = 'AND';
-            $whereStatement[] = $distanceSelectAlias;
-            $whereStatement[] = '<=';
-            $whereStatement[] = $node->distance;
-
-            // End group
-            $whereStatement[] = ')';
-        }
-
-        if ($node instanceof GeoBoundingBox) {
-            // Not existing attributes need be handled as no match
-            if (!\in_array($node->attributeName, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
-                $whereStatement[] = '1 = 0';
-                return;
-            }
-
-            // Start a group GeoDistance BBOX
-            $whereStatement[] = '(';
-
-            // Same like above for
-            $bounds = $node->getBbox();
-
-            $whereStatement = [...$whereStatement, ...$this->createGeoBoundingBoxWhereStatement($documentAlias, $node, $bounds)];
-
-            // End group
-            $whereStatement[] = ')';
-        }
-
-        if ($node instanceof Concatenator) {
-            $whereStatement[] = $node->getConcatenator();
-        }
+        $filterBuilder = new FilterBuilder($this->engine, $this, $this->queryBuilder);
+        $filterBuilder->buildForDocument();
     }
 
     /**

--- a/src/Internal/Search/Sorting.php
+++ b/src/Internal/Search/Sorting.php
@@ -9,12 +9,13 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Search\Sorting\AbstractSorter;
 use Loupe\Loupe\Internal\Search\Sorting\Direction;
 use Loupe\Loupe\Internal\Search\Sorting\GeoPoint;
+use Loupe\Loupe\Internal\Search\Sorting\MultiAttribute;
 use Loupe\Loupe\Internal\Search\Sorting\Relevance;
-use Loupe\Loupe\Internal\Search\Sorting\Simple;
+use Loupe\Loupe\Internal\Search\Sorting\SingleAttribute;
 
 class Sorting
 {
-    private const SORTERS = [Relevance::class, Simple::class, GeoPoint::class];
+    private const SORTERS = [Relevance::class, MultiAttribute::class, SingleAttribute::class, GeoPoint::class];
 
     /**
      * @param array<AbstractSorter> $sorters

--- a/src/Internal/Search/Sorting/Aggregate.php
+++ b/src/Internal/Search/Sorting/Aggregate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Sorting;
+
+enum Aggregate: string
+{
+    case Max = 'MAX';
+    case Min = 'MIN';
+
+    public function buildSql(string $attribute): string
+    {
+        return $this->value . '(' . $attribute . ')';
+    }
+
+    public static function tryFromCaseInsensitive(string $value): null|self
+    {
+        return self::tryFrom(strtoupper($value));
+    }
+}

--- a/src/Internal/Search/Sorting/MultiAttribute.php
+++ b/src/Internal/Search/Sorting/MultiAttribute.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search\Sorting;
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Filter\Ast\Concatenator;
+use Loupe\Loupe\Internal\Filter\Ast\Filter;
+use Loupe\Loupe\Internal\Filter\Ast\Group;
+use Loupe\Loupe\Internal\Filter\Ast\Node;
+use Loupe\Loupe\Internal\Index\IndexInfo;
+use Loupe\Loupe\Internal\LoupeTypes;
+use Loupe\Loupe\Internal\Search\Searcher;
+
+/**
+ * Sorts based on a multi attribute (an array value). Currently supporting min() and max() aggregators.
+ */
+class MultiAttribute extends AbstractSorter
+{
+    private const MULTI_RGXP = '^(max|min)\((' . Configuration::ATTRIBUTE_NAME_RGXP . ')\)$';
+
+    public function __construct(
+        private string $attributeName,
+        private Aggregate $aggregate,
+        private Direction $direction
+    ) {
+    }
+
+    public function apply(Searcher $searcher, Engine $engine): void
+    {
+        $isFloatType = LoupeTypes::isFloatType($engine->getIndexInfo()->getLoupeTypeForAttribute($this->attributeName));
+        $column = $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES) . '.' . ($isFloatType ? 'numeric_value' : 'string_value');
+
+        // Build the subquery, SELECT our aggregate and joining the multi attributes on our attribute name.
+        $qb = $engine->getConnection()
+            ->createQueryBuilder();
+        $qb->select($this->aggregate->buildSql($column));
+        $searcher->addMultiAttributeFromAndJoinToQueryBuilder($qb, $this->attributeName);
+
+        // Now filter only the ones that belong to our document
+        $qb->andWhere(sprintf(
+            '%s.document=%s.id',
+            $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
+            $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
+        ));
+
+        // Now we have the correct attribute and correct document, but we now need to apply the filters, also.
+        // Otherwise, imagine you have two documents with
+        // Document A: ['numbers' => [2, 3, 4, 5]]
+        // Document B: ['numbers' => [1, 3, 4, 5]]
+        // if you now sort for "min(numbers):asc" and also apply a filter with "numbers >= 2 AND numbers <= 4" (for which
+        // both match), you would get document B listed before document A. Because document B's number 1 is lower than document
+        // A's number 2. However, our filter said we're only interested in numbers between 2 and 4 so document A must be
+        // listed before document B as the other numbers are not even relevant for us (facets of the current search result).
+        $ast = $searcher->getFilterAst();
+        $whereStatement = [];
+
+        foreach ($ast->getNodes() as $node) {
+            $this->handleFilterAstNode($engine, $node, $column, $whereStatement);
+        }
+
+        if ($whereStatement !== []) {
+            $qb->andWhere(implode(' ', $whereStatement));
+        }
+
+        $searcher->getQueryBuilder()->addOrderBy('(' . $qb->getSQL() . ')', $this->direction->getSQL());
+    }
+
+    public static function fromString(string $value, Engine $engine, Direction $direction): self
+    {
+        $matches = self::split($value);
+
+        if ($matches === null) {
+            throw new \InvalidArgumentException('Invalid string, call supports() first.');
+        }
+
+        return new self($matches['attribute'], $matches['aggregate'], $direction);
+    }
+
+    public static function supports(string $value, Engine $engine): bool
+    {
+        $matches = self::split($value);
+
+        if ($matches === null) {
+            return false;
+        }
+
+        $attribute = $matches['attribute'];
+
+        // We support if it's configured sortable and a multi type
+        if (!\in_array($attribute, $engine->getConfiguration()->getSortableAttributes(), true) || !LoupeTypes::isMultiType($engine->getIndexInfo()->getLoupeTypeForAttribute($attribute))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function handleFilterAstNode(Engine $engine, Node $node, string $column, array &$whereStatement): void
+    {
+        if ($node instanceof Group) {
+            $groupWhere = [];
+            foreach ($node->getChildren() as $child) {
+                $this->handleFilterAstNode($engine, $child, $column, $groupWhere);
+            }
+
+            if ($groupWhere !== []) {
+                $whereStatement[] = '(';
+                $whereStatement[] = implode(' ', $groupWhere);
+                $whereStatement[] = ')';
+            }
+        }
+
+        if ($node instanceof Filter) {
+            // Only consider the ones of our attribute
+            if ($node->attribute !== $this->attributeName) {
+                return;
+            }
+
+            $sql = $node->operator->isNegative() ?
+                $node->operator->opposite()->buildSql($engine->getConnection(), $column, $node->value) :
+                $node->operator->buildSql($engine->getConnection(), $column, $node->value);
+
+            $whereStatement[] = $sql;
+        }
+
+        if ($node instanceof Concatenator) {
+            $whereStatement[] = $node->getConcatenator();
+        }
+    }
+
+    /**
+     * @return null|array{aggregate: Aggregate, attribute: string}
+     */
+    private static function split(string $value): ?array
+    {
+        $supports = preg_match('@' . self::MULTI_RGXP . '@', $value, $matches);
+
+        if (!$supports) {
+            return null;
+        }
+
+        $aggregate = Aggregate::tryFromCaseInsensitive((string) $matches[1]);
+
+        if ($aggregate === null) {
+            return null;
+        }
+
+        return [
+            'aggregate' => $aggregate,
+            'attribute' => (string) $matches[2],
+        ];
+    }
+}

--- a/src/Internal/Search/Sorting/MultiAttribute.php
+++ b/src/Internal/Search/Sorting/MultiAttribute.php
@@ -97,6 +97,9 @@ class MultiAttribute extends AbstractSorter
         return true;
     }
 
+    /**
+     * @param array<string|float> $whereStatement
+     */
     private function handleFilterAstNode(Engine $engine, Node $node, string $column, array &$whereStatement): void
     {
         if ($node instanceof Group) {

--- a/src/Internal/Search/Sorting/SingleAttribute.php
+++ b/src/Internal/Search/Sorting/SingleAttribute.php
@@ -8,7 +8,7 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\Search\Searcher;
 
-class Simple extends AbstractSorter
+class SingleAttribute extends AbstractSorter
 {
     public function __construct(
         private string $attributeName,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1088,8 +1088,65 @@ class SearchTest extends TestCase
 
     public static function sortOnMultiAttributesWithMinAndMaxModifiers(): \Generator
     {
-        yield 'Test MIN aggregate' => [
+        yield 'Test MIN aggregate without filters (ASC)' => [
             'min(dates):asc',
+            '',
+            [
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'Event C',
+                ],
+            ],
+        ];
+        yield 'Test MIN aggregate without filters (DESC)' => [
+            'min(dates):desc',
+            '',
+            [
+                [
+                    'id' => 3,
+                    'name' => 'Event C',
+                ],
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+            ],
+        ];
+
+        yield 'Test MAX aggregate without filters (ASC)' => [
+            'max(dates):asc',
+            '',
+            [
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'Event C',
+                ],
+            ],
+        ];
+
+        yield 'Test MIN aggregate with filters (ASC)' => [
+            'min(dates):asc',
+            'dates >= 2 AND dates <= 6',
             [
                 [
                     'id' => 1,
@@ -1102,8 +1159,9 @@ class SearchTest extends TestCase
             ],
         ];
 
-        yield 'Test MAX aggregate' => [
-            'max(dates):asc',
+        yield 'Test MIN aggregate with filters (DESC)' => [
+            'min(dates):desc',
+            'dates >= 2 AND dates <= 6',
             [
                 [
                     'id' => 2,
@@ -1112,6 +1170,36 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'name' => 'Event A',
+                ],
+            ],
+        ];
+
+        yield 'Test MAX aggregate with filters (ASC)' => [
+            'max(dates):asc',
+            'dates >= 2 AND dates <= 6',
+            [
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+            ],
+        ];
+
+        yield 'Test MAX aggregate with filters (DESC)' => [
+            'max(dates):desc',
+            'dates >= 2 AND dates <= 6',
+            [
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
                 ],
             ],
         ];
@@ -2831,7 +2919,7 @@ class SearchTest extends TestCase
      *@param array<array<string,mixed>> $expectedHits
      */
     #[DataProvider('sortOnMultiAttributesWithMinAndMaxModifiers')]
-    public function testSortOnMultiAttributesWithMinAndMaxModifiers(string $sort, array $expectedHits): void
+    public function testSortOnMultiAttributesWithMinAndMaxModifiers(string $sort, string $filter, array $expectedHits): void
     {
         $configuration = Configuration::create();
 
@@ -2862,7 +2950,7 @@ class SearchTest extends TestCase
 
         $searchParameters = SearchParameters::create()
             ->withAttributesToRetrieve(['id', 'name'])
-            ->withFilter('dates >= 2 AND dates <= 6')
+            ->withFilter($filter)
             ->withSort([$sort])
         ;
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1086,6 +1086,37 @@ class SearchTest extends TestCase
         ];
     }
 
+    public static function sortOnMultiAttributesWithMinAndMaxModifiers(): \Generator
+    {
+        yield 'Test MIN aggregate' => [
+            'min(dates):asc',
+            [
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+            ],
+        ];
+
+        yield 'Test MAX aggregate' => [
+            'max(dates):asc',
+            [
+                [
+                    'id' => 2,
+                    'name' => 'Event B',
+                ],
+                [
+                    'id' => 1,
+                    'name' => 'Event A',
+                ],
+            ],
+        ];
+    }
+
     public static function sortWithNullAndNonExistingValueProvider(): \Generator
     {
         yield 'ASC' => [
@@ -1144,37 +1175,6 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'name' => 'Star Wars',
-                ],
-            ],
-        ];
-    }
-
-    public static function sortOnMultiAttributesWithMinAndMaxModifiers(): \Generator
-    {
-        yield 'Test MIN aggregate' => [
-            'min(dates):asc',
-            [
-                [
-                    'id' => 1,
-                    'name' => 'Event A',
-                ],
-                [
-                    'id' => 2,
-                    'name' => 'Event B',
-                ],
-            ],
-        ];
-
-        yield 'Test MAX aggregate' => [
-            'max(dates):asc',
-            [
-                [
-                    'id' => 2,
-                    'name' => 'Event B',
-                ],
-                [
-                    'id' => 1,
-                    'name' => 'Event A',
                 ],
             ],
         ];
@@ -2872,7 +2872,7 @@ class SearchTest extends TestCase
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,
-            'totalHits' => count($expectedHits),
+            'totalHits' => \count($expectedHits),
         ]);
     }
 


### PR DESCRIPTION
This will allow to sort by `min()` or `max()` of an array attribute.

```php
$searchParameters = \Loupe\Loupe\SearchParameters::create()
    ->withFilter('numbers >= 2 AND numbers <= 4')
    ->withSort(['min(numbers):asc'])
;
```

Thanks to this, you may for example sort by the next occurrence of an array of dates 😎 