### PR TITLE
Use GLOB for instead of LIKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note that some implementation details (e.g. libraries used) referenced in this b
 Performance depends on many factors but here are some ballpark numbers based on indexing the 
 [~32k movies fixture][MeiliSearch_Movies] provided by MeiliSearch.
 
-* **Querying** for `Amakin Dkywalker` with typo tolerance and relevance ranking takes about **35 ms**
+* **Querying** for `Amakin Dkywalker` with typo tolerance and relevance ranking takes about **26 ms**
 * **Indexing** will take around **60 seconds** (this varies greatly because it depends on how much content per document
   you want to index
 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -913,9 +913,9 @@ class Searcher
 
         if ($prefixLikeOnly) {
             $qb->where(\sprintf(
-                '%s.term LIKE %s',
+                '%s.term GLOB %s',
                 $termsAlias,
-                $this->createNamedParameter($term . '%')
+                $this->createNamedParameter($term . '*')
             ));
         } else {
             $qb->where($this->createWherePartForTerm($term, $prefix, $disableTypoTolerance));
@@ -944,7 +944,7 @@ class Searcher
          *
          * With prefix:
          *
-         *     (term = '<term>' OR term LIKE '<term>%')
+         *     (term = '<term>' OR term GLOB '<term>*')
          */
         if ($prefix) {
             $where[] = '(';
@@ -960,9 +960,9 @@ class Searcher
         if ($prefix) {
             $where[] = 'OR';
             $where[] = \sprintf(
-                '%s.term LIKE %s',
+                '%s.term GLOB %s',
                 $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS),
-                $this->createNamedParameter($term . '%')
+                $this->createNamedParameter($term . '*')
             );
             $where[] = ')';
         }


### PR DESCRIPTION
Did you know `LIKE` is case-insensitive by default in SQLite and thus cannot make use of an index by default? Yeah, I learned this too today while analyzing the query planner. It kept saying it needs to do a full table scan for `LIKE 'foobar%'`.

Seems like this is for historical reasons: https://sqlite.org/lang_expr.html#like

So a simple switch to `GLOB` (which uses `*` instead of `%`) which is case sensitive activates the use of the binary index and again, we are faster! 🚀 
What a day 🤣 