### PR TITLE
Add a use case where date between bounds fails

### DIFF
--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1799,7 +1799,6 @@ class SearchTest extends TestCase
                     (new \DateTimeImmutable('2025-04-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
                 ],
             ],
-            // TODO: this use case should not pass. Funnily enough it's not even returned in the results if appears at the end of the array.
             [
                 'id' => 6,
                 'name' => 'Gladiator',

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -743,6 +743,16 @@ class SearchTest extends TestCase
             'rating > 3.5',
             [
                 [
+                    'id' => 6,
+                    'name' => 'Gladiator',
+                    'rating' => 5,
+                    'dates' => [
+                        1735689600,
+                        1767225600,
+                        1798761600,
+                    ],
+                ],
+                [
                     'id' => 3,
                     'name' => 'Jurassic Park',
                     'rating' => 4,
@@ -757,6 +767,16 @@ class SearchTest extends TestCase
         yield [
             'rating >= 3.5',
             [
+                [
+                    'id' => 6,
+                    'name' => 'Gladiator',
+                    'rating' => 5,
+                    'dates' => [
+                        1735689600,
+                        1767225600,
+                        1798761600,
+                    ],
+                ],
                 [
                     'id' => 2,
                     'name' => 'Indiana Jones',
@@ -1777,6 +1797,17 @@ class SearchTest extends TestCase
                 'dates' => [
                     (new \DateTimeImmutable('2025-03-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
                     (new \DateTimeImmutable('2025-04-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
+                ],
+            ],
+            // TODO: this use case should not pass. Funnily enough it's not even returned in the results if appears at the end of the array.
+            [
+                'id' => 6,
+                'name' => 'Gladiator',
+                'rating' => 5,
+                'dates' => [
+                    (new \DateTimeImmutable('2025-01-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
+                    (new \DateTimeImmutable('2026-01-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
+                    (new \DateTimeImmutable('2027-01-01 00:00:00', new \DateTimeZone('UTC')))->getTimestamp(),
                 ],
             ],
             [


### PR DESCRIPTION
Currently the `dates >= 2000 AND dates <= 4000` will produce the SQL query like this:

```sql
SELECT COUNT() OVER () AS totalHits, d.document
FROM documents d
WHERE d.id IN (SELECT document
               FROM multi_attributes_documents mad
                        INNER JOIN multi_attributes ma ON ma.attribute = 'dates' AND ma.id = mad.attribute
               WHERE (ma.numeric_value >= 2000 AND ma.numeric_value != ':l:n'))
  AND d.id IN (SELECT document
               FROM multi_attributes_documents mad
                        INNER JOIN multi_attributes ma ON ma.attribute = 'dates' AND ma.id = mad.attribute
               WHERE (ma.numeric_value <= 4000 AND ma.numeric_value != ':l:n'))
```

Which may lead to incorrect results. For example, if we have a document ID 123 with the following `dates`:

- `1000`
- `5000`

---

If we run the SQL query that is produced now:

1st subquery will be processed as follows:

- `1000` >= 2000 ❌
- `5000` >= 2000 ✅
➡️ Document ID 123 returned

2nd subquery will be processed as follows:

- `1000` <= 4000 ✅
➡️ Document ID 123 returned
- `5000` <= 4000 ❌

Which we will end up having:

```sql
… WHERE d.id IN (123) AND d.id IN (123)
```

… and the document will be returned in the search result, but this should not happen. 

---

The document should not be returned, because:

- `1000` >= 2000 AND `1000` <= 4000 
➡️ ❌ AND ✅ 
➡️ ❌
- `5000` >= 2000 AND `5000` <= 4000 
➡️ ✅ AND ❌
➡️ ❌

Eventually, the fixed query should likely become a single statement:

```sql
SELECT COUNT() OVER () AS totalHits, d.document
FROM documents d
WHERE d.id IN (SELECT document
               FROM multi_attributes_documents mad
                        INNER JOIN multi_attributes ma ON ma.attribute = 'dates' AND ma.id = mad.attribute
               WHERE (ma.numeric_value >= 1741270207 AND ma.numeric_value <= 1741961407 AND ma.numeric_value != ':l:n'))
```