### PR TITLE
Introduced a memory helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ $searchParameters = SearchParameters::create()
 ;
 
 $results = $loupe->search($searchParameters);
+
+Loupe::freeMemory($loupe); // Force freeing memory and garbage collection, only needed in certain use cases (see performance docs)
 ```
 
 The `$results` array contains a list of search hits and metadata about the query.

--- a/src/Loupe.php
+++ b/src/Loupe.php
@@ -74,6 +74,13 @@ final class Loupe
         $this->engine->deleteDocuments($ids);
     }
 
+    public static function freeMemory(self &$loupe): void
+    {
+        StaticCache::cleanUp($loupe);
+        $loupe = null;
+        gc_collect_cycles();
+    }
+
     public function getConfiguration(): Configuration
     {
         StaticCache::enterContext($this);


### PR DESCRIPTION
Related to https://github.com/loupe-php/loupe/pull/209.

Honestly, the only way I could get Loupe to use a more or less consistent amount of memory is by triggering the GC after every `search()` so the connection to SQLite is cleaned and all the other stuff held in memory is cleaned up.