### PR TITLE
Fix distinct should use best ranked document for highlighting context

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -43,6 +43,12 @@ class Searcher
 
     public const DISTANCE_ALIAS = '_distance';
 
+    public const DISTINCT_RANK_ALIAS = '_distinct_rank';
+
+    public const DISTINCT_VALUE_ALIAS = '_distinct_value';
+
+    public const DOCUMENT_ID_ALIAS = '_document_id';
+
     public const FACET_ALIAS_COUNT_PREFIX = '_facet_count_';
 
     public const FACET_ALIAS_MIN_MAX_PREFIX = '_facet_minmax_';
@@ -67,6 +73,11 @@ class Searcher
      * @var array<int|string, string>
      */
     private array $namedParameters = [];
+
+    /**
+     * @var array<array{sort: string, order: string, needsMaterialization: bool}>
+     */
+    private array $orderByParts = [];
 
     private QueryBuilder $queryBuilder;
 
@@ -198,6 +209,17 @@ class Searcher
         return $cteName;
     }
 
+    public function addOrderBy(string $sort, string $order, bool $needsMaterialization = false): void
+    {
+        $this->orderByParts[] = [
+            'sort' => $sort,
+            'order' => $order,
+            'needsMaterialization' => $needsMaterialization,
+        ];
+
+        $this->queryBuilder->addOrderBy($sort, $order);
+    }
+
     public function createNamedParameter(mixed $value, mixed $type = ParameterType::STRING): string
     {
         if ($type === ParameterType::STRING && (\is_string($value) || \is_int($value))) {
@@ -232,10 +254,10 @@ class Searcher
         $this->addPositionsForFormatting($tokens);
         $this->filterDocuments($tokens); // Then filter the documents (requires the search term CTEs)
         $this->addFacets();
-        $this->selectTotalHits();
         $this->sortDocuments();
         $this->selectDistance();
         $this->applyDistinct();
+        $this->selectTotalHits();
         $this->limitPagination();
 
         $showAllAttributes = \in_array('*', $this->queryParameters->getAttributesToRetrieve(), true);
@@ -767,9 +789,65 @@ class Searcher
         }
 
         $documentsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $this->queryBuilder->addSelect($documentsAlias . '.' . $distinct . ' AS ' . self::DISTINCT_VALUE_ALIAS);
+
+        // We handle DISTINCT by ranking rows within each distinct value and then keeping the top one.
+        // If an ORDER BY part is computed in this query, we first expose it as a select alias so the outer
+        // ranking query can still sort by it.
+        $orderByParts = [];
+        foreach ($this->orderByParts as $index => $orderByPart) {
+            if ($orderByPart['needsMaterialization']) {
+                $alias = '_distinct_order_' . $index;
+                $this->queryBuilder->addSelect($orderByPart['sort'] . ' AS ' . $alias);
+
+                $orderByParts[] = [
+                    'sort' => $alias,
+                    'order' => $orderByPart['order'],
+                ];
+
+                continue;
+            }
+
+            $orderByParts[] = [
+                'sort' => $orderByPart['sort'],
+                'order' => $orderByPart['order'],
+            ];
+        }
+
+        $orderByParts[] = [
+            'sort' => self::DOCUMENT_ID_ALIAS,
+            'order' => 'ASC',
+        ];
+
+        // Now wrap the current query and assign a row number per distinct value using the normalized ORDER BY list.
+        // We add the document id at the end so ties still resolve in a predictable way.
+        $rankedQueryBuilder = $this->engine->getConnection()->createQueryBuilder();
+        $rankedQueryBuilder
+            ->select('*')
+            ->addSelect(\sprintf(
+                'ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS %s',
+                self::DISTINCT_VALUE_ALIAS,
+                implode(', ', array_map(static fn (array $orderByPart): string => $orderByPart['sort'] . ' ' . $orderByPart['order'], $orderByParts)),
+                self::DISTINCT_RANK_ALIAS,
+            ))
+            ->from('(' . $this->queryBuilder->getSQL() . ')')
+            ->setParameters($this->queryBuilder->getParameters(), $this->queryBuilder->getParameterTypes())
+        ;
+
+        // Replace the original builder with the ranked subquery and keep only the first row from each distinct group.
+        // After that we re-apply the normalized ORDER BY parts to the final query builder below.
+        $this->queryBuilder = $this->engine->getConnection()->createQueryBuilder();
         $this->queryBuilder
-            ->addSelect($documentsAlias . '.' . $distinct)
-            ->groupBy($documentsAlias . '.' . $distinct);
+            ->select('*')
+            ->from('(' . $rankedQueryBuilder->getSQL() . ')')
+            ->where(self::DISTINCT_RANK_ALIAS . ' = 1')
+            ->setParameters($rankedQueryBuilder->getParameters(), $rankedQueryBuilder->getParameterTypes())
+        ;
+
+        $this->orderByParts = [];
+        foreach ($orderByParts as $orderByPart) {
+            $this->addOrderBy($orderByPart['sort'], $orderByPart['order']);
+        }
     }
 
     private function askedForFormattingOrMatchesPosition(): bool
@@ -1340,6 +1418,7 @@ class Searcher
     {
         $documentsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
         $this->queryBuilder
+            ->addSelect($documentsAlias . '._id AS ' . self::DOCUMENT_ID_ALIAS)
             ->addSelect($documentsAlias . '._document')
             ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
             ->innerJoin(

--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -58,24 +58,26 @@ abstract class AbstractSorter
         // Because of how Loupe works (SQLite's loosely typed system) we need to always ensure that null and empty values
         // are ordered ascending first.
         // Null and empty values should always come last for Loupe (or generally speaking for any search engine probably).
-        $searcher->getQueryBuilder()->addOrderBy(
+        $searcher->addOrderBy(
             Operator::Equals->buildSql(
                 $engine->getConnection(),
                 $alias,
                 FilterValue::createNull()
             ),
-            Direction::ASC->getSQL()
+            Direction::ASC->getSQL(),
+            true,
         );
 
-        $searcher->getQueryBuilder()->addOrderBy(
+        $searcher->addOrderBy(
             Operator::Equals->buildSql(
                 $engine->getConnection(),
                 $alias,
                 FilterValue::createEmpty()
             ),
-            Direction::ASC->getSQL()
+            Direction::ASC->getSQL(),
+            true,
         );
 
-        $searcher->getQueryBuilder()->addOrderBy($alias, $direction->getSQL());
+        $searcher->addOrderBy($alias, $direction->getSQL(), true);
     }
 }

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -125,7 +125,7 @@ class Relevance extends AbstractSorter
 
         // No need to use the abstract addOrderBy() here because the relevance alias cannot be of
         // our internal null or empty value
-        $searcher->getQueryBuilder()->addOrderBy(Searcher::RELEVANCE_ALIAS, $this->direction->getSQL());
+        $searcher->addOrderBy(Searcher::RELEVANCE_ALIAS, $this->direction->getSQL());
 
         // Apply threshold
         $threshold = $queryParameters->getRankingScoreThreshold();

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -1267,6 +1267,56 @@ class SearchTest extends TestCase
         ]);
     }
 
+    public function testDistinctUsesBestMatchingDocumentForHighlightingContext(): void
+    {
+        $configuration = Configuration::create()
+            ->withFilterableAttributes(['filename'])
+            ->withSearchableAttributes(['content'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            [
+                'id' => 1,
+                'filename' => 'report.pdf',
+                'page' => 1,
+                'content' => 'needle footer',
+            ],
+            [
+                'id' => 2,
+                'filename' => 'report.pdf',
+                'page' => 2,
+                'content' => 'needle important context footer',
+            ],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('needle context')
+            ->withDistinct('filename')
+            ->withAttributesToRetrieve(['id', 'filename', 'content'])
+            ->withAttributesToHighlight(['content']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 2,
+                    'filename' => 'report.pdf',
+                    'content' => 'needle important context footer',
+                    '_formatted' => [
+                        'id' => 2,
+                        'filename' => 'report.pdf',
+                        'content' => '<em>needle</em> important <em>context</em> footer',
+                    ],
+                ],
+            ],
+            'query' => 'needle context',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+    }
+
     /**
      * @param array<array<string, mixed>> $expectedHits
      */


### PR DESCRIPTION
This PR adds a failing regression test that documents incorrect `distinct` behavior for formatted search hits.
When multiple matching documents share the same distinct value, Loupe currently collapses them into one result (which is the desired result). However, the hit content used for `_formatted` / highlighting is not guaranteed to come from the best matching document in that distinct group.

At the moment, Loupe collapses the group but the representative document used highlighting is effectively arbitrary.

I've added a practical example in the tests to show why this matters:
-  one document per page
- all pages share the same filename
- search uses `distinct=filename`

If many pages match, the final hit should use the best page as the highlighting source. Otherwise the snippet may come from an irrelevant page, such as a footer match.

This is a tough one, though because I think we'll need to have yet another subquery for the ranking but only if `distinct` is enabled.