### PR TITLE
Consider folding state in exactness ranking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "toflar/state-set-index": "^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
-        "loupe/matcher": "dev-fix/remember-folding-state as 0.2.3"
+        "loupe/matcher": "^0.2.3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1.31",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "toflar/state-set-index": "^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
-        "loupe/matcher": "^0.2.2"
+        "loupe/matcher": "dev-fix/remember-folding-state as 0.2.3"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1.31",

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -36,7 +36,7 @@ use Toflar\StateSetIndex\StateSetIndex;
 
 class Engine
 {
-    public const VERSION = '0.13.0'; // Increase this whenever a re-index of all documents is needed
+    public const VERSION = '0.13.1'; // Increase this whenever a re-index of all documents is needed
 
     private const DEPENDENCY_HASH_RELEVANT_PACKAGES = [
         'wamania/php-stemmer', // Stemming algorithms might change

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -556,6 +556,9 @@ class IndexInfo
         $table->addColumn('end', Types::INTEGER)
             ->setNotnull(true);
 
+        $table->addColumn('folded', Types::BOOLEAN)
+            ->setNotnull(true);
+
         $table->setPrimaryKey(['term', 'document', 'attribute', 'position']);
         $table->addIndex(['document']);
         $table->addIndex(['position']);

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -422,7 +422,7 @@ class Indexer
                 return;
             }
 
-            // Key is the term, 0 the "document" (id), 1 the "attribute" (as string), 2 the "position", 3 the "start", 4 the "end" of the match - need to optimize for memory here
+            // Key is the term, 0 the "document" (id), 1 the "attribute" (as string), 2 the "position", 3 the "start", 4 the "end" of the match, 5 if folded - need to optimize for memory here
             $termsMapper = [];
             // 0 is the "term" (as string), 1 the "length", 2 the "state" - need to optimize for memory here
             $rows = [];
@@ -432,7 +432,7 @@ class Indexer
             foreach ($preparedDocuments->all() as $document) {
                 foreach ($document->getTerms() as $term) {
                     $rows[] = [$term->getTerm(), $term->getTermLength(), 0];
-                    $termsMapper[$term->getTerm()][] = [$document->getInternalId(), $term->getAttribute(), $term->getPosition(), $term->getStart(), $term->getEnd()];
+                    $termsMapper[$term->getTerm()][] = [$document->getInternalId(), $term->getAttribute(), $term->getPosition(), $term->getStart(), $term->getEnd(), $term->isVariant()];
 
                     // Prefix relevant terms must not be variants
                     if ($indexPrefixes && !$term->isVariant()) {
@@ -491,7 +491,7 @@ class Indexer
             $this->engine->getBulkUpserterFactory()
                 ->create(BulkUpsertConfig::create(
                     IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
-                    ['document', 'attribute', 'position', 'start', 'end', 'term'],
+                    ['document', 'attribute', 'position', 'start', 'end', 'folded', 'term'],
                     $relationRows,
                     ['term', 'document', 'attribute', 'position'],
                     ConflictMode::Ignore
@@ -688,11 +688,11 @@ class Indexer
             $termPosition = 1;
             foreach ($tokenCollection->all() as $token) {
                 // Index the main term
-                $terms[] = new Term($token->getTerm(), $attributeName, $termPosition, $token->getOriginalStartPosition(), $token->getOriginalEndPosition(), false);
+                $terms[] = new Term($token->getTerm(), $attributeName, $termPosition, $token->getOriginalStartPosition(), $token->getOriginalEndPosition(), $token->wasFolded());
 
                 // Index variants
                 foreach ($token->getVariants() as $termVariant) {
-                    $terms[] = new Term($termVariant, $attributeName, $termPosition, $token->getOriginalStartPosition(), $token->getOriginalEndPosition(), false);
+                    $terms[] = new Term($termVariant, $attributeName, $termPosition, $token->getOriginalStartPosition(), $token->getOriginalEndPosition(), true);
                 }
 
                 ++$termPosition;

--- a/src/Internal/Search/Ranking/TermPositions.php
+++ b/src/Internal/Search/Ranking/TermPositions.php
@@ -35,9 +35,9 @@ class TermPositions
             if ($term->hasMatches()) {
                 $this->totalMatchingTerms++;
 
-                $this->totalNumberOfTypos += $totalNumberOfTypos = $term->getLowestNumberOfTypos();
+                $this->totalNumberOfTypos += $term->getLowestNumberOfTypos();
 
-                if ($totalNumberOfTypos === 0) {
+                if ($term->hasExactMatch()) {
                     $this->totalExactMatchingTerms++;
                 }
 
@@ -68,6 +68,8 @@ class TermPositions
         }
 
         foreach (explode(';', $positionsInDocumentPerTerm) as $termSearchedFor) {
+            [$termSearchedFor, $hasExactMatch] = array_pad(explode('|', $termSearchedFor, 2), 2, null);
+
             // Document did not match this term
             if ($termSearchedFor === '0') {
                 $terms[] = new Term([]);
@@ -76,17 +78,22 @@ class TermPositions
 
             $attributePositions = [];
             $termMatches = [];
+            $shouldInferExactMatch = $hasExactMatch === null;
+            $hasExactMatch = $hasExactMatch === '1';
 
             foreach (explode(',', $termSearchedFor) as $positionAttributeCombination) {
-                [$position, $attribute, $numberOfTypos] = explode(':', $positionAttributeCombination, 3);
+                [$position, $attribute, $numberOfTypos, $foldingMismatch] = array_pad(explode(':', $positionAttributeCombination, 4), 4, '0');
                 $attributePositions[$attribute][] = new Position((int) $position, (int) $numberOfTypos);
+                if ($shouldInferExactMatch) {
+                    $hasExactMatch = $hasExactMatch || ((int) $numberOfTypos === 0 && $foldingMismatch === '0');
+                }
             }
 
             foreach ($attributePositions as $attribute => $positions) {
                 $termMatches[] = new TermMatch($attribute, $positions);
             }
 
-            $terms[] = new Term($termMatches);
+            $terms[] = new Term($termMatches, $hasExactMatch);
         }
 
         return new self($terms);

--- a/src/Internal/Search/Ranking/TermPositions.php
+++ b/src/Internal/Search/Ranking/TermPositions.php
@@ -68,10 +68,10 @@ class TermPositions
         }
 
         foreach (explode(';', $positionsInDocumentPerTerm) as $termSearchedFor) {
-            [$termSearchedFor, $hasExactMatch] = array_pad(explode('|', $termSearchedFor, 2), 2, null);
+            [$positionsForTerm, $hasExactMatch] = array_pad(explode('|', $termSearchedFor, 2), 2, null);
 
             // Document did not match this term
-            if ($termSearchedFor === '0') {
+            if ($positionsForTerm === '0') {
                 $terms[] = new Term([]);
                 continue;
             }
@@ -81,7 +81,7 @@ class TermPositions
             $shouldInferExactMatch = $hasExactMatch === null;
             $hasExactMatch = $hasExactMatch === '1';
 
-            foreach (explode(',', $termSearchedFor) as $positionAttributeCombination) {
+            foreach (explode(',', $positionsForTerm ?? '0') as $positionAttributeCombination) {
                 [$position, $attribute, $numberOfTypos, $foldingMismatch] = array_pad(explode(':', $positionAttributeCombination, 4), 4, '0');
                 $attributePositions[$attribute][] = new Position((int) $position, (int) $numberOfTypos);
                 if ($shouldInferExactMatch) {

--- a/src/Internal/Search/Ranking/TermPositions/Term.php
+++ b/src/Internal/Search/Ranking/TermPositions/Term.php
@@ -10,7 +10,8 @@ class Term
      * @param array<TermMatch> $termMatches
      */
     public function __construct(
-        private array $termMatches
+        private array $termMatches,
+        private bool $hasExactMatch = false
     ) {
     }
 
@@ -39,6 +40,11 @@ class Term
     public function getMatches(): array
     {
         return $this->termMatches;
+    }
+
+    public function hasExactMatch(): bool
+    {
+        return $this->hasExactMatch;
     }
 
     public function hasMatches(): bool

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -563,22 +563,38 @@ class Searcher
         $cteSelectQb->addSelect($termsDocumentsAlias . '.position');
         $cteSelectQb->addSelect($termsDocumentsAlias . '.start');
         $cteSelectQb->addSelect($termsDocumentsAlias . '.end');
+        $needsFoldingState = $this->needsFoldingState();
+        $needsTypoCount = $this->needsTypoCount();
+        $termsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS);
 
-        if ($this->needsTypoCount()) {
+        if ($needsTypoCount) {
             $cteSelectQb->addSelect(\sprintf(
                 'MIN(loupe_levensthein(%s.term, %s, %s)) AS typos',
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS),
+                $termsAlias,
                 $this->createNamedParameter($token->getTerm()),
                 $this->engine->getConfiguration()->getTypoTolerance()->firstCharTypoCountsDouble() ? 'true' : 'false'
             ));
+        } else {
+            $cteSelectQb->addSelect('0 AS typos');
+        }
+
+        if ($needsFoldingState) {
+            $cteSelectQb->addSelect(\sprintf(
+                'MAX(CASE WHEN %s.term = %s AND %s.folded = %s THEN 1 ELSE 0 END) AS exact_match',
+                $termsAlias,
+                $this->createNamedParameter($token->getTerm()),
+                $termsDocumentsAlias,
+                $token->wasFolded() ? '1' : '0'
+            ));
+        }
+
+        if ($needsTypoCount || $needsFoldingState) {
             $cteSelectQb->innerJoin(
                 $termsDocumentsAlias,
                 IndexInfo::TABLE_NAME_TERMS,
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS),
-                \sprintf('%s.id = %s.term', $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS), $termsDocumentsAlias)
+                $termsAlias,
+                \sprintf('%s.id = %s.term', $termsAlias, $termsDocumentsAlias)
             );
-        } else {
-            $cteSelectQb->addSelect('0 AS typos');
         }
 
         $cteSelectQb->from(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS, $termsDocumentsAlias);
@@ -624,7 +640,9 @@ class Searcher
 
         $this->addCTE(new Cte(
             $cteName,
-            ['document', 'attribute', 'position', 'start', 'end', 'typos'],
+            $needsFoldingState ?
+                ['document', 'attribute', 'position', 'start', 'end', 'typos', 'exact_match'] :
+                ['document', 'attribute', 'position', 'start', 'end', 'typos'],
             $cteSelectQb
         ));
     }
@@ -1234,6 +1252,11 @@ class Searcher
 
         $this->queryBuilder->setFirstResult($offset);
         $this->queryBuilder->setMaxResults($limit);
+    }
+
+    private function needsFoldingState(): bool
+    {
+        return \in_array('exactness', $this->engine->getConfiguration()->getRankingRules(), true);
     }
 
     /**

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -44,6 +44,7 @@ class Relevance extends AbstractSorter
 
         $ctes = [];
         $relevances = [];
+        $needsFoldingState = \in_array('exactness', $engine->getConfiguration()->getRankingRules(), true);
 
         foreach ($tokens as $token) {
             $cteName = $searcher->getCTENameForToken(Searcher::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
@@ -62,7 +63,6 @@ class Relevance extends AbstractSorter
                 // COALESCE() makes sure that if the token does not match a document, we don't have NULL but a 0 which is important
                 // for the relevance split. Otherwise, the relevance calculation cannot know which of the documents did not match
                 // because it's just a ";" separated list.
-                ->addSelect("COALESCE(group_concat(DISTINCT dm.position || ':' || dm.attribute || ':' || dm.typos), '0' ) AS relevance")
                 ->from(Searcher::CTE_MATCHES)
                 ->leftJoin(
                     Searcher::CTE_MATCHES,
@@ -71,6 +71,12 @@ class Relevance extends AbstractSorter
                     \sprintf('dm.document = %s.document_id', Searcher::CTE_MATCHES)
                 )
                 ->groupBy(Searcher::CTE_MATCHES . '.document_id');
+
+            if ($needsFoldingState) {
+                $qb->addSelect("COALESCE(group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos), '0') || '|' || COALESCE(MAX(dm.exact_match), 0) AS relevance");
+            } else {
+                $qb->addSelect("COALESCE(group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos), '0' ) AS relevance");
+            }
 
             $searcher->addCTE(new Cte($termRelevanceCTE, ['document_id', 'relevance_per_term'], $qb));
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2424,6 +2424,63 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testRelevanceAndRankingScoreForLengthChangingFolding(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['name'])
+            ->withSortableAttributes(['name']);
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'name' => 'Die große Straße',
+            ],
+            [
+                'id' => 2,
+                'name' => 'Die grosse Strasse',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('die große straße')
+            ->withAttributesToRetrieve(['name']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'name' => 'Die große Straße',
+                ],
+                [
+                    'name' => 'Die grosse Strasse',
+                ],
+            ],
+            'query' => 'die große straße',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 2,
+        ]);
+
+        $searchParameters = $searchParameters->withQuery('die grosse strasse');
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'name' => 'Die grosse Strasse',
+                ],
+                [
+                    'name' => 'Die große Straße',
+                ],
+            ],
+            'query' => 'die grosse strasse',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 2,
+        ]);
+    }
+
     public function testRelevanceAndRankingScoreForNonExistentQueryTerms(): void
     {
         $configuration = Configuration::create()

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2486,6 +2486,84 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testRelevanceAndRankingScoreForNormalizedSpelling(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['name'])
+            ->withSortableAttributes(['name']);
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'name' => 'Thomas Müller',
+            ],
+            [
+                'id' => 2,
+                'name' => 'Thomas Muller',
+            ],
+            [
+                'id' => 3,
+                'name' => 'Sandra Mûllêr',
+            ],
+            [
+                'id' => 4,
+                'name' => 'Sandra Muller',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('thomas müller')
+            ->withAttributesToRetrieve(['name']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'name' => 'Thomas Müller',
+                ],
+                [
+                    'name' => 'Thomas Muller',
+                ],
+                [
+                    'name' => 'Sandra Mûllêr',
+                ],
+                [
+                    'name' => 'Sandra Muller',
+                ],
+            ],
+            'query' => 'thomas müller',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 4,
+        ]);
+
+        // Test without umlaut
+        $searchParameters = $searchParameters->withQuery('sandra muller');
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'name' => 'Sandra Muller',
+                ],
+                [
+                    'name' => 'Sandra Mûllêr',
+                ],
+                [
+                    'name' => 'Thomas Muller',
+                ],
+                [
+                    'name' => 'Thomas Müller',
+                ],
+            ],
+            'query' => 'sandra muller',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 4,
+        ]);
+    }
+
     public function testRelevanceAndRankingScoreWithAttributeWeights(): void
     {
         $documents = [

--- a/tests/Unit/Internal/Search/Ranking/AttributeWeightTest.php
+++ b/tests/Unit/Internal/Search/Ranking/AttributeWeightTest.php
@@ -14,37 +14,37 @@ class AttributeWeightTest extends TestCase
     public static function attributeWeightProvider(): \Generator
     {
         yield 'No attributes are weighted' => [
-            '1:title:1,2:summary:1',
+            '1:title:1:0,2:summary:1:0',
             '',
             1.0,
         ];
 
         yield 'No attributes are matched' => [
-            '1:title:1,2:summary:1',
+            '1:title:1:0,2:summary:1:0',
             'unknown_attribute',
             1.0,
         ];
 
         yield 'All attributes are equal' => [
-            '1:title:1,2:summary:1',
+            '1:title:1:0,2:summary:1:0',
             '*',
             1.0,
         ];
 
         yield 'Attributes are applied when found' => [
-            '1:title:1',
+            '1:title:1:0',
             'title:summary',
             1.0,
         ];
 
         yield 'Attributes are applied when found later in list' => [
-            '1:non_existent:1,2:summary:1',
+            '1:non_existent:1:0,2:summary:1:0',
             'title:summary',
             0.8,
         ];
 
         yield 'Terms found in multiple attributes are applied the highest factor' => [
-            '1:title:1,2:summary:1',
+            '1:title:1:0,2:summary:1:0',
             'title:summary',
             1.0,
         ];

--- a/tests/Unit/Internal/Search/Ranking/ExactnessTest.php
+++ b/tests/Unit/Internal/Search/Ranking/ExactnessTest.php
@@ -18,23 +18,28 @@ class ExactnessTest extends TestCase
             0.0,
         ];
 
-        yield 'Zero typos means exact match' => [
-            '1:title:0',
+        yield 'Zero typos without normalization mismatch means exact match' => [
+            '1:title:0:0',
             1.0,
         ];
 
+        yield 'Zero typos with normalization mismatch is not an exact match' => [
+            '1:title:0:1',
+            0,
+        ];
+
         yield 'One typo is not an exact match' => [
-            '1:title:1',
+            '1:title:1:0',
             0,
         ];
 
         yield 'Five typos is also not an exact match' => [
-            '1:title:5',
+            '1:title:5:0',
             0,
         ];
 
         yield 'One term matches exactly, the other does not' => [
-            '1:title:0;3:title:3',
+            '1:title:0:0;3:title:3:0',
             0.5,
         ];
     }

--- a/tests/Unit/Internal/Search/Ranking/ProximityTest.php
+++ b/tests/Unit/Internal/Search/Ranking/ProximityTest.php
@@ -14,13 +14,13 @@ class ProximityTest extends TestCase
     public static function proximityFactorProvider(): \Generator
     {
         yield 'All terms are adjacent' => [
-            '1:attribute:1;2:attribute:1;3:attribute:1',
+            '1:attribute:1:0;2:attribute:1:0;3:attribute:1:0',
             0.1,
             1.0, // All distances are 1, so result is 1
         ];
 
         yield 'Non-adjacent terms' => [
-            '1:attribute:1;3:attribute:1;5:attribute:1',
+            '1:attribute:1:0;3:attribute:1:0;5:attribute:1:0',
             0.1,
             (exp(-0.1 * 2) + exp(-0.1 * 2)) / 2,
         ];
@@ -32,31 +32,31 @@ class ProximityTest extends TestCase
         ];
 
         yield 'Single term' => [
-            '1:attribute:1',
+            '1:attribute:1:0',
             0.1,
             1.0, // One match, must be 1
         ];
 
         yield 'Multiple positions per term, only closest must be considered' => [
-            '1:attribute:1,4:attribute:1;6:attribute:1,10:attribute:1',
+            '1:attribute:1:0,4:attribute:1:0;6:attribute:1:0,10:attribute:1:0',
             0.1,
             (exp(-0.1 * 5)),
         ];
 
         yield 'Higher decay factor' => [
-            '1:attribute:1;4:attribute:1',
+            '1:attribute:1:0;4:attribute:1:0',
             0.5,
             exp(-0.5 * 3), // Only one pair, distance is 3
         ];
 
         yield 'Lots of terms but all in the correct order' => [
-            '1:attribute:1,7:attribute:1,12:attribute:1;2:attribute:1,7:attribute:1;3:attribute:1,5:attribute:1,8:attribute:1,19:attribute:1,28:attribute:1;4:attribute:1;3:attribute:1,5:attribute:1,8:attribute:1,19:attribute:1,28:attribute:1;6:attribute:1;2:attribute:1,7:attribute:1;3:attribute:1,5:attribute:1,8:attribute:1,19:attribute:1,28:attribute:1;9:attribute:1;10:attribute:1',
+            '1:attribute:1:0,7:attribute:1:0,12:attribute:1:0;2:attribute:1:0,7:attribute:1:0;3:attribute:1:0,5:attribute:1:0,8:attribute:1:0,19:attribute:1:0,28:attribute:1:0;4:attribute:1:0;3:attribute:1:0,5:attribute:1:0,8:attribute:1:0,19:attribute:1:0,28:attribute:1:0;6:attribute:1:0;2:attribute:1:0,7:attribute:1:0;3:attribute:1:0,5:attribute:1:0,8:attribute:1:0,19:attribute:1:0,28:attribute:1:0;9:attribute:1:0;10:attribute:1:0',
             0.1,
             1,
         ];
 
         yield 'Attributes must be considered' => [
-            '1:attribute:1;2:other_attribute:1,3:attribute:1', // Here we searched for 2 terms and the second matched in "other_attribute" at position 2 and in "attribute" at position 3, so we have to test that the distance is 2 between attribute!
+            '1:attribute:1:0;2:other_attribute:1:0,3:attribute:1:0', // Here we searched for 2 terms and the second matched in "other_attribute" at position 2 and in "attribute" at position 3, so we have to test that the distance is 2 between attribute!
             0.1,
             exp(-0.1 * 2), // "other_attribute" is not relevant, the best match is in "attribute" and we have a distance of 2
         ];

--- a/tests/Unit/Internal/Search/Ranking/TypoCountTest.php
+++ b/tests/Unit/Internal/Search/Ranking/TypoCountTest.php
@@ -26,17 +26,17 @@ class TypoCountTest extends TestCase
         ];
 
         yield 'Zero typo match' => [
-            '1:title:0',
+            '1:title:0:0',
             1.0,
         ];
 
         yield 'One typo' => [
-            '1:title:1',
+            '1:title:1:0',
             exp(-0.1 * 1),
         ];
 
         yield 'Always lowest amount of typos is considered' => [
-            '1:title:1,2:summary:2;3:summary:1', // Two terms, the first one matched in "title" (1 typo) and "summary" (2 typos), the second in "summary" with 1 typo. So 2 typos in total.
+            '1:title:1:0,2:summary:2:0;3:summary:1:0', // Two terms, the first one matched in "title" (1 typo) and "summary" (2 typos), the second in "summary" with 1 typo. So 2 typos in total.
             exp(-0.1 * 2),
         ];
     }

--- a/tests/Unit/Internal/Search/Ranking/WordCountTest.php
+++ b/tests/Unit/Internal/Search/Ranking/WordCountTest.php
@@ -26,17 +26,17 @@ class WordCountTest extends TestCase
         ];
 
         yield 'One of three terms matches' => [
-            '1:title:1;0;0',
+            '1:title:1:0;0;0',
             1 / 3,
         ];
 
         yield 'Two of three terms match' => [
-            '1:title:1;2:summary:1;0',
+            '1:title:1:0;2:summary:1:0;0',
             2 / 3,
         ];
 
         yield 'All terms match' => [
-            '1:title:1;2:summary:1;3:summary:1',
+            '1:title:1:0;2:summary:1:0;3:summary:1:0',
             1,
         ];
     }


### PR DESCRIPTION
Attempt to fix https://github.com/loupe-php/loupe/issues/286.
Requires https://github.com/loupe-php/matcher/pull/19

This will have a slight performance impact as the `exactness` ranking algorithm now does more work - which is expected, I guess 😊 

/cc @daun - can you check if that fixes the issue? I've used your tests in this PR but maybe there's other stuff I missed.