### PR TITLE
Improve attribute name compatibility

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -178,7 +178,7 @@ class Engine
 
         $document = $this->getConnection()
             ->fetchOne(
-                \sprintf('SELECT document FROM %s WHERE user_id = :id', IndexInfo::TABLE_NAME_DOCUMENTS),
+                \sprintf('SELECT _document FROM %s WHERE _user_id = :id', IndexInfo::TABLE_NAME_DOCUMENTS),
                 [
                     'id' => LoupeTypes::convertToString($identifier),
                 ]

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -340,19 +340,19 @@ class IndexInfo
     {
         $table = $schema->createTable(self::TABLE_NAME_DOCUMENTS);
 
-        $table->addColumn('id', Types::INTEGER)
+        $table->addColumn('_id', Types::INTEGER)
             ->setNotnull(true)
             ->setAutoincrement(true)
         ;
 
-        $table->addColumn('user_id', Types::STRING)
+        $table->addColumn('_user_id', Types::STRING)
             ->setNotnull(true);
 
-        $table->addColumn('document', Types::TEXT)
+        $table->addColumn('_document', Types::TEXT)
             ->setNotnull(true);
 
-        $table->setPrimaryKey(['id']);
-        $table->addUniqueIndex(['user_id']);
+        $table->setPrimaryKey(['_id']);
+        $table->addUniqueIndex(['_user_id']);
 
         $columns = [];
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -112,7 +112,7 @@ class Indexer
         $this->recordChange(function () use ($ids): void {
             $this->engine->getConnection()
                 ->executeStatement(
-                    \sprintf('DELETE FROM %s WHERE user_id IN(:ids)', IndexInfo::TABLE_NAME_DOCUMENTS),
+                    \sprintf('DELETE FROM %s WHERE _user_id IN(:ids)', IndexInfo::TABLE_NAME_DOCUMENTS),
                     [
                         'ids' => LoupeTypes::convertToArrayOfStrings($ids),
                     ],
@@ -139,8 +139,8 @@ class Indexer
         $rows = [];
         foreach ($preparedDocuments->all() as $document) {
             $row = [
-                'user_id' => $document->getUserId(),
-                'document' => $document->getJsonEncodedDocumentData(),
+                '_user_id' => $document->getUserId(),
+                '_document' => $document->getJsonEncodedDocumentData(),
             ];
 
             foreach ($document->getSingleAttributes() as $attribute) {
@@ -155,8 +155,8 @@ class Indexer
         }
 
         $results = $this->engine->getBulkUpserterFactory()
-            ->create(BulkUpsertConfig::create(IndexInfo::TABLE_NAME_DOCUMENTS, $rows, ['user_id'], ConflictMode::Update)
-                ->withReturningColumns(['user_id', 'id']))
+            ->create(BulkUpsertConfig::create(IndexInfo::TABLE_NAME_DOCUMENTS, $rows, ['_user_id'], ConflictMode::Update)
+                ->withReturningColumns(['_user_id', '_id']))
             ->execute();
 
         $mapper = BulkUpserter::convertResultsToKeyValueArray($results);
@@ -627,7 +627,7 @@ class Indexer
     {
         // Clean up term-document relations of documents which no longer exist
         $query = \sprintf(
-            'DELETE FROM %s WHERE document NOT IN (SELECT id FROM %s)',
+            'DELETE FROM %s WHERE document NOT IN (SELECT _id FROM %s)',
             IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
             IndexInfo::TABLE_NAME_DOCUMENTS,
         );
@@ -636,7 +636,7 @@ class Indexer
 
         // Clean up multi-attribute-document relations of documents which no longer exist
         $query = \sprintf(
-            'DELETE FROM %s WHERE document NOT IN (SELECT id FROM %s)',
+            'DELETE FROM %s WHERE document NOT IN (SELECT _id FROM %s)',
             IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,
             IndexInfo::TABLE_NAME_DOCUMENTS,
         );

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -125,7 +125,7 @@ class FilterBuilder
         return $this->engine->getConnection()->createQueryBuilder()
             ->select(
                 \sprintf(
-                    '%s.id AS document_id',
+                    '%s._id AS document_id',
                     $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS)
                 )
             )
@@ -220,7 +220,7 @@ class FilterBuilder
             if (!\in_array($node->attribute, $this->engine->getIndexInfo()->getFilterableAttributes(), true)) {
                 if ($operator->isNegative()) {
                     // If the operator is negative, it means all documents match
-                    $froms[] = 'SELECT id AS document_id, document FROM documents';
+                    $froms[] = 'SELECT _id AS document_id, _document FROM documents';
                 } else {
                     // Otherwise, no document matches
                     $froms[] = 'SELECT document_id FROM (SELECT NULL AS document_id) WHERE 1 = 0';
@@ -228,7 +228,7 @@ class FilterBuilder
             } elseif ($this->engine->getIndexInfo()->isMultiFilterableAttribute($node->attribute)) {
                 $sortingSelects = $this->getSortingSelects($node->attribute);
                 $qb = $this->engine->getConnection()->createQueryBuilder();
-                $qb->select(\sprintf('%s.id AS document_id', $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS)));
+                $qb->select(\sprintf('%s._id AS document_id', $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS)));
                 foreach ($sortingSelects as $sortingSelect => $alias) {
                     $qb->addSelect($sortingSelect . ' AS ' . $alias);
                 }
@@ -250,7 +250,7 @@ class FilterBuilder
                         IndexInfo::TABLE_NAME_DOCUMENTS,
                         $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
                         \sprintf(
-                            '%s.id = %s.document',
+                            '%s._id = %s.document',
                             $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
                             $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS),
                         )
@@ -263,7 +263,7 @@ class FilterBuilder
                 if ($node->operator->isPositive()) {
                     $qb->andWhere($node->operator->buildSql($this->engine->getConnection(), $column, $node->value));
                 } else {
-                    $whereStatement = [$documentAlias . '.id NOT IN ('];
+                    $whereStatement = [$documentAlias . '._id NOT IN ('];
                     $whereStatement[] = $this->createSubQueryForMultiAttribute($node);
                     $whereStatement[] = ')';
                     $qb->andWhere(implode(' ', $whereStatement));
@@ -279,7 +279,7 @@ class FilterBuilder
                 $attribute = $node->attribute;
 
                 if ($attribute === $this->engine->getConfiguration()->getPrimaryKey()) {
-                    $attribute = 'user_id';
+                    $attribute = '_user_id';
                 }
 
                 $cteName = $this->addCTEForSingleAttribute($node, $operator->buildSql(
@@ -313,7 +313,7 @@ class FilterBuilder
                 $distanceCte,
                 $distanceCte,
                 \sprintf(
-                    '%s.document_id = %s.id',
+                    '%s.document_id = %s._id',
                     $distanceCte,
                     $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
                 )

--- a/src/Internal/Search/Sorting/SingleAttribute.php
+++ b/src/Internal/Search/Sorting/SingleAttribute.php
@@ -26,13 +26,13 @@ class SingleAttribute extends AbstractSorter
         }
 
         if ($attribute === $engine->getConfiguration()->getPrimaryKey()) {
-            $attribute = 'user_id';
+            $attribute = '_user_id';
         }
 
         $qb = $engine->getConnection()->createQueryBuilder();
         $qb
             ->select(
-                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS) . '.id AS document_id',
+                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS) . '._id AS document_id',
                 $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS) . '.' . $attribute . ' AS sort_order'
             )
             ->from(
@@ -44,7 +44,7 @@ class SingleAttribute extends AbstractSorter
                 Searcher::CTE_MATCHES,
                 Searcher::CTE_MATCHES,
                 \sprintf(
-                    '%s.document_id = %s.id',
+                    '%s.document_id = %s._id',
                     Searcher::CTE_MATCHES,
                     $engine->getIndexInfo()->getAliasForTable(
                         IndexInfo::TABLE_NAME_DOCUMENTS

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -204,6 +204,23 @@ class IndexTest extends TestCase
         ]);
     }
 
+    public function testCanUseUserIdAndDocumentProperties(): void
+    {
+        $configuration = Configuration::create()
+            ->withFilterableAttributes(['user_id', 'document'])
+        ;
+        $loupe = $this->createLoupe($configuration);
+
+        $document = [
+            'id' => 42,
+            'user_id' => 'my-id',
+            'document' => 'A38',
+        ];
+        $loupe->addDocument($document);
+
+        $this->assertSame($document, $loupe->getDocument(42));
+    }
+
     public function testDeleteAllDocuments(): void
     {
         $configuration = Configuration::create()


### PR DESCRIPTION
Currently, you cannot use `user_id` or `document` on your own documents, because we forgot to prefix those with an `_` (which is not allowed in custom attribute names for exactly that reason).