### PR TITLE
Fix phrase matching when token appears multiple times

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -626,7 +626,7 @@ class Searcher
         // Ensure phrase positions if any
         if ($token->isPartOfPhrase() && $previousPhraseToken) {
             $cteSelectQb->andWhere(\sprintf(
-                '%s.position = (SELECT position + 1 FROM %s WHERE document=td.document AND attribute=td.attribute)',
+                '%s.position IN (SELECT position + 1 FROM %s WHERE document=td.document AND attribute=td.attribute)',
                 $termsDocumentsAlias,
                 $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken),
             ));

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2182,6 +2182,40 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testPhraseSearchWorksWithRepeatedTerms(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title']);
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'title' => 'Gone With the Wind: The Wind Blows No More',
+            ],
+        ]);
+
+        // "she" appears multiple times and might throw off a single position check
+        $searchParameters = SearchParameters::create()
+            ->withQuery('"the wind blows"')
+            ->withAttributesToRetrieve(['id', 'title']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 1,
+                    'title' => 'Gone With the Wind: The Wind Blows No More',
+                ],
+            ],
+            'query' => '"the wind blows"',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+    }
+
     /**
      * @param array<mixed> $expectedResults
      */

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -2196,7 +2196,6 @@ class SearchTest extends TestCase
             ],
         ]);
 
-        // "she" appears multiple times and might throw off a single position check
         $searchParameters = SearchParameters::create()
             ->withQuery('"the wind blows"')
             ->withAttributesToRetrieve(['id', 'title']);


### PR DESCRIPTION
Phrase group search skips results if a term of the phrase already appeared somewhere earlier in an attribute. This changes the logic to consider all possible candidates. Fixes #290.

## Cause

The searcher only considers the first occurrence of a term for checking against valid positions as part of the phrase (`=` comparison). Switching to `IN` and considering all results from the subquery leads to the expected behavior.

```diff
- %s.position = (SELECT position + 1 FROM %s WHERE document=td.document AND attribute=td.attribute)
+ %s.position IN (SELECT position + 1 FROM %s WHERE document=td.document AND attribute=td.attribute)
```

## Example

Title: `Gone With the Wind: The Wind Blows No More`

Search: `"the wind"` ✅
Expected: 1 result
Observed: 1 result
Works: both terms in the group are the first appearance in the attribute

Search: `"wind blows"` 🛑
Expected: 1 result
Observed: 0 results
Fails: "wind" already appears once in the attribute before the phrase that should match