### PR TITLE
Prevent SQLite from materializing the CTEs

### DIFF
--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -43,13 +43,13 @@ abstract class AbstractSorter
 
         $searcher->getQueryBuilder()
             ->innerJoin(
-                Searcher::CTE_MATCHES,
+                $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
                 $cteName,
                 $cteName,
                 sprintf(
                     '%s.document_id = %s.document_id',
                     $cteName,
-                    Searcher::CTE_MATCHES
+                    $searcher->addSuffixToCteName(Searcher::CTE_MATCHES)
                 )
             );
 

--- a/src/Internal/Search/Sorting/GeoPoint.php
+++ b/src/Internal/Search/Sorting/GeoPoint.php
@@ -35,11 +35,11 @@ class GeoPoint extends AbstractSorter
             ->from($cteName)
             ->innerJoin(
                 $cteName,
-                Searcher::CTE_MATCHES,
-                Searcher::CTE_MATCHES,
+                $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
+                $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
                 sprintf(
                     '%s.document_id = %s.document_id',
-                    Searcher::CTE_MATCHES,
+                    $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
                     $cteName
                 )
             )

--- a/src/Internal/Search/Sorting/SingleAttribute.php
+++ b/src/Internal/Search/Sorting/SingleAttribute.php
@@ -41,11 +41,11 @@ class SingleAttribute extends AbstractSorter
             )
             ->innerJoin(
                 $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-                Searcher::CTE_MATCHES,
-                Searcher::CTE_MATCHES,
+                $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
+                $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
                 sprintf(
                     '%s.document_id = %s.id',
-                    Searcher::CTE_MATCHES,
+                    $searcher->addSuffixToCteName(Searcher::CTE_MATCHES),
                     $engine->getIndexInfo()->getAliasForTable(
                         IndexInfo::TABLE_NAME_DOCUMENTS
                     )
@@ -53,7 +53,7 @@ class SingleAttribute extends AbstractSorter
             )
             ->groupBy('document_id');
 
-        $cteName = 'order_' . $this->attributeName;
+        $cteName = $searcher->addSuffixToCteName('order_' . $this->attributeName);
 
         $this->addAndOrderByCte($searcher, $engine, $this->direction, $cteName, $qb);
     }


### PR DESCRIPTION
This took me almost 4 full work days of debugging, running all sorts of debugging tools from blackfire on to valgrind, memprof etc.

The background is this: I have a worker process where Loupe is used to analyze log messages. This is a long running task that processes thousands of message for a minute. I noticed a memory leak, memory usage grew almost indefinitely causing my process to crash regularly.
However, I was unable to find any issue, blackfire always reported a normal memory usage. I was just seeing the memory grow using `htop` or `time -v`. So clearly, there was a leak but it was not from within PHP.

So after a ton of different approaches I think I finally found the issue: SQLite seems to be materializing all the CTEs because they have the same name and for as long as the process is running, it will seemingly add more and more information to internal memory structures. As far as I could see, we have absolutely no control over this behavior in PHP - neither when using `SQLite3` nor `PDO`.

This PR adds the `spl_object_id()` of the `Searcher` instance to all CTE names which fixes my issue somehow.
It's not the best fix because at some point - when the process is running really long - the object IDs can be re-used again and then probably things will start accumulating again because there will be identical CTE names.

As far as I can see, killing the PHP process is the only thing that will kill the things SQLite memorized.
Maybe this is a bug in PDO/SQLite3 (or any underlying library) but here's where my knowledge ends. 

I was also not able to create a simple reproducer. It seems like the queries have to be complex enough for SQLite to start materializing. According to https://sqlite.org/lang_with.html#materialization_hints, SQLite decides itself if a query should be materialized or not. 
Probably, this issue could also be fixed by adding the `AS NOT MATERIALIZED` hint on every CTE but that's only available as of SQLite 3.35.0 and I prefer the current solution to raising the minimum supported version at the moment.

But still, the thought of the fact that SQLite materializes CTEs for as long as the process runs puzzles me. Because this would always cause memory leaks for people using stuff like frankenphp (in worker mode) or Swoole etc. Maybe I'm missing something else.

Meaning, that I would expect the materialized data to be cleared, when I call `->close()` on the DB connections.