### PR TITLE
Update wamania/php-stemmer to 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-intl": "*",
         "ext-mbstring": "*",
         "doctrine/dbal": "^3.9 || ^4.0",
-        "wamania/php-stemmer": "^3.0",
+        "wamania/php-stemmer": "^4.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "mjaschen/phpgeo": "^5.0 || ^6.0",
         "toflar/state-set-index": "^3.0",


### PR DESCRIPTION
The 3.0.x versions still require voku/portable-utf8, which causes many deprecation warnings on PHP 8.4.