### PR TITLE
Use an iterator instead of array_chunk()

### DIFF
--- a/src/Internal/Index/BulkUpserter/BulkUpserter.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserter.php
@@ -7,6 +7,7 @@ namespace Loupe\Loupe\Internal\Index\BulkUpserter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
+use Loupe\Loupe\Internal\Util;
 
 class BulkUpserter
 {
@@ -62,7 +63,7 @@ class BulkUpserter
         $chunkSize = max((int) round($this->variableLimit / \count($this->bulkUpsertConfig->getRowColumns()), 0, PHP_ROUND_HALF_DOWN), 1);
         $results = [];
 
-        foreach (array_chunk($this->bulkUpsertConfig->getRows(), $chunkSize) as $chunk) {
+        foreach (Util::arrayChunk($this->bulkUpsertConfig->getRows(), $chunkSize) as $chunk) {
             $rows = $this->normalizeRows($chunk);
             // Modern path: INSERT .. ON CONFLICT .. DO UPDATE [RETURNING]
             $results = [...$results, ...$this->executeModern($rows, $updateColumns)];

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -73,7 +73,7 @@ class Indexer
 
         // Now index the documents in chunks as preparing too many documents and keeping it all in memory before
         // inserting would result in too much memory usage.
-        foreach (array_chunk($documents, self::MAX_DOCS_PER_BATCH) as $batch) {
+        foreach (Util::arrayChunk($documents, self::MAX_DOCS_PER_BATCH) as $batch) {
             $preparedDocuments = new PreparedDocumentCollection();
             foreach ($batch as $document) {
                 $preparedDocuments->add($this->prepareDocument($document));

--- a/src/Internal/Util.php
+++ b/src/Internal/Util.php
@@ -9,6 +9,36 @@ use Loupe\Loupe\Exception\InvalidJsonException;
 class Util
 {
     /**
+     * This is a slightly more memory-efficient alternative to array_chunk().
+     * @param non-empty-array<array<mixed>> $array
+     * @return \Generator<non-empty-list<array<mixed>>>
+     */
+    public static function arrayChunk(array $array, int $size): \Generator
+    {
+        if ($size <= 0) {
+            throw new \InvalidArgumentException('Chunk size must be greater than 0.');
+        }
+
+        $chunk = [];
+        $count = 0;
+
+        foreach ($array as $value) {
+            $chunk[] = $value;
+            $count++;
+
+            if ($count === $size) {
+                yield $chunk;
+                $chunk = [];
+                $count = 0;
+            }
+        }
+
+        if ($count > 0) {
+            yield $chunk;
+        }
+    }
+
+    /**
      * @return array<mixed>
      */
     public static function decodeJson(string $data): array


### PR DESCRIPTION
This shaves off another 8 MB of RAM from `php bin/bench/index.php` while only being 0.5s slower which might also just be a random result. The memory improvement, however, is consistent.