### PR TITLE
Handle nonexistent data directory on startup

### DIFF
--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -8,6 +8,11 @@ use Loupe\Loupe\Configuration;
 
 class InvalidConfigurationException extends \InvalidArgumentException implements LoupeExceptionInterface
 {
+    public static function becauseRequiredDataDirMissing(): self
+    {
+        return new self('Data directory argument is required and cannot be empty.');
+    }
+
     public static function becauseCouldNotCreateDataDir(string $folder): self
     {
         return new self(

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -8,11 +8,6 @@ use Loupe\Loupe\Configuration;
 
 class InvalidConfigurationException extends \InvalidArgumentException implements LoupeExceptionInterface
 {
-    public static function becauseRequiredDataDirMissing(): self
-    {
-        return new self('Data directory argument is required and cannot be empty.');
-    }
-
     public static function becauseCouldNotCreateDataDir(string $folder): self
     {
         return new self(
@@ -32,5 +27,10 @@ class InvalidConfigurationException extends \InvalidArgumentException implements
                 $attributeName
             )
         );
+    }
+
+    public static function becauseRequiredDataDirMissing(): self
+    {
+        return new self('Data directory argument is required and cannot be empty.');
     }
 }

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -22,13 +22,17 @@ final class LoupeFactory implements LoupeFactoryInterface
 
     public function create(string $dataDir, Configuration $configuration): Loupe
     {
-        $dataDir = (string) realpath($dataDir);
+        if ($dataDir === '') {
+            throw InvalidConfigurationException::becauseRequiredDataDirMissing();
+        }
 
         if (!is_dir($dataDir)) {
-            if (!mkdir($dataDir, 0777, true)) {
+            if (!@mkdir($dataDir, 0777, true)) {
                 throw InvalidConfigurationException::becauseCouldNotCreateDataDir($dataDir);
             }
         }
+
+        $dataDir = (string) realpath($dataDir);
 
         return $this->createFromConnectionPool(
             $this->createConnectionPool($configuration, $dataDir),

--- a/tests/Unit/LoupeFactoryTest.php
+++ b/tests/Unit/LoupeFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Loupe\Tests\Unit;
 
 use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Exception\InvalidConfigurationException;
 use Loupe\Loupe\Loupe;
 use Loupe\Loupe\LoupeFactory;
 use Loupe\Loupe\Tests\StorageFixturesTestTrait;
@@ -26,5 +27,44 @@ class LoupeFactoryTest extends TestCase
         $configuration = Configuration::create();
         $client = (new LoupeFactory())->create($this->createTemporaryDirectory(), $configuration);
         $this->assertInstanceOf(Loupe::class, $client);
+    }
+
+    public function testEmptyStringDataDirThrows(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Data directory argument is required and cannot be empty.');
+
+        (new LoupeFactory())->create('', Configuration::create());
+    }
+
+    public function testNonExistentDataDirIsCreatedAutomatically(): void
+    {
+        $dataDir = $this->createTemporaryDirectory() . '/' . uniqid();
+        $this->assertDirectoryDoesNotExist($dataDir);
+
+        $loupe = (new LoupeFactory())->create($dataDir, Configuration::create());
+
+        $this->assertDirectoryExists($dataDir);
+        $this->assertInstanceOf(Loupe::class, $loupe);
+    }
+
+    public function testNestedDataDirIsCreatedAutomatically(): void
+    {
+        $dataDir = $this->createTemporaryDirectory() . '/' . uniqid() . '/a/b/c';
+        $this->assertDirectoryDoesNotExist($dataDir);
+
+        $loupe = (new LoupeFactory())->create($dataDir, Configuration::create());
+
+        $this->assertDirectoryExists($dataDir);
+        $this->assertInstanceOf(Loupe::class, $loupe);
+    }
+
+    public function testUncreatableDataDirThrows(): void
+    {
+        $dataDir = '/this_root_path_cannot_exist_' . uniqid('', true) . '/subdir';
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new LoupeFactory())->create($dataDir, Configuration::create());
     }
 }

--- a/tests/Unit/LoupeFactoryTest.php
+++ b/tests/Unit/LoupeFactoryTest.php
@@ -15,6 +15,14 @@ class LoupeFactoryTest extends TestCase
 {
     use StorageFixturesTestTrait;
 
+    public function testEmptyStringDataDirThrows(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Data directory argument is required and cannot be empty.');
+
+        (new LoupeFactory())->create('', Configuration::create());
+    }
+
     public function testInMemoryClient(): void
     {
         $configuration = Configuration::create();
@@ -22,19 +30,15 @@ class LoupeFactoryTest extends TestCase
         $this->assertInstanceOf(Loupe::class, $client);
     }
 
-    public function testPersistedClient(): void
+    public function testNestedDataDirIsCreatedAutomatically(): void
     {
-        $configuration = Configuration::create();
-        $client = (new LoupeFactory())->create($this->createTemporaryDirectory(), $configuration);
-        $this->assertInstanceOf(Loupe::class, $client);
-    }
+        $dataDir = $this->createTemporaryDirectory() . '/' . uniqid() . '/a/b/c';
+        $this->assertDirectoryDoesNotExist($dataDir);
 
-    public function testEmptyStringDataDirThrows(): void
-    {
-        $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('Data directory argument is required and cannot be empty.');
+        $loupe = (new LoupeFactory())->create($dataDir, Configuration::create());
 
-        (new LoupeFactory())->create('', Configuration::create());
+        $this->assertDirectoryExists($dataDir);
+        $this->assertInstanceOf(Loupe::class, $loupe);
     }
 
     public function testNonExistentDataDirIsCreatedAutomatically(): void
@@ -48,15 +52,11 @@ class LoupeFactoryTest extends TestCase
         $this->assertInstanceOf(Loupe::class, $loupe);
     }
 
-    public function testNestedDataDirIsCreatedAutomatically(): void
+    public function testPersistedClient(): void
     {
-        $dataDir = $this->createTemporaryDirectory() . '/' . uniqid() . '/a/b/c';
-        $this->assertDirectoryDoesNotExist($dataDir);
-
-        $loupe = (new LoupeFactory())->create($dataDir, Configuration::create());
-
-        $this->assertDirectoryExists($dataDir);
-        $this->assertInstanceOf(Loupe::class, $loupe);
+        $configuration = Configuration::create();
+        $client = (new LoupeFactory())->create($this->createTemporaryDirectory(), $configuration);
+        $this->assertInstanceOf(Loupe::class, $client);
     }
 
     public function testUncreatableDataDirThrows(): void


### PR DESCRIPTION
Close #273 and make sure nonexistent data directories are created during setup. Currently, it fails with an exception.

The issue was that `realpath` returns `false` for nonexistent paths. That means an existing path was unintentionally required since a nonexistent path would lead to calling `mkdir` with `false` as its argument. By shuffling things around and calling `realpath` after creating any folders, this is avoided.

Also defines behavior around an empty data dir argument: throw a configuration exception. One option would have been to fall back to `cwd`, but I figure it's better to make this explicit in the consumer code.
