### PR TITLE
Weigh detected document language against content length

### DIFF
--- a/src/Internal/LanguageDetection/NitotmLanguageDetector.php
+++ b/src/Internal/LanguageDetection/NitotmLanguageDetector.php
@@ -29,10 +29,18 @@ class NitotmLanguageDetector implements LanguageDetectorInterface
         $bestScoresPerLanguage = [];
         $languagePerAttribute = [];
         foreach ($document as $attribute => $value) {
+            if ($value === '') {
+                continue;
+            }
+
             $languageResult = $this->getLanguageDetector()->detect($value);
+            $weight = log(mb_strlen($value) + 1);
 
             // Store the best score per language
             foreach ($languageResult->scores() as $lang => $score) {
+                // Weigh longer texts higher because scores will be more precise
+                $score = $score * $weight;
+
                 if (isset($bestScoresPerLanguage[$lang])) {
                     $bestScoresPerLanguage[$lang] = max($bestScoresPerLanguage[$lang], $score);
                 } else {
@@ -84,7 +92,7 @@ class NitotmLanguageDetector implements LanguageDetectorInterface
                 EldMode::MODE_BYTES, // Use bytes mode which requires less memory but is still fast enough for our use case
             );
             $this->languageDetector->enableTextCleanup(true); // Clean stuff like URLs, domains etc. to improve language detection
-            $this->languageDetector->langSubset($this->languages); // Use the subset (unfortunately this is still loading the "small" ngrams set as well, see https://github.com/nitotm/efficient-language-detector/issues/15)
+            $this->languageDetector->langSubset($this->languages);
         }
 
         return $this->languageDetector;

--- a/tests/Unit/Internal/LanguageDetection/NitotmLanguageDetectorTest.php
+++ b/tests/Unit/Internal/LanguageDetection/NitotmLanguageDetectorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit\Internal\LanguageDetection;
+
+use Loupe\Loupe\Internal\LanguageDetection\NitotmLanguageDetector;
+use PHPUnit\Framework\TestCase;
+
+class NitotmLanguageDetectorTest extends TestCase
+{
+    public function testWeightedLanguageDetection(): void
+    {
+        $detector = new NitotmLanguageDetector([]);
+        $detectionResult = $detector->detectForDocument([
+            'title' => 'Die Hard', // If we wouldn't weigh, this entire document would be detected as "nl" because "Die Hard" looks very Dutch apparently
+            'overview' => 'NYPD cop John McClane\'s plan to reconcile with his estranged wife is thrown for a serious loop when, minutes after he arrives at her office, the entire building is overtaken by a group of terrorists. With little help from the LAPD, wisecracking McClane sets out to single-handedly rescue the hostages and bring the bad guys down.',
+        ]);
+
+        $this->assertSame('en', $detectionResult->getBestLanguageForAttribute('overview'));
+        $this->assertSame('en', $detectionResult->getBestLanguageForDocument());
+    }
+}


### PR DESCRIPTION
This improves language detection. Currently we consider the highest score in all attributes for the best language for the entire document (which is used as fallback, if the detection of an attribute is not reliable). This, however, produces nonsense. For example `Die Hard` is detected as being `nl` with a score of `0.73556907664029`.
The entire `overview` is detected as `en` with a score of `0.67265363592984`.
Hence, we choose the best language for this document to be `nl` which is of course nonsense.

This PR introduces a weighting on the length of `$value` so that longer content gets weighted more because language detection is obviously better when there are more ngrams to check 😊 