### PR TITLE
Split indexing into chunks by number of terms instead of documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Note that some implementation details (e.g. libraries used) referenced in this b
 Performance depends on many factors but here are some ballpark numbers based on indexing the 
 [~32k movies fixture][MeiliSearch_Movies] provided by MeiliSearch.
 
-* **Indexing** will take around **32 seconds** (~1000 documents per second)
-* **Querying** for `Amakin Dkywalker` with typo tolerance and relevance ranking takes about **100 ms**
+* **Querying** for `Amakin Dkywalker` with typo tolerance and relevance ranking takes about **70 ms**
+* **Indexing** will take around **60 seconds** (this varies greatly because it depends on how much content per document
+  you want to index
 
 Note that anything above 50k documents is probably not a use case for Loupe. You can run your own benchmarks 
 using the scripts in the `bin/bench` folder: `index.php` for indexing and `search.php` for searching. 

--- a/src/Internal/Index/PreparedDocument.php
+++ b/src/Internal/Index/PreparedDocument.php
@@ -82,6 +82,11 @@ final class PreparedDocument
         return $this->terms;
     }
 
+    public function getTermsCount(): int
+    {
+        return \count($this->terms);
+    }
+
     public function getUserId(): string
     {
         return $this->userId;


### PR DESCRIPTION
I think this concludes my quest for making Loupe the best version it can be for `0.13`.
I now consider the memory issues to be fixed when I compare it to the `250 MB` used on some version a few days ago:

```
Indexed in 61.27 s using 100.50 MiB
```

😎 

Also, when I updated the stats in the `README.md` I noticed, that searching is now way faster as well 🤯
This seemed odd to me because I mainly worked on indexing, not on the querying part so I checked the blackfire comparisons and...drum roll...it's because of `pdo-sqlite` being **way faster** than the `sqlite3` extension 😊 

So by changing the requirements we not only get way faster and optimized indexing but also an over `40%` speed improvement on querying 🥳 🚀 
I'll sum up some of the performance stats when releasing `0.13`.