### PR TITLE
Always sort null and empty values last

### DIFF
--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -56,14 +56,15 @@ abstract class AbstractSorter
         $alias = $cteName . '.sort_order';
 
         // Because of how Loupe works (SQLite's loosely typed system) we need to always ensure that null and empty values
-        // are ordered (in the opposite way) first, so that they then match with the regular sorting
+        // are ordered ascending first.
+        // Null and empty values should always come last for Loupe (or generally speaking for any search engine probably).
         $searcher->getQueryBuilder()->addOrderBy(
             Operator::Equals->buildSql(
                 $engine->getConnection(),
                 $alias,
                 FilterValue::createNull()
             ),
-            $direction->opposite()->getSQL()
+            Direction::ASC->getSQL()
         );
 
         $searcher->getQueryBuilder()->addOrderBy(
@@ -72,7 +73,7 @@ abstract class AbstractSorter
                 $alias,
                 FilterValue::createEmpty()
             ),
-            $direction->opposite()->getSQL()
+            Direction::ASC->getSQL()
         );
 
         $searcher->getQueryBuilder()->addOrderBy($alias, $direction->getSQL());

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1028,6 +1028,16 @@ class SearchTest extends TestCase
             ['rating:asc', 'name:asc'],
             [
                 [
+                    'id' => 2,
+                    'name' => 'Indiana Jones',
+                    'rating' => 3.5,
+                ],
+                [
+                    'id' => 3,
+                    'name' => 'Jurassic Park',
+                    'rating' => 4,
+                ],
+                [
                     'id' => 5,
                     'name' => 'Back to the future',
                     'rating' => null,
@@ -1040,16 +1050,6 @@ class SearchTest extends TestCase
                 [
                     'id' => 1,
                     'name' => 'Star Wars',
-                ],
-                [
-                    'id' => 2,
-                    'name' => 'Indiana Jones',
-                    'rating' => 3.5,
-                ],
-                [
-                    'id' => 3,
-                    'name' => 'Jurassic Park',
-                    'rating' => 4,
                 ],
             ],
         ];


### PR DESCRIPTION
I think we're doing this wrong currently because when I sort by e.g. `title` alphabetically, then all the `null` and `''` (empty string) values come first.
I think this never makes sense from a search engine's perspective. They should always come last, no matter if I order `asc` or `desc`. If I don't want to have them in the result set at all, then I can `filter` them out but when I just search for `foobar` and want to order them alphabetically then those without a `title` should never appear first no matter if descending or ascending.

Or an other example for a `rating` property: If I order results descending, then I want the highest rated documents and never null values first. And if I order ascending, then I want the lowest rated documents, never null values first.
Again, if they should not be part of the result set at all then I filter them out but if I do not want to filter but just sort, then I never care about those without a rating at all. 

Wdyt @daun @alexander-schranz?