### PR TITLE
Make document limit configurable

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -29,13 +29,6 @@ class Searcher
     public const RELEVANCE_ALIAS = '_relevance';
 
     /**
-     * If searching for a query that is super broad like "this is taking so long", way too many
-     * documents are going to match so we have to internally limit those matches to prevent
-     * "endless" search queries.
-     */
-    private const MAX_DOCUMENT_MATCHES = 1000;
-
-    /**
      * @var array<string, array{cols: array<string>, sql: string}>
      */
     private array $CTEs = [];
@@ -297,7 +290,7 @@ class Searcher
         }
 
         $cteSelectQb->addOrderBy('position');
-        $cteSelectQb->setMaxResults(self::MAX_DOCUMENT_MATCHES);
+        $cteSelectQb->setMaxResults($this->searchParameters->getMaxHitsPerTerm());
 
         $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
         $this->CTEs[$cteName]['cols'] = ['document', 'term', 'attribute', 'position', 'typos'];

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -33,6 +33,8 @@ final class SearchParameters
 
     private int $hitsPerPage = 20;
 
+    private int $maxHitsPerTerm = 1000;
+
     private int $page = 1;
 
     private string $query = '';
@@ -128,6 +130,11 @@ final class SearchParameters
         return $this->hitsPerPage;
     }
 
+    public function getMaxHitsPerTerm(): int
+    {
+        return $this->maxHitsPerTerm;
+    }
+
     public function getPage(): int
     {
         return $this->page;
@@ -221,6 +228,14 @@ final class SearchParameters
 
         $clone = clone $this;
         $clone->hitsPerPage = $hitsPerPage;
+
+        return $clone;
+    }
+
+    public function withMaxHitsPerTerm(int $maxHitsPerTerm): self
+    {
+        $clone = clone $this;
+        $clone->maxHitsPerTerm = $maxHitsPerTerm;
 
         return $clone;
     }

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -27,4 +27,13 @@ class SearchParametersTest extends TestCase
 
         SearchParameters::create()->withHitsPerPage(2000);
     }
+
+    public function testMaxHitsPerTerm(): void
+    {
+        $searchParameters = SearchParameters::create();
+        $this->assertSame(1000, $searchParameters->getMaxHitsPerTerm());
+
+        $searchParameters = $searchParameters->withMaxHitsPerTerm(500);
+        $this->assertSame(500, $searchParameters->getMaxHitsPerTerm());
+    }
 }


### PR DESCRIPTION
- Allow customizing the 1000-documents-per-term limit
- Needs to be rebased if/when merging #163 but wanted to get your opinion on making this configurable
- Meilisearch has a similar setting [`maxTotalHits`](https://www.meilisearch.com/docs/reference/api/settings#update-pagination-settings) which applies to the whole result set, so is a bit different in scope
  - If we named this `maxTotalHits` as well and also applied it to the final result query as well, we'd have the same concept. WDYT? Might be good to keep this in sync conceptually.
