### PR TITLE
Set synchronous to OFF

### DIFF
--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -119,6 +119,10 @@ final class LoupeFactory implements LoupeFactoryInterface
             'PRAGMA temp_store = MEMORY',
             // Set timeout to 5 seconds to avoid locking issues
             'PRAGMA busy_timeout = ' . self::SQLITE_BUSY_TIMEOUT,
+            // Loupe is a search index. It contains volatile data by definition so if there's a power outage
+            // that could leave our database in a corrupt state, we don't care. It can always be re-built by
+            // a full re-index. Hence, we set synchronous to OFF which reduces disk writes dramatically.
+            'PRAGMA synchronous = OFF',
         ];
 
         foreach ($optimizations as $optimization) {


### PR DESCRIPTION
Noticed that when indexing huge amounts of data, there are disk writes up to 1 GB happening. I checked the SQLite docs a bit and it seems to me like this is due to `synchronous` being set to `NORMAL` or `FULL` (we don't set it now so it depends on the system's defaults).

I think, as Loupe is not meant to be used as persistent storage but only for volatile data, we can even set this to `OFF`. This dramatically reduces the disk writes.

Can anybody confirm this? (You can use `php bin/bench/index.php` with the 32k movies and monitor with your favorite disk monitoring utility).

/cc @daun @alexander-schranz