### PR TITLE
Fix and validate document schema before indexing

### DIFF
--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -81,7 +81,7 @@ class Indexer
 
         try {
             $this->engine->getConnection()
-                ->transactional(function () use ($indexInfo, $documents, &$successfulCount, &$documentExceptions) {
+                ->transactional(function () use ($documents, &$successfulCount, &$documentExceptions) {
                     foreach ($documents as $document) {
                         try {
                             $this->engine->getConnection()

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -48,6 +48,34 @@ class Indexer
             $indexInfo->setup($firstDocument);
         }
 
+        // Fix and validate all documents first to update the document schema if needed.
+        // Updating the schema locks the database so we don't want to do this while indexing (which can take quite a while)
+        $documentExceptions = [];
+
+        foreach ($documents as &$document) {
+            try {
+                $indexInfo->fixAndValidateDocument($document);
+            } catch (\Throwable $exception) {
+                if ($exception instanceof LoupeExceptionInterface) {
+                    $primaryKey = $document[$this->engine->getConfiguration()->getPrimaryKey()] ?? null;
+
+                    // We cannot report this exception on the document because the key is missing - we have to
+                    // abort early here.
+                    if ($primaryKey === null) {
+                        return new IndexResult(0, $documentExceptions, $exception);
+                    }
+
+                    $documentExceptions[$primaryKey] = $exception;
+                    continue;
+                }
+
+                throw new IndexException($exception->getMessage(), 0, $exception);
+            }
+        }
+        if ($documentExceptions !== []) {
+            return new IndexResult(0, $documentExceptions);
+        }
+
         $documentExceptions = [];
         $successfulCount = 0;
 
@@ -56,8 +84,6 @@ class Indexer
                 ->transactional(function () use ($indexInfo, $documents, &$successfulCount, &$documentExceptions) {
                     foreach ($documents as $document) {
                         try {
-                            $indexInfo->fixAndValidateDocument($document);
-
                             $this->engine->getConnection()
                                 ->transactional(function () use ($document) {
                                     $documentId = $this->createDocument($document);
@@ -170,7 +196,7 @@ class Indexer
                 continue;
             }
 
-            $data[$attribute] = LoupeTypes::convertValueToType($document[$attribute], $loupeType);
+            $data[$attribute] = LoupeTypes::convertValueToType($document[$attribute] ?? null, $loupeType);
         }
 
         // Markers for IS EMPTY and IS NULL filters on multi attributes

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -29,7 +29,7 @@ class IndexTest extends TestCase
                 ]),
             ],
             function (IndexResult $indexResult) {
-                self::assertSame(1, $indexResult->successfulDocumentsCount());
+                self::assertSame(0, $indexResult->successfulDocumentsCount());
                 self::assertSame(1, $indexResult->erroredDocumentsCount());
                 self::assertCount(1, $indexResult->allDocumentExceptions());
                 self::assertNull($indexResult->generalException());
@@ -54,7 +54,7 @@ class IndexTest extends TestCase
             ],
 
             function (IndexResult $indexResult) {
-                self::assertSame(2, $indexResult->successfulDocumentsCount());
+                self::assertSame(0, $indexResult->successfulDocumentsCount());
                 self::assertSame(1, $indexResult->erroredDocumentsCount());
                 self::assertCount(1, $indexResult->allDocumentExceptions());
                 self::assertNull($indexResult->generalException());

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -3008,6 +3008,7 @@ class SearchTest extends TestCase
             [
                 'id' => 5,
                 'name' => 'Back to the future',
+                'rating' => null,
             ],
         ]);
 


### PR DESCRIPTION
At the moment, we're validating the schema of every document while indexing. This can cause document schema updates within the transaction which will in turn then lock the database. So you cannot search while indexing is taking place (only if there are schema changes).

This PR changes this so that we're validating and fixing schema stuff first and only then we'll start indexing.

/cc @daun 