### PR TITLE
Performance optimization on ORDER BY

### DIFF
--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -45,15 +45,10 @@ class FilterBuilder
 
         // Build the subquery, SELECT our aggregate and joining the multi attributes on our attribute name.
         $qb = $this->engine->getConnection()->createQueryBuilder();
-        $qb->select($aggregate->buildSql($column));
+        $qb->addSelect($this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS) . '.document AS document_id');
+        $qb->addSelect($aggregate->buildSql($column) . ' AS sort_order');
         $this->addMultiAttributeFromAndJoinToQueryBuilder($qb, $attribute);
-
-        // Now filter only the ones that belong to our document
-        $qb->andWhere(sprintf(
-            '%s.document=%s.id',
-            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-            $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-        ));
+        $qb->groupBy('document_id');
 
         $whereStatement = [];
         $this->handleFilterAstNode($this->searcher->getFilterAst()->getRoot(), $whereStatement);

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -47,8 +47,6 @@ class Searcher
      */
     private array $geoDistanceSelectsAdded = [];
 
-    private bool $multiAttributeJoinAdded = false;
-
     private QueryBuilder $queryBuilder;
 
     private Sorting $sorting;
@@ -64,6 +62,9 @@ class Searcher
         $this->filterAst = $filterParser->getAst($this->searchParameters->getFilter());
     }
 
+    /**
+     * @param array<string> $cols
+     */
     public function addCTE(string $cteName, array $cols, string $sql): void
     {
         $this->CTEs[$cteName]['cols'] = $cols;

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -64,6 +64,12 @@ class Searcher
         $this->filterAst = $filterParser->getAst($this->searchParameters->getFilter());
     }
 
+    public function addCTE(string $cteName, array $cols, string $sql): void
+    {
+        $this->CTEs[$cteName]['cols'] = $cols;
+        $this->CTEs[$cteName]['sql'] = $sql;
+    }
+
     public function addGeoDistanceSelectToQueryBuilder(string $attribute, float $latitude, float $longitude): string
     {
         $alias = self::DISTANCE_ALIAS . '_' . $attribute;
@@ -89,37 +95,6 @@ class Searcher
         $this->geoDistanceSelectsAdded[$alias] = true;
 
         return $alias;
-    }
-
-    public function addJoinForMultiAttributes(): void
-    {
-        if ($this->multiAttributeJoinAdded) {
-            return;
-        }
-
-        $this->queryBuilder
-            ->innerJoin(
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-                IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                sprintf(
-                    '%s.id = %s.document',
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                )
-            )
-            ->innerJoin(
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES,
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-                sprintf(
-                    '%s.attribute = %s.id',
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
-                    $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-                )
-            );
-
-        $this->multiAttributeJoinAdded = true;
     }
 
     public function fetchResult(): SearchResult

--- a/src/Internal/Search/Sorting/MultiAttribute.php
+++ b/src/Internal/Search/Sorting/MultiAttribute.php
@@ -6,7 +6,6 @@ namespace Loupe\Loupe\Internal\Search\Sorting;
 
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\Engine;
-use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\LoupeTypes;
 use Loupe\Loupe\Internal\Search\FilterBuilder\FilterBuilder;
 use Loupe\Loupe\Internal\Search\Searcher;
@@ -36,27 +35,10 @@ class MultiAttribute extends AbstractSorter
 
     public function apply(Searcher $searcher, Engine $engine): void
     {
-        $searcher->addJoinForMultiAttributes();
-        $isFloatType = LoupeTypes::isFloatType($engine->getIndexInfo()->getLoupeTypeForAttribute($this->attributeName));
-
         $filterBuilder = new FilterBuilder($engine, $searcher, $searcher->getQueryBuilder());
-        $havingStatements = $filterBuilder->buildForMultiAttribute($this->attributeName);
-        $additionalCondition = '';
+        $qb = $filterBuilder->buildForMultiAttribute($this->attributeName, $this->aggregate);
 
-        if ($havingStatements !== []) {
-            $additionalCondition = ' AND (' . implode(' ', $havingStatements) . ')';
-        }
-
-        $sort = $this->aggregate->buildSql(sprintf(
-            'CASE WHEN %s.attribute = %s%s THEN %s.%s ELSE NULL END',
-            $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-            $searcher->getQueryBuilder()->createNamedParameter($this->attributeName),
-            $additionalCondition,
-            $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES),
-            $isFloatType ? 'numeric_value' : 'string_value'
-        ));
-
-        $searcher->getQueryBuilder()->addOrderBy($sort, $this->direction->getSQL());
+        $searcher->getQueryBuilder()->addOrderBy('(' . $qb->getSQL() . ')', $this->direction->getSQL());
     }
 
     public static function fromString(string $value, Engine $engine, Direction $direction): self


### PR DESCRIPTION
The `HAVING` is nice because it seems to work for all sorts of `filter` definitions but of course, it's way too slow now. So we need to go back to `WHERE` and only apply `HAVING` where absolutely needed.

The `ORDER BY` is currently super slow as well unfortnuately, joining way too many rows in big data sets.