### PR TITLE
Fix change detection optimizer must only run if reindex is not needed

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -87,9 +87,9 @@ class IndexInfo
                     ],
                 ], ['key'], ConflictMode::Update))
                 ->execute();
-        });
 
-        $this->needsSetup = false;
+            $this->needsSetup = false;
+        });
     }
 
     /**


### PR DESCRIPTION
The 1:1 replacement optimization speeds up indexing a lot but we have to disable this, if a re-index is necessary because e.g. the configuration changed and thus, some attributes are now not searchable anymore etc.