### PR TITLE
Make search parameters serializable

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -155,7 +155,7 @@ final class Configuration
 
     public static function fromString(string $string): self
     {
-        return self::fromArray(json_decode($string, true));
+        return self::fromArray(json_decode($string, true, 512, JSON_THROW_ON_ERROR));
     }
 
     /**
@@ -315,7 +315,7 @@ final class Configuration
 
     public function toString(): string
     {
-        return (string) json_encode($this->toArray());
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
     }
 
     public static function validateAttributeName(string $name): void

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -63,6 +63,83 @@ final class SearchParameters
     }
 
     /**
+     * @param array{
+     *     attributesToHighlight?: array<string>,
+     *     attributesToRetrieve?: array<string>,
+     *     attributesToSearchOn?: array<string>,
+     *     filter?: string,
+     *     highlightEndTag?: string,
+     *     highlightStartTag?: string,
+     *     hitsPerPage?: int,
+     *     page?: int,
+     *     query?: string,
+     *     rankingScoreThreshold?: float,
+     *     showMatchesPosition?: bool,
+     *     showRankingScore?: bool,
+     *     sort?: array<string>
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $instance = new self();
+
+        if (isset($data['attributesToHighlight'])) {
+            $instance = $instance->withAttributesToHighlight(
+                $data['attributesToHighlight'],
+                $data['highlightStartTag'] ?? '<em>',
+                $data['highlightEndTag'] ?? '</em>',
+            );
+        }
+
+        if (isset($data['attributesToRetrieve'])) {
+            $instance = $instance->withAttributesToRetrieve($data['attributesToRetrieve']);
+        }
+
+        if (isset($data['attributesToSearchOn'])) {
+            $instance = $instance->withAttributesToSearchOn($data['attributesToSearchOn']);
+        }
+
+        if (isset($data['filter'])) {
+            $instance = $instance->withFilter($data['filter']);
+        }
+
+        if (isset($data['hitsPerPage'])) {
+            $instance = $instance->withHitsPerPage($data['hitsPerPage']);
+        }
+
+        if (isset($data['page'])) {
+            $instance = $instance->withPage($data['page']);
+        }
+
+        if (isset($data['query'])) {
+            $instance = $instance->withQuery($data['query']);
+        }
+
+        if (isset($data['rankingScoreThreshold'])) {
+            $instance = $instance->withRankingScoreThreshold($data['rankingScoreThreshold']);
+        }
+
+        if (isset($data['showMatchesPosition'])) {
+            $instance = $instance->withShowMatchesPosition($data['showMatchesPosition']);
+        }
+
+        if (isset($data['showRankingScore'])) {
+            $instance = $instance->withShowRankingScore($data['showRankingScore']);
+        }
+
+        if (isset($data['sort'])) {
+            $instance = $instance->withSort($data['sort']);
+        }
+
+        return $instance;
+    }
+
+    public static function fromString(string $string): self
+    {
+        return self::fromArray(json_decode($string, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    /**
      * @return array<string>
      */
     public function getAttributesToHighlight(): array
@@ -159,6 +236,47 @@ final class SearchParameters
     public function showRankingScore(): bool
     {
         return $this->showRankingScore;
+    }
+
+    /**
+     * @return array{
+     *     attributesToHighlight: array<string>,
+     *     attributesToRetrieve: array<string>,
+     *     attributesToSearchOn: array<string>,
+     *     filter: string,
+     *     highlightEndTag: string,
+     *     highlightStartTag: string,
+     *     hitsPerPage: int,
+     *     page: int,
+     *     query: string,
+     *     rankingScoreThreshold: float,
+     *     showMatchesPosition: bool,
+     *     showRankingScore: bool,
+     *     sort: array<string>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'attributesToHighlight' => $this->attributesToHighlight,
+            'attributesToRetrieve' => $this->attributesToRetrieve,
+            'attributesToSearchOn' => $this->attributesToSearchOn,
+            'filter' => $this->filter,
+            'highlightEndTag' => $this->highlightEndTag,
+            'highlightStartTag' => $this->highlightStartTag,
+            'hitsPerPage' => $this->hitsPerPage,
+            'page' => $this->page,
+            'query' => $this->query,
+            'rankingScoreThreshold' => $this->rankingScoreThreshold,
+            'showMatchesPosition' => $this->showMatchesPosition,
+            'showRankingScore' => $this->showRankingScore,
+            'sort' => $this->sort,
+        ];
+    }
+
+    public function toString(): string
+    {
+        return json_encode($this->toArray(), JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -20,11 +20,51 @@ class SearchParametersTest extends TestCase
         );
     }
 
+    public function testImmutability(): void
+    {
+        $params = SearchParameters::create();
+        $newParams = $params->withPage(2);
+
+        $this->assertNotSame($params, $newParams);
+        $this->assertSame(1, $params->getPage());
+        $this->assertSame(2, $newParams->getPage());
+    }
+
     public function testMaxHitsPerPage(): void
     {
         $this->expectException(InvalidSearchParametersException::class);
         $this->expectExceptionMessage('Cannot request more than 1000 documents per request, use pagination.');
 
         SearchParameters::create()->withHitsPerPage(2000);
+    }
+
+    public function testToArrayAndFromArray(): void
+    {
+        $original = SearchParameters::create()
+            ->withQuery('hello world')
+            ->withPage(3)
+            ->withHitsPerPage(50)
+            ->withRankingScoreThreshold(0.25)
+            ->withFilter("status = 'active'")
+            ->withAttributesToRetrieve(['title', 'author'])
+            ->withAttributesToHighlight(['title'], '<strong>', '</strong>')
+            ->withAttributesToSearchOn(['title'])
+            ->withShowMatchesPosition(true)
+            ->withShowRankingScore(true)
+            ->withSort(['popularity:desc']);
+
+        $array = $original->toArray();
+        $reconstructed = SearchParameters::fromArray($array);
+
+        $this->assertSame($original->toArray(), $reconstructed->toArray());
+    }
+
+    public function testToStringAndFromString(): void
+    {
+        $params = SearchParameters::create()->withQuery('test');
+        $json = $params->toString();
+        $parsed = SearchParameters::fromString($json);
+
+        $this->assertSame($params->toArray(), $parsed->toArray());
     }
 }


### PR DESCRIPTION
Some more work on serialization. Now you can serialize both, the configuration and the search parameters which is e.g. useful when trying to copy the config and search parameters for a local debugging session etc.