### PR TITLE
Faster aggregate sorting

### DIFF
--- a/src/Internal/Search/Sorting.php
+++ b/src/Internal/Search/Sorting.php
@@ -20,7 +20,7 @@ class Sorting
     /**
      * @param array<AbstractSorter> $sorters
      */
-    public function __construct(
+    private function __construct(
         private Engine $engine,
         private array $sorters
     ) {
@@ -40,6 +40,7 @@ class Sorting
     {
         $sorters = [];
 
+        $i = 0;
         foreach ($sort as $v) {
             if (!\is_string($v)) {
                 throw new SortFormatException('Sort parameters must be an array of strings.');
@@ -65,9 +66,18 @@ class Sorting
                 throw SortFormatException::becauseNotSortable($chunks[0]);
             }
 
+            $sorter->setId(++$i);
             $sorters[] = $sorter;
         }
 
         return new self($engine, $sorters);
+    }
+
+    /**
+     * @return array<AbstractSorter>
+     */
+    public function getSorters(): array
+    {
+        return $this->sorters;
     }
 }

--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -13,9 +13,23 @@ use Loupe\Loupe\Internal\Search\Searcher;
 
 abstract class AbstractSorter
 {
+    private int $id = 0;
+
     abstract public function apply(Searcher $searcher, Engine $engine): void;
 
     abstract public static function fromString(string $value, Engine $engine, Direction $direction): self;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
 
     abstract public static function supports(string $value, Engine $engine): bool;
 


### PR DESCRIPTION
Instead of selecting all the possible attributes, we apply the aggregate sorters on filter level already so that when having many thousand matches, performance can be quite a bit better.