### PR TITLE
Query SQLite version only once

### DIFF
--- a/src/Internal/ConnectionPool.php
+++ b/src/Internal/ConnectionPool.php
@@ -10,7 +10,8 @@ class ConnectionPool
 {
     public function __construct(
         public Connection $loupeConnection,
-        public Connection $ticketConnection
+        public Connection $ticketConnection,
+        public string $sqliteVersion,
     ) {
 
     }

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -43,8 +43,6 @@ class Engine
 
     private IndexInfo $indexInfo;
 
-    private string $sqliteVersion = '';
-
     private StateSetIndex $stateSetIndex;
 
     private StopwordsInterface $stopwords;
@@ -71,11 +69,6 @@ class Engine
         $this->stopwords = new InMemoryStopWords($this->configuration->getStopWords());
         $this->formatter = new Formatter(new Matcher($this->getTokenizer(), $this->stopwords));
         $this->filterParser = new Parser($this);
-        $this->sqliteVersion = match (true) {
-            \is_callable([$this->getConnection(), 'getServerVersion']) => $this->getConnection()->getServerVersion(), // @phpstan-ignore function.alreadyNarrowedType
-            (($nativeConnection = $this->getConnection()->getNativeConnection()) instanceof \SQLite3) => $nativeConnection->version()['versionString'],
-            (($nativeConnection = $this->getConnection()->getNativeConnection()) instanceof \PDO) => $nativeConnection->getAttribute(\PDO::ATTR_SERVER_VERSION),
-        };
     }
 
     /**
@@ -275,7 +268,7 @@ class Engine
         }
 
         // Use native UPSERT if possible
-        if (version_compare($this->sqliteVersion, '3.35.0', '>=')) {
+        if (version_compare($this->connectionPool->sqliteVersion, '3.35.0', '>=')) {
             $columns = [];
             $set = [];
             $values = [];

--- a/tests/Unit/Internal/StateSetIndex/StateSetTest.php
+++ b/tests/Unit/Internal/StateSetIndex/StateSetTest.php
@@ -226,7 +226,7 @@ class StateSetTest extends TestCase
             (new DsnParser())->parse((class_exists(\SQLite3::class) ? 'sqlite3' : 'pdo-sqlite') . '://notused:inthis@case/' . $ticketPath)
         );
 
-        $engine = new Engine(new ConnectionPool($connection, $ticketConnection), $configuration, new NullLogger(), $dir);
+        $engine = new Engine(new ConnectionPool($connection, $ticketConnection, '3.35.0'), $configuration, new NullLogger(), $dir);
         $indexInfo = $engine->getIndexInfo();
         if ($indexInfo->needsSetup()) {
             $indexInfo->setup([


### PR DESCRIPTION
Currently, we fetch the SQLite version always twice, that makes no sense.