### PR TITLE
Use per-document transactions instead of one large batch transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note that some implementation details (e.g. libraries used) referenced in this b
 Performance depends on many factors but here are some ballpark numbers based on indexing the 
 [~32k movies fixture][MeiliSearch_Movies] provided by MeiliSearch.
 
-* **Indexing** will take a little over **90 seconds** (~350 documents per second)
+* **Indexing** will take around **230 seconds** (~140 documents per second)
 * **Querying** for `Amakin Dkywalker` with typo tolerance and relevance ranking takes about **100 ms**
 
 Note that anything above 50k documents is probably not a use case for Loupe. You can run your own benchmarks 

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -128,8 +128,8 @@ final class LoupeFactory implements LoupeFactoryInterface
             'PRAGMA mmap_size = 33554432',
             // Store temporary tables in memory instead of on disk
             'PRAGMA temp_store = MEMORY',
-            // Set timeout to 2 seconds to avoid locking issues
-            'PRAGMA busy_timeout = 2000',
+            // Set timeout to 5 seconds to avoid locking issues
+            'PRAGMA busy_timeout = 5000',
         ];
 
         foreach ($optimizations as $optimization) {


### PR DESCRIPTION
Right now the `Indexer` wraps large batches of documents (e.g. 100 or 1000 at once) in a single outer transaction. While this speeds up bulk indexing, it also means SQLite holds a write lock for the entire duration of that batch. Because SQLite only allows one writer at a time, this blocks any other process from adding documents until the batch finishes, causing lock contention and `database is locked` errors under concurrency.

By switching to one transaction per document, each write lock is held only for a very short time. The trade-off is that this slows down bulk indexing. But on the upside, it significantly improves concurrent behavior: multiple writers can take turns quickly, readers are not blocked (with WAL mode), and overall throughput under load is more predictable.

You can easily reproduce the issue right now: Just run `php bin/bench/index.php` concurrently (e.g. 3 processes), they will fail pretty much immediately. With this PR, they all complete successfully.

I'm proposing this change because I think this is more important than the indexing speed. If indexing speed is of the essence, using Loupe (aka a search engine that uses SQLite which allows only one writer at a time) is probably not the right decision anyway. You should opt for a different engine then.

Future plans: We should try to split the document processing (tokenization etc.) and the database writes into two separate steps so that writing to the database could happen in bigger batches and faster for even shorter locking times.