### PR TITLE
Use the new binary mode of nitotm/efficient-language-detector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "mjaschen/phpgeo": "^5.0 || ^6.0",
         "toflar/state-set-index": "^3.0",
         "psr/log": "^2.0 || ^3.0",
-        "nitotm/efficient-language-detector": "^3.0",
+        "nitotm/efficient-language-detector": "^3.1",
         "loupe/matcher": "^0.2.1"
     },
     "require-dev": {

--- a/src/Internal/LanguageDetection/NitotmLanguageDetector.php
+++ b/src/Internal/LanguageDetection/NitotmLanguageDetector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\LanguageDetection;
 
+use Nitotm\Eld\EldDataFile;
+use Nitotm\Eld\EldMode;
+use Nitotm\Eld\EldScheme;
 use Nitotm\Eld\LanguageDetector;
 
 class NitotmLanguageDetector implements LanguageDetectorInterface
@@ -75,7 +78,11 @@ class NitotmLanguageDetector implements LanguageDetectorInterface
     private function getLanguageDetector(): LanguageDetector
     {
         if ($this->languageDetector === null) {
-            $this->languageDetector = new LanguageDetector();
+            $this->languageDetector = new LanguageDetector(
+                EldDataFile::LARGE, // Large is actually faster than small, see https://github.com/nitotm/efficient-language-detector/issues/15
+                EldScheme::ISO639_1,
+                EldMode::MODE_BYTES, // Use bytes mode which requires less memory but is still fast enough for our use case
+            );
             $this->languageDetector->enableTextCleanup(true); // Clean stuff like URLs, domains etc. to improve language detection
             $this->languageDetector->langSubset($this->languages); // Use the subset (unfortunately this is still loading the "small" ngrams set as well, see https://github.com/nitotm/efficient-language-detector/issues/15)
         }


### PR DESCRIPTION
This adjusts to the new execution modes released yesterday: https://github.com/nitotm/efficient-language-detector/releases/tag/v3.1.0

We can now use the `large` database instead of `small` and still reduce the `80 MB` RAM to `40 MB` with only a very little performance penalty - this is exactly the mode we need for Loupe 🥳 