### PR TITLE
Increase the pack size for the stored state set

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -33,7 +33,7 @@ use Toflar\StateSetIndex\StateSetIndex;
 
 class Engine
 {
-    public const VERSION = '0.9.0'; // Increase this whenever a re-index of all documents is needed
+    public const VERSION = '0.12.0'; // Increase this whenever a re-index of all documents is needed
 
     private Parser $filterParser;
 

--- a/src/Internal/StateSetIndex/StateSet.php
+++ b/src/Internal/StateSetIndex/StateSet.php
@@ -80,7 +80,7 @@ class StateSet implements StateSetInterface
             return;
         }
 
-        file_put_contents($cacheFile, pack('N*', ...array_keys($stateSet)));
+        file_put_contents($cacheFile, pack('Q*', ...array_keys($stateSet)));
     }
 
     private function getStateSetCacheFile(): ?string
@@ -107,7 +107,7 @@ class StateSet implements StateSetInterface
                 $data = $this->loadFromStorage();
                 $this->dumpStateSetCache($data);
             } else {
-                $data = (array) unpack('N*', (string) file_get_contents($cacheFile));
+                $data = (array) unpack('Q*', (string) file_get_contents($cacheFile));
                 $data = array_combine($data, array_fill(0, \count($data), true));
             }
         }

--- a/tests/Unit/Internal/StateSetIndex/StateSetTest.php
+++ b/tests/Unit/Internal/StateSetIndex/StateSetTest.php
@@ -198,7 +198,7 @@ class StateSetTest extends TestCase
         sort($all);
 
         $dump = (string) file_get_contents($engine->getDataDir() . '/state_set.bin');
-        $dump = (array) unpack('N*', $dump);
+        $dump = (array) unpack('Q*', $dump);
         $dump = array_combine($dump, array_fill(0, \count($dump), true));
         sort($dump);
 


### PR DESCRIPTION
Depending on how you configure the typo tolerance alphabet size and index length, you can easily end up having states that exceed the 32bit maximum of 2^32 - 1. So let's switch to 64 bits here.

Wdyt @ausi? 