### PR TITLE
Use packed arrays for better memory usage

### DIFF
--- a/src/Internal/Index/BulkUpserter/BulkUpsertConfig.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpsertConfig.php
@@ -14,11 +14,13 @@ class BulkUpsertConfig
     private array $returningColumns = [];
 
     /**
-     * @param non-empty-list<array<mixed>> $rows
+     * @param non-empty-list<string> $rowColumns
+     * @param non-empty-list<array<int, mixed>> $rows
      * @param non-empty-array<string> $uniqueColumns
      */
-    public function __construct(
+    private function __construct(
         private string $table,
+        private array $rowColumns,
         private array $rows,
         private array $uniqueColumns,
         private ConflictMode $conflictMode
@@ -28,12 +30,13 @@ class BulkUpsertConfig
     }
 
     /**
-     * @param non-empty-list<array<mixed>> $rows
+     * @param non-empty-list<string> $rowColumns
+     * @param non-empty-list<array<int, mixed>> $rows
      * @param non-empty-array<string> $uniqueColumns
      */
-    public static function create(string $table, array $rows, array $uniqueColumns, ConflictMode $conflictMode): self
+    public static function create(string $table, array $rowColumns, array $rows, array $uniqueColumns, ConflictMode $conflictMode): self
     {
-        return new self($table, $rows, $uniqueColumns, $conflictMode);
+        return new self($table, $rowColumns, $rows, $uniqueColumns, $conflictMode);
     }
 
     public function getChangeDetectingColumn(): ?string
@@ -55,7 +58,15 @@ class BulkUpsertConfig
     }
 
     /**
-     * @return non-empty-list<array<mixed>>
+     * @return non-empty-list<string>
+     */
+    public function getRowColumns(): array
+    {
+        return $this->rowColumns;
+    }
+
+    /**
+     * @return non-empty-list<array<int, mixed>>
      */
     public function getRows(): array
     {

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -76,16 +76,16 @@ class IndexInfo
 
         $this->engine->getIndexer()->recordChange(function () {
             $this->engine->getBulkUpserterFactory()
-                ->create(new BulkUpsertConfig(self::TABLE_NAME_INDEX_INFO, [
+                ->create(BulkUpsertConfig::create(
+                    self::TABLE_NAME_INDEX_INFO,
+                    ['key', 'value'],
                     [
-                        'key' => 'engineVersion',
-                        'value' => Engine::VERSION,
+                        ['engineVersion', Engine::VERSION],
+                        ['configHash', $this->engine->getConfiguration()->getIndexHash()],
                     ],
-                    [
-                        'key' => 'configHash',
-                        'value' => $this->engine->getConfiguration()->getIndexHash(),
-                    ],
-                ], ['key'], ConflictMode::Update))
+                    ['key'],
+                    ConflictMode::Update
+                ))
                 ->execute();
 
             $this->needsSetup = false;
@@ -574,10 +574,15 @@ class IndexInfo
             $this->updateSchema();
 
             $this->engine->getBulkUpserterFactory()
-                ->create(new BulkUpsertConfig(self::TABLE_NAME_INDEX_INFO, [[
-                    'key' => 'documentSchema',
-                    'value' => json_encode($documentSchema),
-                ]], ['key'], ConflictMode::Update))
+                ->create(BulkUpsertConfig::create(
+                    self::TABLE_NAME_INDEX_INFO,
+                    ['key', 'value'],
+                    [
+                        ['documentSchema', json_encode($documentSchema)],
+                    ],
+                    ['key'],
+                    ConflictMode::Update
+                ))
                 ->execute();
         });
     }

--- a/src/Internal/Index/PreparedDocument/MultiAttribute.php
+++ b/src/Internal/Index/PreparedDocument/MultiAttribute.php
@@ -7,7 +7,7 @@ namespace Loupe\Loupe\Internal\Index\PreparedDocument;
 class MultiAttribute
 {
     /**
-     * @param array<string|float> $values
+     * @param array<string|float|bool> $values
      */
     public function __construct(
         private string $name,
@@ -21,7 +21,7 @@ class MultiAttribute
     }
 
     /**
-     * @return float[]|string[]
+     * @return float[]|string[]|bool[]
      */
     public function getValues(): array
     {


### PR DESCRIPTION
This makes reading the code a bit harder but instead of using keyed arrays we use packed arrays now which frees up a lot of memory. 

`develop`: Indexed in 55.70 s using 224.06 MiB
`PR`: Indexed in 56.49 s using 204.06 MiB

More memory work to come.