### PR TITLE
Also chunk terms

### DIFF
--- a/src/Internal/Index/BulkUpserter/BulkUpserter.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserter.php
@@ -75,7 +75,7 @@ class BulkUpserter
     }
 
     /**
-     * @param non-empty-list<array<mixed>> $rows
+     * @param array<array<string, mixed>> $rows
      * @param array<string> $columns
      * @param array<int<0, max>|string, mixed> $parameters
      */
@@ -93,7 +93,7 @@ class BulkUpserter
     }
 
     /**
-     * @param non-empty-list<array<mixed>> $rows
+     * @param array<array<string, mixed>> $rows
      * @param array<string> $updateColumns
      * @return array<mixed>
      */
@@ -169,8 +169,8 @@ class BulkUpserter
     }
 
     /**
-     * @param non-empty-list<array<mixed>> $rows
-     * @return non-empty-list<array<string, mixed>>
+     * @param array<array<mixed>> $rows
+     * @return array<array<string, mixed>>
      */
     private function normalizeRows(array $rows): array
     {

--- a/src/Internal/Index/PreparedDocumentCollection.php
+++ b/src/Internal/Index/PreparedDocumentCollection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Index;
 
+use Loupe\Loupe\Internal\Util;
+
 class PreparedDocumentCollection
 {
     /**
@@ -16,8 +18,8 @@ class PreparedDocumentCollection
      */
     public function __construct(array $documents = [])
     {
-        foreach ($documents as $token) {
-            $this->add($token);
+        foreach ($documents as $document) {
+            $this->add($document);
         }
     }
 
@@ -44,6 +46,16 @@ class PreparedDocumentCollection
         return array_map(static function (PreparedDocument $document) {
             return $document->getInternalId();
         }, $this->documents);
+    }
+
+    /**
+     * @return \Generator<PreparedDocumentCollection>
+     */
+    public function chunk(int $size): \Generator
+    {
+        foreach (Util::arrayChunk($this->documents, $size) as $documents) {
+            yield new self($documents);
+        }
     }
 
     public function count(): int

--- a/src/Internal/Util.php
+++ b/src/Internal/Util.php
@@ -10,8 +10,10 @@ class Util
 {
     /**
      * This is a slightly more memory-efficient alternative to array_chunk().
-     * @param non-empty-array<array<mixed>> $array
-     * @return \Generator<non-empty-list<array<mixed>>>
+     *
+     * @template T
+     * @param array<T> $array
+     * @return \Generator<array<T>>
      */
     public static function arrayChunk(array $array, int $size): \Generator
     {


### PR DESCRIPTION
We're now also chunking the terms when indexing which has a huge impact on the memory usage.

The numbers for chunking are chosen more or less randomly. They apply to the number of documents which is not accurate at all of course. You could have 1000 small documents or 10 really big documents.

I also thought about not chunking at all and leaving it entirely to the users but that resulted in very bad results because the only thing developers can influence is the number of documents they pass to `addDocuments()`. So still, it could be that users add 10 really big documents and they have no way of making sure that Loupe chunks the terms correctly.
So I really want to handle this internally.

But maybe we can somehow chunk based on the number of terms instead of just the number of documents. I guess that's what I'll try next.
But here's to end the day (we started out at over `220 MB` of RAM):

`develop`: Indexed in 61.40 s using 154.50 MiB
`This PR`: Indexed in 62.07 s using 116.50 MiB