### PR TITLE
Fix crop and highlight used together

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -973,7 +973,7 @@ class Searcher
             $attributeOptions = $options;
 
             if (\in_array($attribute, $attributesToCrop, true)) {
-                $attributeOptions = $options->withEnableCrop();
+                $attributeOptions = $attributeOptions->withEnableCrop();
 
                 if (isset($this->queryParameters->getAttributesToCrop()[$attribute])) {
                     $attributeOptions = $attributeOptions->withCropLength($this->queryParameters->getAttributesToCrop()[$attribute]);
@@ -981,7 +981,7 @@ class Searcher
             }
 
             if (\in_array($attribute, $attributesToHighlight, true)) {
-                $attributeOptions = $options->withEnableHighlight();
+                $attributeOptions = $attributeOptions->withEnableHighlight();
             }
 
             if (\is_array($formatted[$attribute])) {

--- a/tests/Functional/Formatting/CroppingTest.php
+++ b/tests/Functional/Formatting/CroppingTest.php
@@ -167,7 +167,7 @@ class CroppingTest extends TestCase
             [
                 'overview' => 20,
             ],
-            [],
+            ['title', 'overview'],
             [
                 'hits' => [
                     [
@@ -178,7 +178,7 @@ class CroppingTest extends TestCase
                         '_formatted' => [
                             'id' => 24,
                             'title' => 'Kill Bill: Vol. 1',
-                            'overview' => 'An assassin is shot…their assassination circle…',
+                            'overview' => 'An <em>assassin</em> is shot…their <em>assassination</em> circle…',
                             'genres' => ['Action', 'Crime'],
                         ],
                     ],


### PR DESCRIPTION
Solve issue #199 which seems to be caused by two interlocking issues: 

1. The composition of formatting options was overwritten locally when both are used
2. The test used the wrong params so it looked like passing when actually it would fail 😩