### PR TITLE
Improve performance of new query handling

### DIFF
--- a/src/Internal/Search/Sorting/MultiAttribute.php
+++ b/src/Internal/Search/Sorting/MultiAttribute.php
@@ -102,7 +102,7 @@ class MultiAttribute extends AbstractSorter
         return $engine->getConnection()->createQueryBuilder()
             ->addSelect(
                 $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS) . '.document AS document_id',
-                $this->aggregate->buildSql($column) . 'AS sort_order'
+                $this->aggregate->buildSql($column) . ' AS sort_order'
             )
             ->from(
                 IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,


### PR DESCRIPTION
Currently, all CTEs select the document which seems to be pretty slow on big documents.
I thought sqlite would optimize this but that does not seem to be the case. Now we're just fetching IDs and the document content is fetched only in during the final stages.

This brought a complex query of mine from 2.5s down to 0.5.