### PR TITLE
Functional tests to illustrate concurrency issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,17 +33,19 @@
         "loupe/matcher": "^0.2"
     },
     "require-dev": {
-        "symfony/var-dumper": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symplify/easy-coding-standard": "^12.6",
-        "symfony/finder": "^7.0",
+        "phpstan/phpstan": "^2.0",
         "phpunit/phpunit": "^10.5",
-        "phpstan/phpstan": "^2.0"
+        "symfony/filesystem": "^7.0",
+        "symfony/finder": "^7.0",
+        "symfony/process": "^7.0",
+        "symfony/var-dumper": "^7.0",
+        "symplify/easy-coding-standard": "^12.6"
     },
     "scripts": {
         "tests": "@php vendor/bin/phpunit",
         "unit-tests": "@php vendor/bin/phpunit --testsuite=unit",
         "functional-tests": "@php vendor/bin/phpunit --testsuite=functional",
+        "slow-tests": "@php vendor/bin/phpunit --testsuite=slow",
         "cs-fixer": "@php vendor/bin/ecs check --fix",
         "ci-cs-fixer": "@php vendor/bin/ecs check",
         "phpstan": "@php vendor/bin/phpstan analyse"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,9 @@
         <testsuite name="functional">
             <directory>tests/Functional</directory>
         </testsuite>
+        <testsuite name="slow">
+            <directory>tests/Slow</directory>
+        </testsuite>
     </testsuites>
 
     <source restrictDeprecations="true"

--- a/tests/Slow/ConcurrencyTest.php
+++ b/tests/Slow/ConcurrencyTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Slow;
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Tests\Functional\FunctionalTestTrait;
+use Loupe\Loupe\Tests\StorageFixturesTestTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+class ConcurrencyTest extends TestCase
+{
+    use FunctionalTestTrait;
+    use StorageFixturesTestTrait;
+
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = $this->createTemporaryDirectory();
+    }
+
+    public function testLoupeDoesNotGetStuckIfProcessIsKilled(): void
+    {
+        $processes = [
+            'worker-1' => $this->createWorkerProcess(500),
+            'worker-2' => $this->createWorkerProcess(500),
+            'worker-3' => $this->createWorkerProcess(0, [[
+                'id' => 'the-one-in-question',
+                'content' => 'Content of worker-3',
+            ]]),
+        ];
+
+        // Run all processes, then kill worker-2 and assert that the stuff from worker-3 still make it into Loupe
+        $this->runAndWaitForProcesses($processes, 'worker-2');
+
+        $loupe = $this->createLoupe(self::getConfiguration(), $this->tempDir);
+
+        $this->assertSame('Content of worker-3', $loupe->getDocument('the-one-in-question')['content'] ?? null);
+    }
+
+    public function testManyConcurrentProcesses(): void
+    {
+        $processes = [];
+
+        // Create 5 processes with 100 random documents which are all bigger in content so that indexing one document
+        // takes longer, showcasing that simply indexing one document after the other within its own transaction
+        // is not sufficient if there are too many concurrent processes.
+        for ($i = 1; $i <= 5; $i++) {
+            $processes['worker-' . $i] = $this->createWorkerProcess(100, [], [], 1000);
+        }
+
+        $this->runAndWaitForProcesses($processes);
+
+        $loupe = $this->createLoupe(self::getConfiguration(), $this->tempDir);
+
+        $this->assertSame(500, $loupe->countDocuments());
+    }
+
+    public function testTheLatestProcessWins(): void
+    {
+        $processes = [
+            // Worker 1 creates 500 random documents
+            'worker-1' => $this->createWorkerProcess(500),
+            // Worker 2 creates one specific document
+            'worker-2' => $this->createWorkerProcess(0, [[
+                'id' => 'the-one-in-question',
+                'content' => 'Content of worker-2',
+            ]]),
+            // Worker 3 overrides that specific document but first, it creates 1000 other documents so overriding happens last
+            'worker-3' => $this->createWorkerProcess(1000, [], [[
+                'id' => 'the-one-in-question',
+                'content' => 'Content of worker-3',
+            ]]),
+            // Worker 4 also wants to override that document, but it does it at the beginning
+            'worker-4' => $this->createWorkerProcess(0, [[
+                'id' => 'the-one-in-question',
+                'content' => 'Content of worker-4',
+            ]]),
+        ];
+
+        $this->runAndWaitForProcesses($processes);
+
+        $loupe = $this->createLoupe(self::getConfiguration(), $this->tempDir);
+
+        // Should have 1501 documents because 1500 random plus "the-one-in-question"
+        $this->assertSame(1501, $loupe->countDocuments());
+
+        // The last worker that was started is worker-4 so even though previous processes might take longer to complete,
+        // the last one that wanted to modify a document, must be the one that wins
+        $this->assertSame('Content of worker-4', $loupe->getDocument('the-one-in-question')['content'] ?? null);
+    }
+
+    /**
+     * @param array<array<string, mixed>> $preDocuments
+     * @param array<array<string, mixed>> $postDocuments
+     */
+    private function createWorkerProcess(int $numberOfRandomDocuments, array $preDocuments = [], array $postDocuments = [], int $numberOfWordsPerDocument = 100): Process
+    {
+        $command = [(new PhpExecutableFinder())->find(), __DIR__ . '/../bin/worker.php'];
+        $env = [
+            'LOUPE_FUNCTIONAL_TEST_TEMP_DIR' => $this->tempDir,
+            'LOUPE_FUNCTIONAL_TEST_CONFIGURATION' => self::getConfiguration()->toString(),
+            'LOUPE_FUNCTIONAL_TEST_NUMBER_OF_RANDOM_DOCUMENTS' => $numberOfRandomDocuments,
+            'LOUPE_FUNCTIONAL_TEST_PRE_DOCUMENTS' => json_encode($preDocuments),
+            'LOUPE_FUNCTIONAL_TEST_POST_DOCUMENTS' => json_encode($postDocuments),
+            'LOUPE_FUNCTIONAL_TEST_NUMBER_OF_WORDS_PER_DOCUMENT' => $numberOfWordsPerDocument,
+        ];
+
+        return new Process($command, env: $env, timeout: null);
+    }
+
+    private static function getConfiguration(): Configuration
+    {
+        return Configuration::create()
+            ->withSearchableAttributes(['content'])
+            ->withLanguages(['en'])
+        ;
+    }
+
+    /**
+     * @param array<string, Process> $processes
+     */
+    private function runAndWaitForProcesses(array $processes, string|null $processToKill = null): void
+    {
+        foreach ($processes as $process) {
+            usleep(500000); // 0.5 seconds to simulate incoming workers one after the other
+            $process->start();
+        }
+
+        if ($processToKill !== null) {
+            $processes[$processToKill]->stop(0);
+        }
+
+        // Wait for them to complete
+        $errors = [];
+        foreach ($processes as $processName => $process) {
+            $process->wait();
+
+            if ($processToKill !== null && $processToKill === $processName) {
+                continue;
+            }
+
+            if (!$process->isSuccessful()) {
+                $errors[] = \sprintf('[%s]: ', $processName) . $process->getOutput() . PHP_EOL . $process->getErrorOutput();
+            }
+        }
+
+        if ($errors !== []) {
+            $this->fail(implode(PHP_EOL, $errors));
+        }
+    }
+}

--- a/tests/bin/worker.php
+++ b/tests/bin/worker.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\LoupeFactory;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$env = getenv();
+$configuration = $env['LOUPE_FUNCTIONAL_TEST_CONFIGURATION'] ?? null;
+$tempDir = $env['LOUPE_FUNCTIONAL_TEST_TEMP_DIR'] ?? null;
+$numberOfRandomDocuments = (int) ($env['LOUPE_FUNCTIONAL_TEST_NUMBER_OF_RANDOM_DOCUMENTS'] ?? 0);
+$numberOfWordsPerDocument = (int) ($env['LOUPE_FUNCTIONAL_TEST_NUMBER_OF_WORDS_PER_DOCUMENT'] ?? 100);
+$preDocuments = json_decode($env['LOUPE_FUNCTIONAL_TEST_PRE_DOCUMENTS'] ?? '{}', true);
+$postDocuments = json_decode($env['LOUPE_FUNCTIONAL_TEST_POST_DOCUMENTS'] ?? '{}', true);
+
+$generateRandomWords = function () use ($numberOfWordsPerDocument): string {
+    static $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    $words = [];
+
+    for ($i = 0; $i < $numberOfWordsPerDocument; $i++) {
+        $length = rand(3, 10); // each word will be between 3–10 chars
+        $word = '';
+
+        for ($j = 0; $j < $length; $j++) {
+            $word .= $alphabet[rand(0, \strlen($alphabet) - 1)];
+        }
+
+        $words[] = $word;
+    }
+
+    return implode(' ', $words);
+};
+
+$generateDocuments = function (int $count) use ($generateRandomWords): array {
+    $documents = [];
+
+    for ($i = 0; $i < $count; $i++) {
+        $documents[] = [
+            'id' => uniqid(),
+            'content' => $generateRandomWords(),
+        ];
+    }
+
+    return $documents;
+};
+
+if (!$configuration || !$tempDir) {
+    echo 'Did not pass the expected environment variables for this test.';
+    exit(1);
+}
+
+try {
+    $configuration = Configuration::fromString($configuration);
+} catch (\Throwable $exception) {
+    echo 'Could not instantiate the configuration for this test: ' . $exception->getMessage();
+    exit(1);
+}
+
+try {
+    $loupeFactory = new LoupeFactory();
+    $loupe = $loupeFactory->create($tempDir, $configuration);
+} catch (\Throwable $exception) {
+    echo 'Could not instantiate the loupe factory for this test: ' . $exception->getMessage();
+    exit(1);
+}
+
+try {
+    $documents = array_merge(
+        $preDocuments,
+        $generateDocuments($numberOfRandomDocuments),
+        $postDocuments
+    );
+
+    $loupe->addDocuments($documents);
+} catch (\Throwable $exception) {
+    echo 'Could not add documents for this test: ' . $exception->getMessage();
+    exit(1);
+}
+
+exit(0);


### PR DESCRIPTION
The current version 0.12 mainly suffers from two key issues that I would like to improve in v0.13. In my opinion, these are also the things that still keep me from calling this a "stable software" and thus releasing version 1.0.

### 1st key issue: Concurrency handling

SQLite is great. Its flexibility and simplicity enabled a project like Loupe in the first place. However, there is one major issue: There cannot be multiple, concurrent writers. There can only ever be one process writing to an SQLite database. While in normal environments this is not an issue, it is for Loupe. Normally, writing to the database happens quickly in very short transactions. So if your writes take milliseconds like they normally do, you can have hundreds of concurrent writing processes. However, indexing thousands of documents can take pretty long. That means that one process can block another one or in worst case, cause the other one to abort due to `database locked` if it has to wait longer than `busy_timeout` which is currently set to 5 seconds. That's also why we currently index one document after the other in order to hopefully stay within the 5 seconds. This, however, is not a long term solution. Bigger documents (= taking longer to index) combined with a growing number of concurrent processes can still cause Loupe to fail.

### 2nd key issue: too much file I/O

Having this current workaround of one document per transaction **drastically** increases file I/O. 10,000 inserts = ~10,000 journal writes + ~10,000 fsyncs (or at least a large number of syncs depending on mode). Also, currently we do loads of UPSERT queries. So every single term or attribute value is UPSERTed in its own query. We do not batch insert data which also has a huge negative impact on the index speed.

### What does this PR do?

This PR is the first step towards v0.13. It provides the functional tests illustrating all the current issues (and also potential new issues) so we can do test-driven software development to fix all the failing tests. It includes 3 main tests:

1. Ensure correct order:
When `worker-1` is started before `worker-2`, it must be properly queued. If both want to write document ID `the-one-in-question`, `worker-2` **must** win over `worker-1` because it was triggered after. Currently if `worker-1` takes 1 minute to index, a concurrently running `worker-2` could index `the-one-in-question` before `worker-1` makes it to that document. This will cause `worker-1` to write **after** and thus win over `worker-2` which is wrong. 
2. Tolerate failing processes:
We will have to implement some queuing logic in some way. I plan to implement some "ticket" architecture. Meaning that every modifying process retrieves a ticket first, ensuring its position in the queue. It can then process whatever it wants once it is its turn. Once the process is done, it would update a second database (cannot use `loupe.db` because this one is potentially locked) to inform other processes that it's done and the next ticket can do whatever it wants to do. That should fix 1). However, if a process is killed for some reason, this would cause its ticket to be never acknowledged, hence causing all other processes to be blocked forever. We have to make this fail-proof which is covered in those functional tests as well now.
3. Tolerate bigger documents
All of this should allow not running into errors when documents take longer than 5 seconds to index. This currently fails which this PR also covers.

A nice side effect of those tests is that we can also compare the **indexing speed** between the current implementation and whatever solution I come up with.