### PR TITLE
Fix unconditional DISTINCT in filter/sort-only queries

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1013,7 +1013,7 @@ class Searcher
     {
         $froms = [];
         $qbMatches = $this->engine->getConnection()->createQueryBuilder();
-        $qbMatches->select('document_id')->distinct();
+        $qbMatches->select('document_id');
 
         // User filters
         $froms[] = $this->filterBuilder->buildFrom();
@@ -1038,6 +1038,13 @@ class Searcher
             $qbMatches->from('(' . $froms[0] . ')');
         } else {
             $qbMatches->from('(' . implode(' INTERSECT ', $froms) . ')');
+        }
+
+        if (!$tokenCollection->empty()) {
+            // Keep DISTINCT here for SQLite performance. Even though the upstream queries already produce one row per
+            // document in practice, making that uniqueness explicit helps SQLite choose a better plan for the final
+            // matches CTE. Removing DISTINCT keeps the results correct, but performs slower.
+            $qbMatches->distinct();
         }
 
         $this->addCTE(new Cte(self::CTE_MATCHES, ['document_id'], $qbMatches));


### PR DESCRIPTION
Closes #271 

`Searcher::filterDocuments()` applied `->distinct()` unconditionally, even for filter-only or sort-only operations where duplicates should not occur. This caused SQLite to materialize the CTE and build additional temporary indexes unnecessarily.

This change makes `DISTINCT` conditional: it is now applied only when a token collection is present, as duplicate rows should only arise from token-based queries (e.g., full-text matching).

**Benchmarks**
Included are two new benchmarks that can be used to test performance for sort and filter-sort only operations.

| Scenario | Before | After |
|---|---|---|
| Sort only | ~66 ms | ~35 ms |
| Filter Sort | ~50 ms | ~30 ms |
