### PR TITLE
Configurable matching strategy: require all terms

### DIFF
--- a/docs/searching.md
+++ b/docs/searching.md
@@ -42,6 +42,21 @@ $searchParameters = \Loupe\Loupe\SearchParameters::create()
 Hint: Note that your query is stripped if it's very long. See the section about [maximum query tokens in the 
 configuration settings][Config].
 
+## Matching strategy
+
+By default, a search will match any documents that match at least one of the query terms. You can change this behavior by configuring a matching strategy.
+
+`any`: A document is returned if it matches at least one of the query terms. This is the default matching strategy.
+
+`all`: A document is only returned if it matches all query terms.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withQuery('all of these words must match')
+    ->withMatchingStrategy(\Loupe\Config\MatchingStrategy::All)
+;
+```
+
 ## Attributes to receive
 
 By default, Loupe returns all the attributes of the documents you've indexed. If you are interested in only a subset 

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -53,7 +53,7 @@ By default, a search will match any documents that match at least one of the que
 ```php
 $searchParameters = \Loupe\Loupe\SearchParameters::create()
     ->withQuery('all of these words must match')
-    ->withMatchingStrategy(\Loupe\Config\MatchingStrategy::All)
+    ->withMatchingStrategy('all')
 ;
 ```
 

--- a/src/Config/MatchingStrategy.php
+++ b/src/Config/MatchingStrategy.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Config;
+
+enum MatchingStrategy: string
+{
+    case All = 'all';
+    case Any = 'any';
+}

--- a/src/Exception/InvalidSearchParametersException.php
+++ b/src/Exception/InvalidSearchParametersException.php
@@ -13,6 +13,14 @@ class InvalidSearchParametersException extends \InvalidArgumentException impleme
         return new self('The distinct attribute must be a single filterable attribute.');
     }
 
+    /**
+     * @param array<string> $allowed
+     */
+    public static function invalidMatchingStrategy(string $given, array $allowed): self
+    {
+        return new self(\sprintf('Invalid matching strategy "%s". Allowed values: %s.', $given, implode(', ', $allowed)));
+    }
+
     public static function maxLimit(): self
     {
         return new self(\sprintf('Cannot request more than %d documents per request, use pagination.', SearchParameters::MAX_LIMIT));

--- a/src/Internal/Search/MatchingStrategy.php
+++ b/src/Internal/Search/MatchingStrategy.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Loupe\Loupe\Config;
+namespace Loupe\Loupe\Internal\Search;
 
 enum MatchingStrategy: string
 {

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Location\Bounds;
 use Loupe\Loupe\BrowseResult;
-use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\Internal\Engine;
@@ -823,7 +822,7 @@ class Searcher
         }
 
         $strategy = $this->queryParameters instanceof SearchParameters
-            ? $this->queryParameters->getMatchingStrategy()
+            ? MatchingStrategy::from($this->queryParameters->getMatchingStrategy())
             : MatchingStrategy::Any;
 
         $positiveOperator = match ($strategy) {

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Location\Bounds;
 use Loupe\Loupe\BrowseResult;
+use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\Internal\Engine;
@@ -821,7 +822,16 @@ class Searcher
             }
         }
 
-        $where = implode(' OR ', array_map(
+        $strategy = $this->queryParameters instanceof SearchParameters
+            ? $this->queryParameters->getMatchingStrategy()
+            : MatchingStrategy::Any;
+
+        $positiveOperator = match ($strategy) {
+            MatchingStrategy::All => ' AND ',
+            MatchingStrategy::Any => ' OR ',
+        };
+
+        $where = implode($positiveOperator, array_map(
             fn ($statements) => '(' . implode(' AND ', $statements) . ')',
             $positiveConditions
         ));

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe;
 
+use Loupe\Loupe\Config\MatchingStrategy;
+use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\Internal\Search\AbstractQueryParameters;
 
 final class SearchParameters extends AbstractQueryParameters
@@ -32,6 +34,8 @@ final class SearchParameters extends AbstractQueryParameters
     private string $highlightEndTag = '</em>';
 
     private string $highlightStartTag = '<em>';
+
+    private MatchingStrategy $matchingStrategy = MatchingStrategy::Any;
 
     private float $rankingScoreThreshold = 0.0;
 
@@ -63,6 +67,7 @@ final class SearchParameters extends AbstractQueryParameters
      *     page?: ?int,
      *     offset?: int,
      *     limit?: int,
+     *     matchingStrategy?: string,
      *     query?: string,
      *     rankingScoreThreshold?: float,
      *     showMatchesPosition?: bool,
@@ -93,6 +98,19 @@ final class SearchParameters extends AbstractQueryParameters
 
         if (isset($data['facets'])) {
             $instance = $instance->withFacets($data['facets']);
+        }
+
+        if (isset($data['matchingStrategy'])) {
+            $strategy = MatchingStrategy::tryFrom($data['matchingStrategy']);
+
+            if ($strategy === null) {
+                throw InvalidSearchParametersException::invalidMatchingStrategy(
+                    $data['matchingStrategy'],
+                    array_column(MatchingStrategy::cases(), 'value'),
+                );
+            }
+
+            $instance = $instance->withMatchingStrategy($strategy);
         }
 
         if (isset($data['rankingScoreThreshold'])) {
@@ -176,6 +194,7 @@ final class SearchParameters extends AbstractQueryParameters
         $hash[] = json_encode($this->getHitsPerPage());
         $hash[] = json_encode($this->getPage());
         $hash[] = json_encode($this->getLimit());
+        $hash[] = json_encode($this->getMatchingStrategy()->value);
         $hash[] = json_encode($this->getOffset());
         $hash[] = json_encode($this->getQuery());
         $hash[] = json_encode($this->showMatchesPosition());
@@ -192,6 +211,11 @@ final class SearchParameters extends AbstractQueryParameters
     public function getHighlightStartTag(): string
     {
         return $this->highlightStartTag;
+    }
+
+    public function getMatchingStrategy(): MatchingStrategy
+    {
+        return $this->matchingStrategy;
     }
 
     public function getRankingScoreThreshold(): float
@@ -231,6 +255,7 @@ final class SearchParameters extends AbstractQueryParameters
      *     page: ?int,
      *     offset: int,
      *     limit: int,
+     *     matchingStrategy: string,
      *     query: string,
      *     attributesToRetrieve: array<string>,
      *     attributesToSearchOn: array<string>,
@@ -251,6 +276,7 @@ final class SearchParameters extends AbstractQueryParameters
             'cropMarker' => $this->cropMarker,
             'highlightEndTag' => $this->highlightEndTag,
             'highlightStartTag' => $this->highlightStartTag,
+            'matchingStrategy' => $this->matchingStrategy->value,
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'showMatchesPosition' => $this->showMatchesPosition,
             'showRankingScore' => $this->showRankingScore,
@@ -319,6 +345,14 @@ final class SearchParameters extends AbstractQueryParameters
     {
         $clone = clone $this;
         $clone->facets = $facets;
+
+        return $clone;
+    }
+
+    public function withMatchingStrategy(MatchingStrategy $matchingStrategy): self
+    {
+        $clone = clone $this;
+        $clone->matchingStrategy = $matchingStrategy;
 
         return $clone;
     }

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe;
 
-use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\Internal\Search\AbstractQueryParameters;
+use Loupe\Loupe\Internal\Search\MatchingStrategy;
 
 final class SearchParameters extends AbstractQueryParameters
 {
@@ -101,16 +101,7 @@ final class SearchParameters extends AbstractQueryParameters
         }
 
         if (isset($data['matchingStrategy'])) {
-            $strategy = MatchingStrategy::tryFrom($data['matchingStrategy']);
-
-            if ($strategy === null) {
-                throw InvalidSearchParametersException::invalidMatchingStrategy(
-                    $data['matchingStrategy'],
-                    array_column(MatchingStrategy::cases(), 'value'),
-                );
-            }
-
-            $instance = $instance->withMatchingStrategy($strategy);
+            $instance = $instance->withMatchingStrategy($data['matchingStrategy']);
         }
 
         if (isset($data['rankingScoreThreshold'])) {
@@ -194,7 +185,7 @@ final class SearchParameters extends AbstractQueryParameters
         $hash[] = json_encode($this->getHitsPerPage());
         $hash[] = json_encode($this->getPage());
         $hash[] = json_encode($this->getLimit());
-        $hash[] = json_encode($this->getMatchingStrategy()->value);
+        $hash[] = json_encode($this->getMatchingStrategy());
         $hash[] = json_encode($this->getOffset());
         $hash[] = json_encode($this->getQuery());
         $hash[] = json_encode($this->showMatchesPosition());
@@ -213,9 +204,9 @@ final class SearchParameters extends AbstractQueryParameters
         return $this->highlightStartTag;
     }
 
-    public function getMatchingStrategy(): MatchingStrategy
+    public function getMatchingStrategy(): string
     {
-        return $this->matchingStrategy;
+        return $this->matchingStrategy->value;
     }
 
     public function getRankingScoreThreshold(): float
@@ -276,7 +267,7 @@ final class SearchParameters extends AbstractQueryParameters
             'cropMarker' => $this->cropMarker,
             'highlightEndTag' => $this->highlightEndTag,
             'highlightStartTag' => $this->highlightStartTag,
-            'matchingStrategy' => $this->matchingStrategy->value,
+            'matchingStrategy' => $this->getMatchingStrategy(),
             'rankingScoreThreshold' => $this->rankingScoreThreshold,
             'showMatchesPosition' => $this->showMatchesPosition,
             'showRankingScore' => $this->showRankingScore,
@@ -349,10 +340,19 @@ final class SearchParameters extends AbstractQueryParameters
         return $clone;
     }
 
-    public function withMatchingStrategy(MatchingStrategy $matchingStrategy): self
+    public function withMatchingStrategy(string $matchingStrategy): self
     {
+        $strategy = MatchingStrategy::tryFrom($matchingStrategy);
+
+        if ($strategy === null) {
+            throw InvalidSearchParametersException::invalidMatchingStrategy(
+                $matchingStrategy,
+                array_column(MatchingStrategy::cases(), 'value'),
+            );
+        }
+
         $clone = clone $this;
-        $clone->matchingStrategy = $matchingStrategy;
+        $clone->matchingStrategy = $strategy;
 
         return $clone;
     }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1909,6 +1909,26 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testMatchingStrategyAllWithNegation(): void
+    {
+        $loupe = $this->setupLoupeWithMoviesFixture();
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('young london glaciologist -passion')
+            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [],
+            'query' => 'young london glaciologist -passion',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 0,
+            'totalHits' => 0,
+        ]);
+    }
+
     public function testMaxHits(): void
     {
         $configuration = Configuration::create()

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1838,91 +1838,6 @@ class SearchTest extends TestCase
         ]);
     }
 
-    public function testMatchingStrategyAnyRequiresAnyOneTerm(): void
-    {
-        $configuration = Configuration::create()
-            ->withSortableAttributes(['title'])
-            ->withSearchableAttributes(['title', 'overview', 'genres'])
-            ->withTypoTolerance(TypoTolerance::create()->disable());
-
-        $loupe = $this->createLoupe($configuration);
-        $this->indexFixture($loupe, 'movies');
-
-        $searchParameters = SearchParameters::create()
-            ->withQuery('young london glaciologist music')
-            ->withAttributesToRetrieve(['id', 'title'])
-            ->withSort(['title:asc']);
-
-        $this->searchAndAssertResults($loupe, $searchParameters, [
-            'hits' => [
-                [
-                    'id' => 27,
-                    'title' => '9 Songs',
-                ],
-                [
-                    'id' => 16,
-                    'title' => 'Dancer in the Dark',
-                ],
-                [
-                    'id' => 12,
-                    'title' => 'Finding Nemo',
-                ],
-                [
-                    'id' => 18,
-                    'title' => 'The Fifth Element',
-                ],
-            ],
-            'query' => 'young london glaciologist music',
-            'hitsPerPage' => 20,
-            'page' => 1,
-            'totalPages' => 1,
-            'totalHits' => 4,
-        ]);
-    }
-
-    public function testMatchingStrategyAllRequiresAllTerms(): void
-    {
-        $configuration = Configuration::create()
-            ->withSortableAttributes(['title'])
-            ->withSearchableAttributes(['title', 'overview', 'genres'])
-            ->withTypoTolerance(TypoTolerance::create()->disable());
-
-        $loupe = $this->createLoupe($configuration);
-        $this->indexFixture($loupe, 'movies');
-
-        $searchParameters = SearchParameters::create()
-            ->withQuery('young london glaciologist music')
-            ->withAttributesToRetrieve(['id', 'title'])
-            ->withMatchingStrategy(MatchingStrategy::All)
-            ->withSort(['title:asc']);
-
-        $this->searchAndAssertResults($loupe, $searchParameters, [
-            'hits' => [
-                [
-                    'id' => 27,
-                    'title' => '9 Songs',
-                ],
-            ],
-            'query' => 'young london glaciologist music',
-            'hitsPerPage' => 20,
-            'page' => 1,
-            'totalPages' => 1,
-            'totalHits' => 1,
-        ]);
-
-        $impossibleParameters = $searchParameters
-            ->withQuery('young london glaciologist music life things');
-
-        $this->searchAndAssertResults($loupe, $impossibleParameters, [
-            'hits' => [],
-            'query' => 'young london glaciologist music life things',
-            'hitsPerPage' => 20,
-            'page' => 1,
-            'totalPages' => 0,
-            'totalHits' => 0,
-        ]);
-    }
-
     public function testMatchingStrategyAllConsidersNegation(): void
     {
         $loupe = $this->setupLoupeWithMoviesFixture();
@@ -1973,6 +1888,91 @@ class SearchTest extends TestCase
             'page' => 1,
             'totalPages' => 1,
             'totalHits' => 1,
+        ]);
+    }
+
+    public function testMatchingStrategyAllRequiresAllTerms(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
+            ->withTypoTolerance(TypoTolerance::create()->disable());
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('young london glaciologist music')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 27,
+                    'title' => '9 Songs',
+                ],
+            ],
+            'query' => 'young london glaciologist music',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+
+        $impossibleParameters = $searchParameters
+            ->withQuery('young london glaciologist music life things');
+
+        $this->searchAndAssertResults($loupe, $impossibleParameters, [
+            'hits' => [],
+            'query' => 'young london glaciologist music life things',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 0,
+            'totalHits' => 0,
+        ]);
+    }
+
+    public function testMatchingStrategyAnyRequiresAnyOneTerm(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
+            ->withTypoTolerance(TypoTolerance::create()->disable());
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('young london glaciologist music')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 27,
+                    'title' => '9 Songs',
+                ],
+                [
+                    'id' => 16,
+                    'title' => 'Dancer in the Dark',
+                ],
+                [
+                    'id' => 12,
+                    'title' => 'Finding Nemo',
+                ],
+                [
+                    'id' => 18,
+                    'title' => 'The Fifth Element',
+                ],
+            ],
+            'query' => 'young london glaciologist music',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 4,
         ]);
     }
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1953,8 +1953,10 @@ class SearchTest extends TestCase
         $loupe = $this->createLoupe($configuration);
         $this->indexFixture($loupe, 'movies');
 
+        // `and the son` would match at least 2 documents
+        // `and "the son"` would only match 1 document
         $searchParameters = SearchParameters::create()
-            ->withQuery('"she is" her daughter')
+            ->withQuery('and "the son"')
             ->withMatchingStrategy(MatchingStrategy::All)
             ->withAttributesToRetrieve(['id', 'title'])
             ->withSort(['title:asc']);
@@ -1962,11 +1964,11 @@ class SearchTest extends TestCase
         $this->searchAndAssertResults($loupe, $searchParameters, [
             'hits' => [
                 [
-                    'id' => 17,
-                    'title' => 'The Dark',
+                    'id' => 19,
+                    'title' => 'Metropolis',
                 ],
             ],
-            'query' => '"she is" her daughter',
+            'query' => 'and "the son"',
             'hitsPerPage' => 20,
             'page' => 1,
             'totalPages' => 1,

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1943,6 +1943,37 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testMatchingStrategyAllConsidersPhrase(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview'])
+            ->withTypoTolerance(TypoTolerance::create()->disable());
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('"she is" her daughter')
+            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 17,
+                    'title' => 'The Dark',
+                ],
+            ],
+            'query' => '"she is" her daughter',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+    }
+
     public function testMaxHits(): void
     {
         $configuration = Configuration::create()

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Functional;
 
+use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Config\TypoTolerance;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\SearchParameters;
@@ -1834,6 +1835,77 @@ class SearchTest extends TestCase
             'page' => 1,
             'totalPages' => 1,
             'totalHits' => \count($expectedHits),
+        ]);
+    }
+
+    public function testMatchingStrategyAll(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
+            ->withTypoTolerance(TypoTolerance::create()->disable());
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        // "any" = default = must contain at least one of the terms
+        $anyParameters = SearchParameters::create()
+            ->withQuery('young london glaciologist music')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $anyParameters, [
+            'hits' => [
+                [
+                    'id' => 27,
+                    'title' => '9 Songs',
+                ],
+                [
+                    'id' => 16,
+                    'title' => 'Dancer in the Dark',
+                ],
+                [
+                    'id' => 12,
+                    'title' => 'Finding Nemo',
+                ],
+                [
+                    'id' => 18,
+                    'title' => 'The Fifth Element',
+                ],
+            ],
+            'query' => 'young london glaciologist music',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 4,
+        ]);
+
+        // "all" = must contain all terms
+        $allParameters = $anyParameters->withMatchingStrategy(MatchingStrategy::All);
+
+        $this->searchAndAssertResults($loupe, $allParameters, [
+            'hits' => [
+                [
+                    'id' => 27,
+                    'title' => '9 Songs',
+                ],
+            ],
+            'query' => 'young london glaciologist music',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+
+        $impossibleParameters = $anyParameters->withQuery('young london glaciologist music life things')->withMatchingStrategy(MatchingStrategy::All);
+
+        $this->searchAndAssertResults($loupe, $impossibleParameters, [
+            'hits' => [],
+            'query' => 'young london glaciologist music life things',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 0,
+            'totalHits' => 0,
         ]);
     }
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1838,7 +1838,7 @@ class SearchTest extends TestCase
         ]);
     }
 
-    public function testMatchingStrategyAll(): void
+    public function testMatchingStrategyAnyRequiresAnyOneTerm(): void
     {
         $configuration = Configuration::create()
             ->withSortableAttributes(['title'])
@@ -1848,13 +1848,12 @@ class SearchTest extends TestCase
         $loupe = $this->createLoupe($configuration);
         $this->indexFixture($loupe, 'movies');
 
-        // "any" = default = must contain at least one of the terms
-        $anyParameters = SearchParameters::create()
+        $searchParameters = SearchParameters::create()
             ->withQuery('young london glaciologist music')
             ->withAttributesToRetrieve(['id', 'title'])
             ->withSort(['title:asc']);
 
-        $this->searchAndAssertResults($loupe, $anyParameters, [
+        $this->searchAndAssertResults($loupe, $searchParameters, [
             'hits' => [
                 [
                     'id' => 27,
@@ -1879,11 +1878,25 @@ class SearchTest extends TestCase
             'totalPages' => 1,
             'totalHits' => 4,
         ]);
+    }
 
-        // "all" = must contain all terms
-        $allParameters = $anyParameters->withMatchingStrategy(MatchingStrategy::All);
+    public function testMatchingStrategyAllRequiresAllTerms(): void
+    {
+        $configuration = Configuration::create()
+            ->withSortableAttributes(['title'])
+            ->withSearchableAttributes(['title', 'overview', 'genres'])
+            ->withTypoTolerance(TypoTolerance::create()->disable());
 
-        $this->searchAndAssertResults($loupe, $allParameters, [
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('young london glaciologist music')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withSort(['title:asc']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
             'hits' => [
                 [
                     'id' => 27,
@@ -1897,7 +1910,8 @@ class SearchTest extends TestCase
             'totalHits' => 1,
         ]);
 
-        $impossibleParameters = $anyParameters->withQuery('young london glaciologist music life things')->withMatchingStrategy(MatchingStrategy::All);
+        $impossibleParameters = $searchParameters
+            ->withQuery('young london glaciologist music life things');
 
         $this->searchAndAssertResults($loupe, $impossibleParameters, [
             'hits' => [],
@@ -1909,7 +1923,7 @@ class SearchTest extends TestCase
         ]);
     }
 
-    public function testMatchingStrategyAllWithNegation(): void
+    public function testMatchingStrategyAllConsidersNegation(): void
     {
         $loupe = $this->setupLoupeWithMoviesFixture();
 

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Functional;
 
-use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Config\TypoTolerance;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\SearchParameters;
@@ -1844,7 +1843,7 @@ class SearchTest extends TestCase
 
         $searchParameters = SearchParameters::create()
             ->withQuery('young london glaciologist -passion')
-            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withMatchingStrategy('all')
             ->withAttributesToRetrieve(['id', 'title'])
             ->withSort(['title:asc']);
 
@@ -1872,7 +1871,7 @@ class SearchTest extends TestCase
         // `and "the son"` would only match 1 document
         $searchParameters = SearchParameters::create()
             ->withQuery('and "the son"')
-            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withMatchingStrategy('all')
             ->withAttributesToRetrieve(['id', 'title'])
             ->withSort(['title:asc']);
 
@@ -1904,7 +1903,7 @@ class SearchTest extends TestCase
         $searchParameters = SearchParameters::create()
             ->withQuery('young london glaciologist music')
             ->withAttributesToRetrieve(['id', 'title'])
-            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withMatchingStrategy('all')
             ->withSort(['title:asc']);
 
         $this->searchAndAssertResults($loupe, $searchParameters, [

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Unit;
 
-use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\SearchParameters;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +32,7 @@ class SearchParametersTest extends TestCase
 
     public function testMatchingStrategyDefaultsToAny(): void
     {
-        $this->assertSame(MatchingStrategy::Any, SearchParameters::create()->getMatchingStrategy());
+        $this->assertSame('any', SearchParameters::create()->getMatchingStrategy());
     }
 
     public function testMatchingStrategyFromArrayRejectsUnknownValue(): void
@@ -60,7 +59,7 @@ class SearchParametersTest extends TestCase
             ->withQuery('hello world')
             ->withPage(3)
             ->withHitsPerPage(50)
-            ->withMatchingStrategy(MatchingStrategy::All)
+            ->withMatchingStrategy('all')
             ->withRankingScoreThreshold(0.25)
             ->withFilter("status = 'active'")
             ->withAttributesToRetrieve(['title', 'author'])
@@ -74,7 +73,7 @@ class SearchParametersTest extends TestCase
         $reconstructed = SearchParameters::fromArray($array);
 
         $this->assertSame($original->toArray(), $reconstructed->toArray());
-        $this->assertSame(MatchingStrategy::All, $reconstructed->getMatchingStrategy());
+        $this->assertSame('all', $reconstructed->getMatchingStrategy());
     }
 
     public function testToStringAndFromString(): void
@@ -84,5 +83,13 @@ class SearchParametersTest extends TestCase
         $parsed = SearchParameters::fromString($json);
 
         $this->assertSame($params->toArray(), $parsed->toArray());
+    }
+
+    public function testWithMatchingStrategyRejectsUnknownValue(): void
+    {
+        $this->expectException(InvalidSearchParametersException::class);
+        $this->expectExceptionMessage('Invalid matching strategy "bogus"');
+
+        SearchParameters::create()->withMatchingStrategy('bogus');
     }
 }

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Tests\Unit;
 
+use Loupe\Loupe\Config\MatchingStrategy;
 use Loupe\Loupe\Exception\InvalidSearchParametersException;
 use Loupe\Loupe\SearchParameters;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +31,21 @@ class SearchParametersTest extends TestCase
         $this->assertSame(2, $newParams->getPage());
     }
 
+    public function testMatchingStrategyDefaultsToAny(): void
+    {
+        $this->assertSame(MatchingStrategy::Any, SearchParameters::create()->getMatchingStrategy());
+    }
+
+    public function testMatchingStrategyFromArrayRejectsUnknownValue(): void
+    {
+        $this->expectException(InvalidSearchParametersException::class);
+        $this->expectExceptionMessage('Invalid matching strategy "bogus"');
+
+        SearchParameters::fromArray([
+            'matchingStrategy' => 'bogus',
+        ]);
+    }
+
     public function testMaxHitsPerPage(): void
     {
         $this->expectException(InvalidSearchParametersException::class);
@@ -44,6 +60,7 @@ class SearchParametersTest extends TestCase
             ->withQuery('hello world')
             ->withPage(3)
             ->withHitsPerPage(50)
+            ->withMatchingStrategy(MatchingStrategy::All)
             ->withRankingScoreThreshold(0.25)
             ->withFilter("status = 'active'")
             ->withAttributesToRetrieve(['title', 'author'])
@@ -57,6 +74,7 @@ class SearchParametersTest extends TestCase
         $reconstructed = SearchParameters::fromArray($array);
 
         $this->assertSame($original->toArray(), $reconstructed->toArray());
+        $this->assertSame(MatchingStrategy::All, $reconstructed->getMatchingStrategy());
     }
 
     public function testToStringAndFromString(): void


### PR DESCRIPTION
Introduce a new config to allow narrowing search results with each additional term:

`matching_strategy: any | all (default: any)`

## Example

```php
$searchParameters = SearchParameters::create()
    ->withQuery('all of these words must match')
    ->withMatchingStrategy('all');
```

## `any`

Current matching strategy. Only one of the terms must match. Great default for text-heavy applications where users aren't familiar with all of the content: returning more documents with each search term, combined with proper ranking and a threshold, is a good user experience there.

## `all`

New matching strategy: all terms must match. Filters down the result set with each additional term instead of expanding it. Great for projects working with more structured data where editors more or less know what they're looking for, e.g. a database of orders, where searching for a customer name + a city should narrow the results to all orders to that name in that city.

## Prior art

The name of the option is [directly lifted](https://www.meilisearch.com/docs/reference/api/search/search-with-post#matching-strategy) from Meilisearch. There, the default is different: `last` = drop terms from the end of the query until enough results are found. However, `all` is one possible value for the matching strategy.

## Performance

Search performance for multiple terms is identical or slightly faster because less documents are returned in most cases.

Search performance for single terms is unchanged.