### PR TITLE
Make configuration serializable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,5 +218,17 @@ $configuration = \Loupe\Loupe\Configuration::create()
 print_r($logger->getRecords());
 ```
 
+## Serializing and reconstructing configuration
+
+If you need to serialize the configuration of Loupe e.g. to allow configuration using a DSN, you can use the `toString()` and `fromString()` helpers accordingly:
+
+```php
+$configuration = \Loupe\Loupe\Configuration::create();
+
+$serialized = $configuration->toString();
+$reconstructed = \Loupe\Loupe\Configuration::fromString($serialized);
+```
+
+Note that this does not work for instances such as the "logger".
 
 [Paper]: https://hpi.de/oldsite/fileadmin/user_upload/fachgebiete/naumann/publications/PDFs/2012_fenz_efficient.pdf

--- a/src/Config/TypoTolerance.php
+++ b/src/Config/TypoTolerance.php
@@ -51,6 +51,47 @@ final class TypoTolerance
         return $this->firstCharTypoCountsDouble;
     }
 
+    /**
+     * @param array{
+     *     alphabetSize?: int,
+     *     firstCharTypoCountsDouble?: bool,
+     *     indexLength?: int,
+     *     isDisabled?: bool,
+     *     isEnabledForPrefixSearch?: bool,
+     *     typoThresholds?: array<int, int>
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $instance = new self();
+
+        if (isset($data['isDisabled']) && $data['isDisabled'] === true) {
+            $instance = $instance->disable();
+        }
+
+        if (isset($data['alphabetSize'])) {
+            $instance = $instance->withAlphabetSize((int) $data['alphabetSize']);
+        }
+
+        if (isset($data['firstCharTypoCountsDouble'])) {
+            $instance = $instance->withFirstCharTypoCountsDouble((bool) $data['firstCharTypoCountsDouble']);
+        }
+
+        if (isset($data['indexLength'])) {
+            $instance = $instance->withIndexLength((int) $data['indexLength']);
+        }
+
+        if (isset($data['isEnabledForPrefixSearch'])) {
+            $instance = $instance->withEnabledForPrefixSearch((bool) $data['isEnabledForPrefixSearch']);
+        }
+
+        if (isset($data['typoThresholds']) && \is_array($data['typoThresholds'])) {
+            $instance = $instance->withTypoThresholds($data['typoThresholds']);
+        }
+
+        return $instance;
+    }
+
     public function getAlphabetSize(): int
     {
         return $this->alphabetSize;
@@ -86,6 +127,28 @@ final class TypoTolerance
     public function isEnabledForPrefixSearch(): bool
     {
         return $this->isEnabledForPrefixSearch;
+    }
+
+    /**
+     * @return array{
+     *     alphabetSize: int,
+     *     firstCharTypoCountsDouble: bool,
+     *     indexLength: int,
+     *     isDisabled: bool,
+     *     isEnabledForPrefixSearch: bool,
+     *     typoThresholds: array<int, int>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'alphabetSize' => $this->alphabetSize,
+            'firstCharTypoCountsDouble' => $this->firstCharTypoCountsDouble,
+            'indexLength' => $this->indexLength,
+            'isDisabled' => $this->isDisabled,
+            'isEnabledForPrefixSearch' => $this->isEnabledForPrefixSearch,
+            'typoThresholds' => $this->typoThresholds,
+        ];
     }
 
     public function withAlphabetSize(int $alhabetSize): self

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -81,6 +81,84 @@ final class Configuration
     }
 
     /**
+     * @param array{
+     *     displayedAttributes?: array<string>,
+     *     filterableAttributes?: array<string>,
+     *     languages?: array<string>,
+     *     maxQueryTokens?: int,
+     *     minTokenLengthForPrefixSearch?: int,
+     *     primaryKey?: string,
+     *     rankingRules?: array<string>,
+     *     searchableAttributes?: array<string>,
+     *     sortableAttributes?: array<string>,
+     *     stopWords?: array<string>,
+     *     typoTolerance?: array{
+     *         alphabetSize?: int,
+     *         firstCharTypoCountsDouble?: bool,
+     *         indexLength?: int,
+     *         isDisabled?: bool,
+     *         isEnabledForPrefixSearch?: bool,
+     *         typoThresholds?: array<int, int>
+     *     }
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $instance = new self();
+
+        if (isset($data['displayedAttributes'])) {
+            $instance = $instance->withDisplayedAttributes($data['displayedAttributes']);
+        }
+
+        if (isset($data['filterableAttributes'])) {
+            $instance = $instance->withFilterableAttributes($data['filterableAttributes']);
+        }
+
+        if (isset($data['languages'])) {
+            $instance = $instance->withLanguages($data['languages']);
+        }
+
+        if (isset($data['maxQueryTokens'])) {
+            $instance = $instance->withMaxQueryTokens((int) $data['maxQueryTokens']);
+        }
+
+        if (isset($data['minTokenLengthForPrefixSearch'])) {
+            $instance = $instance->withMinTokenLengthForPrefixSearch((int) $data['minTokenLengthForPrefixSearch']);
+        }
+
+        if (isset($data['primaryKey'])) {
+            $instance = $instance->withPrimaryKey($data['primaryKey']);
+        }
+
+        if (isset($data['rankingRules'])) {
+            $instance = $instance->withRankingRules($data['rankingRules']);
+        }
+
+        if (isset($data['searchableAttributes'])) {
+            $instance = $instance->withSearchableAttributes($data['searchableAttributes']);
+        }
+
+        if (isset($data['sortableAttributes'])) {
+            $instance = $instance->withSortableAttributes($data['sortableAttributes']);
+        }
+
+        if (isset($data['stopWords'])) {
+            $instance = $instance->withStopWords($data['stopWords']);
+        }
+
+        if (isset($data['typoTolerance']) && \is_array($data['typoTolerance'])) {
+            $instance = $instance->withTypoTolerance(TypoTolerance::fromArray($data['typoTolerance']));
+        }
+
+        return $instance;
+    }
+
+    public static function fromString(string $string): self
+    {
+        return self::fromArray(json_decode($string, true));
+    }
+
+    /**
      * @return array<string>
      */
     public function getDisplayedAttributes(): array
@@ -194,6 +272,50 @@ final class Configuration
     public function getTypoTolerance(): TypoTolerance
     {
         return $this->typoTolerance;
+    }
+
+    /**
+     * @return array{
+     *     displayedAttributes: array<string>,
+     *     filterableAttributes: array<string>,
+     *     languages: array<string>,
+     *     maxQueryTokens: int,
+     *     minTokenLengthForPrefixSearch: int,
+     *     primaryKey: string,
+     *     rankingRules: array<string>,
+     *     searchableAttributes: array<string>,
+     *     sortableAttributes: array<string>,
+     *     stopWords: array<string>,
+     *     typoTolerance: array{
+     *         alphabetSize: int,
+     *         firstCharTypoCountsDouble: bool,
+     *         indexLength: int,
+     *         isDisabled: bool,
+     *         isEnabledForPrefixSearch: bool,
+     *         typoThresholds: array<int, int>
+     *     }
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'displayedAttributes' => $this->displayedAttributes,
+            'filterableAttributes' => $this->filterableAttributes,
+            'languages' => $this->languages,
+            'maxQueryTokens' => $this->maxQueryTokens,
+            'minTokenLengthForPrefixSearch' => $this->minTokenLengthForPrefixSearch,
+            'primaryKey' => $this->primaryKey,
+            'rankingRules' => $this->rankingRules,
+            'searchableAttributes' => $this->searchableAttributes,
+            'sortableAttributes' => $this->sortableAttributes,
+            'stopWords' => $this->stopWords,
+            'typoTolerance' => $this->typoTolerance->toArray(),
+        ];
+    }
+
+    public function toString(): string
+    {
+        return (string) json_encode($this->toArray());
     }
 
     public static function validateAttributeName(string $name): void

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests;
+
+use Loupe\Loupe\Config\TypoTolerance;
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Exception\InvalidConfigurationException;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    public function testGetIndexHashChangesOnMutation(): void
+    {
+        $a = Configuration::create();
+        $b = $a->withPrimaryKey('different');
+
+        $this->assertNotSame($a->getIndexHash(), $b->getIndexHash());
+    }
+
+    public function testImmutability(): void
+    {
+        $config = Configuration::create();
+        $newConfig = $config->withPrimaryKey('changed');
+
+        $this->assertNotSame($config, $newConfig);
+        $this->assertSame('id', $config->getPrimaryKey());
+        $this->assertSame('changed', $newConfig->getPrimaryKey());
+    }
+
+    public function testInvalidAttributeNameThrows(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        Configuration::create()->withFilterableAttributes(['this one has spaces']);
+    }
+
+    public function testInvalidRankingRuleThrowsException(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        Configuration::create()->withRankingRules(['invalid-rule']);
+    }
+
+    public function testToArrayAndFromArray(): void
+    {
+        $original = Configuration::create()
+            ->withDisplayedAttributes(['title', 'description'])
+            ->withFilterableAttributes(['category'])
+            ->withLanguages(['en', 'fr'])
+            ->withMaxQueryTokens(20)
+            ->withMinTokenLengthForPrefixSearch(2)
+            ->withPrimaryKey('uid')
+            ->withRankingRules(['words', 'typo'])
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['popularity'])
+            ->withStopWords(['a', 'the'])
+            ->withTypoTolerance(
+                TypoTolerance::create()
+                    ->withAlphabetSize(10)
+                    ->withFirstCharTypoCountsDouble(false)
+                    ->withIndexLength(5)
+                    ->withEnabledForPrefixSearch(true)
+                    ->withTypoThresholds([
+                        10 => 3,
+                        5 => 2,
+                    ])
+            );
+
+        $array = $original->toArray();
+        $reconstructed = Configuration::fromArray($array);
+
+        $this->assertSame($original->toArray(), $reconstructed->toArray());
+    }
+
+    public function testTooLongAttributeNameThrows(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $invalidName = str_repeat('a', Configuration::MAX_ATTRIBUTE_NAME_LENGTH + 1);
+        Configuration::create()->withFilterableAttributes([$invalidName]);
+    }
+
+    public function testToStringAndFromString(): void
+    {
+        $config = Configuration::create()->withPrimaryKey('custom_id');
+
+        $string = $config->toString();
+        $decoded = Configuration::fromString($string);
+
+        $this->assertSame($config->toArray(), $decoded->toArray());
+    }
+
+    public function testValidAttributeNameBoundary(): void
+    {
+        $validName = str_repeat('a', Configuration::MAX_ATTRIBUTE_NAME_LENGTH);
+        $config = Configuration::create()->withFilterableAttributes([$validName]);
+
+        $this->assertContains($validName, $config->getFilterableAttributes());
+    }
+}


### PR DESCRIPTION
This should help for tools like SEAL that may want to provide some `adapter: loupe://<serialized_config>` configuration value or so 😊 

/cc @alexander-schranz 