### PR TITLE
Attribute truncation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "toflar/state-set-index": "^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
-        "loupe/matcher": "^0.2.3"
+        "loupe/matcher": "dev-feature/truncation"
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1.31",
@@ -42,6 +42,12 @@
         "symfony/process": "^7.3.4",
         "symfony/var-dumper": "^7.3.5",
         "symplify/easy-coding-standard": "^12.6.2"
+    },
+    "repositories": {
+        "loupe-matcher": {
+            "type": "vcs",
+            "url": "https://github.com/loupe-php/matcher.git"
+        }
     },
     "scripts": {
         "tests": "@php vendor/bin/phpunit",

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -386,7 +386,7 @@ truncated at the end, so you will get the beginning of the value up to the defin
 
 ```php
 $searchParameters = \Loupe\Loupe\SearchParameters::create()
-    ->withAttributesToTruncate(['overview', 'content']);
+    ->withAttributesToTruncate(['overview']);
 ```
 
 The result of a truncated attribute will look like this:
@@ -406,6 +406,15 @@ $results = [
         ],
     ],
 ];
+```
+
+For very long attributes, it is recommended to remove the attribute from the list of `attributesToRetrieve`
+and only return the truncated version to save bandwidth.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToRetrieve(['id', 'title'])
+    ->withAttributesToTruncate(['content']);
 ```
 
 The default truncation length is 250 characters. You can define a different truncation length by passing in an

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -379,9 +379,60 @@ $results = [
 ];
 ```
 
+## Attribute truncation
+
+Loupe can truncate selected attributes to a certain length to avoid returning excessively long values. Attributes are
+truncated at the end, so you will get the beginning of the value up to the defined truncation length.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToTruncate(['overview', 'content']);
+```
+
+The result of a truncated attribute will look like this:
+
+```php
+$results = [
+    'hits' => [
+        [
+            'id' => 24,
+            'title' => 'Kill Bill: Vol. 1',
+            'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+            '_formatted' => [
+                'id' => 24,
+                'title' => 'Kill Bill: Vol. 1',
+                'overview' => 'An assassin is shot by her ruthless employer…',
+            ],
+        ],
+    ],
+];
+```
+
+The default truncation length is 250 characters. You can define a different truncation length by passing in an
+integer value.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToTruncate(['overview', 'content'], cropLength: 500);
+```
+
+Optionally, define a custom truncation length for each attribute by passing in an array of lengths keyed by attribute name.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToTruncate(['overview', => 100, 'content' => 300]);
+```
+
+The truncation edge is marked with an ellipsis `…` character by default. You can change this by passing in a custom marker.
+
+```php
+$searchParameters = \Loupe\Loupe\SearchParameters::create()
+    ->withAttributesToTruncate(['overview', 'content'], truncationMarker: '∞');
+```
+
 ## Context cropping
 
-Loupe can crop selected attributes to a certain length around the search terms. The is useful to
+Loupe can crop selected attributes around the search terms. This special form of truncation is useful to
 show as much context as possible around matched words when displaying results.
 
 ```php

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1145,6 +1145,9 @@ class Searcher
         $attributesToCrop = ['*'] === $this->queryParameters->getAttributesToCrop()
             ? array_keys($hit)
             : array_keys($this->queryParameters->getAttributesToCrop());
+        $attributesToTruncate = ['*'] === $this->queryParameters->getAttributesToTruncate()
+            ? array_keys($hit)
+            : array_keys($this->queryParameters->getAttributesToTruncate());
         $attributesToHighlight = ['*'] === $this->queryParameters->getAttributesToHighlight()
             ? array_keys($hit)
             : $this->queryParameters->getAttributesToHighlight();
@@ -1152,11 +1155,13 @@ class Searcher
         $options = (new FormatterOptions())
             ->withCropLength($this->queryParameters->getCropLength())
             ->withCropMarker($this->queryParameters->getCropMarker())
+            ->withTruncationLength($this->queryParameters->getTruncationLength())
+            ->withTruncationMarker($this->queryParameters->getTruncationMarker())
             ->withHighlightStartTag($this->queryParameters->getHighlightStartTag())
             ->withHighlightEndTag($this->queryParameters->getHighlightEndTag())
         ;
 
-        $requiresFormatting = \count($attributesToCrop) > 0 || \count($attributesToHighlight) > 0;
+        $requiresFormatting = \count($attributesToTruncate) > 0 || \count($attributesToCrop) > 0 || \count($attributesToHighlight) > 0;
         $showMatchesPosition = $this->queryParameters->showMatchesPosition();
 
         if (!$requiresFormatting && !$showMatchesPosition) {
@@ -1201,6 +1206,14 @@ class Searcher
 
                 if (isset($this->queryParameters->getAttributesToCrop()[$attribute])) {
                     $attributeOptions = $attributeOptions->withCropLength($this->queryParameters->getAttributesToCrop()[$attribute]);
+                }
+            }
+
+            if (\in_array($attribute, $attributesToTruncate, true)) {
+                $attributeOptions = $attributeOptions->withEnableTruncation();
+
+                if (isset($this->queryParameters->getAttributesToTruncate()[$attribute])) {
+                    $attributeOptions = $attributeOptions->withTruncationLength($this->queryParameters->getAttributesToTruncate()[$attribute]);
                 }
             }
 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -785,6 +785,10 @@ class Searcher
             return true;
         }
 
+        if ($this->queryParameters->getAttributesToTruncate() !== []) {
+            return true;
+        }
+
         return $this->queryParameters->showMatchesPosition();
     }
 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -259,7 +259,7 @@ class Searcher
                     round($result[self::RELEVANCE_ALIAS], 5) : 0.0;
             }
 
-            $this->formatHit($hit, $result, $tokensIncludingStopwords);
+            $this->formatHit($hit, $document, $result, $tokensIncludingStopwords);
 
             $hits[] = $hit;
         }
@@ -1135,26 +1135,28 @@ class Searcher
 
     /**
      * @param array<mixed> $hit
+     * @param array<mixed> $document
      * @param array<mixed> $queryResult
      */
-    private function formatHit(array &$hit, array $queryResult, TokenCollection $queryTerms): void
+    private function formatHit(array &$hit, array $document, array $queryResult, TokenCollection $queryTerms): void
     {
         if (!$this->queryParameters instanceof SearchParameters) {
             return;
         }
 
         $searchableAttributes = ['*'] === $this->engine->getConfiguration()->getSearchableAttributes()
-            ? array_keys($hit)
+            ? array_keys($document)
             : $this->engine->getConfiguration()->getSearchableAttributes();
         $attributesToCrop = ['*'] === $this->queryParameters->getAttributesToCrop()
-            ? array_keys($hit)
+            ? array_keys($document)
             : array_keys($this->queryParameters->getAttributesToCrop());
         $attributesToTruncate = ['*'] === $this->queryParameters->getAttributesToTruncate()
-            ? array_keys($hit)
+            ? array_keys($document)
             : array_keys($this->queryParameters->getAttributesToTruncate());
         $attributesToHighlight = ['*'] === $this->queryParameters->getAttributesToHighlight()
-            ? array_keys($hit)
+            ? array_keys($document)
             : $this->queryParameters->getAttributesToHighlight();
+        $attributesToFormat = array_merge($attributesToCrop, $attributesToTruncate, $attributesToHighlight);
 
         $options = (new FormatterOptions())
             ->withCropLength($this->queryParameters->getCropLength())
@@ -1165,7 +1167,7 @@ class Searcher
             ->withHighlightEndTag($this->queryParameters->getHighlightEndTag())
         ;
 
-        $requiresFormatting = \count($attributesToTruncate) > 0 || \count($attributesToCrop) > 0 || \count($attributesToHighlight) > 0;
+        $requiresFormatting = \count($attributesToFormat) > 0;
         $showMatchesPosition = $this->queryParameters->showMatchesPosition();
 
         if (!$requiresFormatting && !$showMatchesPosition) {
@@ -1198,8 +1200,14 @@ class Searcher
         $matchesPosition = [];
 
         foreach ($searchableAttributes as $attribute) {
-            // Do not include any attribute not required by the result (limited by attributesToRetrieve)
-            if (!isset($hit[$attribute])) {
+            if (!isset($document[$attribute])) {
+                continue;
+            }
+
+            $isFormattable = \in_array($attribute, $attributesToFormat, true);
+
+            // Attributes must either already be in the result (attributesToRetrieve) or explicitly requested for formatting
+            if (!isset($hit[$attribute]) && !$isFormattable) {
                 continue;
             }
 
@@ -1225,10 +1233,13 @@ class Searcher
                 $attributeOptions = $attributeOptions->withEnableHighlight();
             }
 
-            if (\is_array($formatted[$attribute])) {
-                foreach ($formatted[$attribute] as $key => $value) {
+            $value = $document[$attribute];
+
+            if (\is_array($value)) {
+                $formattedValue = $value;
+                foreach ($value as $key => $arrayValue) {
                     // Do not pass along match positions as we don't have reliable information about the position of matches in arrays
-                    $formatterResult = $this->formatAttributeForHit($attribute, (string) $value, $queryTerms, $attributeOptions);
+                    $formatterResult = $this->formatAttributeForHit($attribute, (string) $arrayValue, $queryTerms, $attributeOptions);
 
                     if ($showMatchesPosition && $formatterResult->hasMatches()) {
                         $matchesPosition[$attribute] ??= [];
@@ -1236,11 +1247,15 @@ class Searcher
                     }
 
                     if ($requiresFormatting) {
-                        $formatted[$attribute][$key] = $formatterResult->getFormattedText();
+                        $formattedValue[$key] = $formatterResult->getFormattedText();
                     }
                 }
+
+                if ($requiresFormatting) {
+                    $formatted[$attribute] = $formattedValue;
+                }
             } else {
-                $formatterResult = $this->formatAttributeForHit($attribute, (string) $formatted[$attribute], $queryTerms, $attributeOptions, $matchPositionInfo);
+                $formatterResult = $this->formatAttributeForHit($attribute, (string) $value, $queryTerms, $attributeOptions, $matchPositionInfo);
 
                 if ($showMatchesPosition && $formatterResult->hasMatches()) {
                     $matchesPosition[$attribute] = $formatterResult->getMatchesArray();

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -368,17 +368,17 @@ final class SearchParameters extends AbstractQueryParameters
     }
 
     /**
-     * @param array<string>|array<string,int> $ttributesToTruncate
+     * @param array<string>|array<string,int> $attributesToTruncate
      */
     public function withAttributesToTruncate(
-        array $ttributesToTruncate,
+        array $attributesToTruncate,
         int $truncationLength = 250,
         string $truncationMarker = '…',
     ): self {
         $clone = clone $this;
 
         $attributes = [];
-        foreach ($ttributesToTruncate as $key => $attribute) {
+        foreach ($attributesToTruncate as $key => $attribute) {
             if (\is_string($key) && \is_int($attribute)) {
                 $attributes[$key] = $attribute;
             } elseif (\is_string($attribute)) {

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -20,6 +20,11 @@ final class SearchParameters extends AbstractQueryParameters
      */
     private array $attributesToHighlight = [];
 
+    /**
+     * @var array<string>
+     */
+    private array $attributesToTruncate = [];
+
     private int $cropLength = 50;
 
     private string $cropMarker = '…';
@@ -48,6 +53,10 @@ final class SearchParameters extends AbstractQueryParameters
      */
     private array $sort = [Internal\Search\Searcher::RELEVANCE_ALIAS . ':desc'];
 
+    private int $truncationLength = 250;
+
+    private string $truncationMarker = '…';
+
     public static function create(): static
     {
         return new self();
@@ -56,6 +65,7 @@ final class SearchParameters extends AbstractQueryParameters
     /**
      * @param array{
      *     attributesToCrop?: array<string>|array<string,int>,
+     *     attributesToTruncate?: array<string>|array<string,int>,
      *     attributesToHighlight?: array<string>,
      *     attributesToRetrieve?: array<string>,
      *     attributesToSearchOn?: array<string>,
@@ -85,6 +95,14 @@ final class SearchParameters extends AbstractQueryParameters
                 $data['attributesToCrop'],
                 $data['cropLength'] ?? 50,
                 $data['cropMarker'] ?? '…',
+            );
+        }
+
+        if (isset($data['attributesToTruncate'])) {
+            $instance = $instance->withAttributesToTruncate(
+                $data['attributesToTruncate'],
+                $data['truncationLength'] ?? 250,
+                $data['truncationMarker'] ?? '…',
             );
         }
 
@@ -143,6 +161,14 @@ final class SearchParameters extends AbstractQueryParameters
         return $this->attributesToHighlight;
     }
 
+    /**
+     * @return array<string,int>
+     */
+    public function getAttributesToTruncate(): array
+    {
+        return $this->attributesToTruncate;
+    }
+
     public function getCropLength(): int
     {
         return $this->cropLength;
@@ -175,8 +201,11 @@ final class SearchParameters extends AbstractQueryParameters
 
         $hash[] = json_encode($this->getAttributesToCrop());
         $hash[] = json_encode($this->getAttributesToHighlight());
+        $hash[] = json_encode($this->getAttributesToTruncate());
         $hash[] = json_encode($this->getCropLength());
         $hash[] = json_encode($this->getCropMarker());
+        $hash[] = json_encode($this->getTruncationLength());
+        $hash[] = json_encode($this->getTruncationMarker());
         $hash[] = json_encode($this->getHighlightEndTag());
         $hash[] = json_encode($this->getHighlightStartTag());
         $hash[] = json_encode($this->getAttributesToRetrieve());
@@ -222,6 +251,16 @@ final class SearchParameters extends AbstractQueryParameters
         return $this->sort;
     }
 
+    public function getTruncationLength(): int
+    {
+        return $this->truncationLength;
+    }
+
+    public function getTruncationMarker(): string
+    {
+        return $this->truncationMarker;
+    }
+
     public function showMatchesPosition(): bool
     {
         return $this->showMatchesPosition;
@@ -236,9 +275,12 @@ final class SearchParameters extends AbstractQueryParameters
      * @return array{
      *     attributesToCrop: array<string,int>,
      *     attributesToHighlight: array<string>,
+     *     attributesToTruncate: array<string,int>,
      *     facets: array<string>,
      *     cropLength: int,
      *     cropMarker: string,
+     *     truncationLength: int,
+     *     truncationMarker: string,
      *     filter: string,
      *     highlightEndTag: string,
      *     highlightStartTag: string,
@@ -261,10 +303,13 @@ final class SearchParameters extends AbstractQueryParameters
     {
         return array_merge(parent::toArray(), [
             'attributesToCrop' => $this->attributesToCrop,
+            'attributesToTruncate' => $this->attributesToTruncate,
             'attributesToHighlight' => $this->attributesToHighlight,
             'facets' => $this->facets,
             'cropLength' => $this->cropLength,
             'cropMarker' => $this->cropMarker,
+            'truncationLength' => $this->truncationLength,
+            'truncationMarker' => $this->truncationMarker,
             'highlightEndTag' => $this->highlightEndTag,
             'highlightStartTag' => $this->highlightStartTag,
             'matchingStrategy' => $this->getMatchingStrategy(),
@@ -318,6 +363,34 @@ final class SearchParameters extends AbstractQueryParameters
         $clone->attributesToHighlight = $attributesToHighlight;
         $clone->highlightStartTag = $highlightStartTag;
         $clone->highlightEndTag = $highlightEndTag;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string>|array<string,int> $ttributesToTruncate
+     */
+    public function withAttributesToTruncate(
+        array $ttributesToTruncate,
+        int $truncationLength = 250,
+        string $truncationMarker = '…',
+    ): self {
+        $clone = clone $this;
+
+        $attributes = [];
+        foreach ($ttributesToTruncate as $key => $attribute) {
+            if (\is_string($key) && \is_int($attribute)) {
+                $attributes[$key] = $attribute;
+            } elseif (\is_string($attribute)) {
+                $attributes[$attribute] = $truncationLength;
+            }
+        }
+
+        ksort($attributes);
+
+        $clone->attributesToCrop = $attributes;
+        $clone->truncationMarker = $truncationMarker;
+        $clone->truncationLength = $truncationLength;
 
         return $clone;
     }

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -388,7 +388,7 @@ final class SearchParameters extends AbstractQueryParameters
 
         ksort($attributes);
 
-        $clone->attributesToCrop = $attributes;
+        $clone->attributesToTruncate = $attributes;
         $clone->truncationMarker = $truncationMarker;
         $clone->truncationLength = $truncationLength;
 

--- a/src/SearchParameters.php
+++ b/src/SearchParameters.php
@@ -21,7 +21,7 @@ final class SearchParameters extends AbstractQueryParameters
     private array $attributesToHighlight = [];
 
     /**
-     * @var array<string>
+     * @var array<string,int>
      */
     private array $attributesToTruncate = [];
 

--- a/tests/Functional/Formatting/CroppingTest.php
+++ b/tests/Functional/Formatting/CroppingTest.php
@@ -19,6 +19,7 @@ class CroppingTest extends TestCase
         yield 'Cropping with too little text and no change' => [
             'assassin employer member vengeance',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             [],
             [
@@ -47,6 +48,7 @@ class CroppingTest extends TestCase
         yield 'Cropping with multiple matches' => [
             'assassin',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             [],
             [
@@ -75,6 +77,7 @@ class CroppingTest extends TestCase
         yield 'Cropping at the beginning' => [
             'selma',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             [],
             [
@@ -103,6 +106,7 @@ class CroppingTest extends TestCase
         yield 'Cropping at the end' => [
             'surroundings',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             [],
             [
@@ -131,6 +135,7 @@ class CroppingTest extends TestCase
         yield 'Cropping with custom crop length' => [
             'assassin',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             [],
             [
@@ -161,9 +166,41 @@ class CroppingTest extends TestCase
             25,
         ];
 
+        yield 'Cropping returns cropped value in _formatted even when attribute is excluded from attributesToRetrieve' => [
+            'assassin',
+            ['title', 'overview'],
+            ['id', 'title'],
+            ['overview'],
+            ['overview'],
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <em>assassin</em> is shot…their <em>assassination</em> circle…',
+                        ],
+                    ],
+                ],
+                'query' => 'assassin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            [],
+            '<em>',
+            '</em>',
+            '…',
+            20,
+        ];
+
         yield 'Cropping with highlights' => [
             'assassin',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             [
                 'overview' => 20,
             ],
@@ -194,6 +231,7 @@ class CroppingTest extends TestCase
 
     /**
      * @param array<string> $searchableAttributes
+     * @param array<string> $attributesToRetrieve
      * @param array<string>|array<string,int> $attributesToCrop
      * @param array<string> $attributesToHighlight
      * @param array<mixed> $expectedResults
@@ -203,6 +241,7 @@ class CroppingTest extends TestCase
     public function testCropping(
         string $query,
         array $searchableAttributes,
+        array $attributesToRetrieve,
         array $attributesToCrop,
         array $attributesToHighlight,
         array $expectedResults,
@@ -226,7 +265,7 @@ class CroppingTest extends TestCase
             ->withQuery($query)
             ->withAttributesToHighlight($attributesToHighlight, $highlightStartTag, $highlightEndTag)
             ->withAttributesToCrop($attributesToCrop, $cropLength, $cropMarker)
-            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
+            ->withAttributesToRetrieve($attributesToRetrieve)
             ->withSort(['title:asc'])
         ;
 

--- a/tests/Functional/Formatting/FormattingTest.php
+++ b/tests/Functional/Formatting/FormattingTest.php
@@ -181,4 +181,133 @@ class FormattingTest extends TestCase
 
         $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
     }
+
+    public static function truncationProvider(): \Generator
+    {
+        yield 'Truncation shortens long values at word boundary with default marker' => [
+            'assassin',
+            ['title', 'overview'],
+            ['overview'],
+            ['overview'],
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <em>assassin</em> is shot by her ruthless employer,…',
+                            'genres' => ['Action', 'Crime'],
+                        ],
+                    ],
+                ],
+                'query' => 'assassin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            50,
+        ];
+
+        yield 'Truncation per attribute applies attribute-specific lengths' => [
+            'Bill',
+            ['title', 'overview'],
+            [
+                'title' => 5,
+                'overview' => 30,
+            ],
+            ['title', 'overview'],
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill…',
+                            'overview' => 'An assassin is shot by her…',
+                            'genres' => ['Action', 'Crime'],
+                        ],
+                    ],
+                ],
+                'query' => 'Bill',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+        ];
+
+        yield 'Truncation with custom marker' => [
+            'assassin',
+            ['title', 'overview'],
+            ['overview'],
+            ['overview'],
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        'overview' => 'An assassin is shot by her ruthless employer, Bill, and other members of their assassination circle – but she lives to plot her vengeance.',
+                        'genres' => ['Action', 'Crime'],
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <em>assassin</em> is shot by her ruthless employer, [...]',
+                            'genres' => ['Action', 'Crime'],
+                        ],
+                    ],
+                ],
+                'query' => 'assassin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            50,
+            ' [...]',
+        ];
+    }
+
+    /**
+     * @param array<string> $searchableAttributes
+     * @param array<string>|array<string,int> $attributesToTruncate
+     * @param array<string> $attributesToHighlight
+     * @param array<mixed> $expectedResults
+     */
+    #[DataProvider('truncationProvider')]
+    public function testTruncation(
+        string $query,
+        array $searchableAttributes,
+        array $attributesToTruncate,
+        array $attributesToHighlight,
+        array $expectedResults,
+        int $truncationLength = 250,
+        string $truncationMarker = '…',
+    ): void {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes($searchableAttributes)
+            ->withFilterableAttributes(['genres'])
+            ->withSortableAttributes(['title'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery($query)
+            ->withAttributesToTruncate($attributesToTruncate, $truncationLength, $truncationMarker)
+            ->withAttributesToHighlight($attributesToHighlight)
+            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
+            ->withSort(['title:asc'])
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
+    }
 }

--- a/tests/Functional/Formatting/FormattingTest.php
+++ b/tests/Functional/Formatting/FormattingTest.php
@@ -184,6 +184,7 @@ class FormattingTest extends TestCase
 
     /**
      * @param array<string> $searchableAttributes
+     * @param array<string> $attributesToRetrieve
      * @param array<string>|array<string,int> $attributesToTruncate
      * @param array<string> $attributesToHighlight
      * @param array<mixed> $expectedResults
@@ -192,6 +193,7 @@ class FormattingTest extends TestCase
     public function testTruncation(
         string $query,
         array $searchableAttributes,
+        array $attributesToRetrieve,
         array $attributesToTruncate,
         array $attributesToHighlight,
         array $expectedResults,
@@ -211,7 +213,7 @@ class FormattingTest extends TestCase
             ->withQuery($query)
             ->withAttributesToTruncate($attributesToTruncate, $truncationLength, $truncationMarker)
             ->withAttributesToHighlight($attributesToHighlight)
-            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
+            ->withAttributesToRetrieve($attributesToRetrieve)
             ->withSort(['title:asc'])
         ;
 
@@ -223,6 +225,7 @@ class FormattingTest extends TestCase
         yield 'Truncation shortens long values at word boundary with default marker' => [
             'assassin',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             ['overview'],
             [
@@ -252,6 +255,7 @@ class FormattingTest extends TestCase
         yield 'Truncation per attribute applies attribute-specific lengths' => [
             'Bill',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             [
                 'title' => 5,
                 'overview' => 30,
@@ -280,9 +284,37 @@ class FormattingTest extends TestCase
             ],
         ];
 
+        yield 'Truncation returns truncated value in _formatted even when attribute is excluded from attributesToRetrieve' => [
+            'assassin',
+            ['title', 'overview'],
+            ['id', 'title'],
+            ['overview'],
+            ['overview'],
+            [
+                'hits' => [
+                    [
+                        'id' => 24,
+                        'title' => 'Kill Bill: Vol. 1',
+                        '_formatted' => [
+                            'id' => 24,
+                            'title' => 'Kill Bill: Vol. 1',
+                            'overview' => 'An <em>assassin</em> is shot by her ruthless employer,…',
+                        ],
+                    ],
+                ],
+                'query' => 'assassin',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 1,
+            ],
+            50,
+        ];
+
         yield 'Truncation with custom marker' => [
             'assassin',
             ['title', 'overview'],
+            ['id', 'title', 'overview', 'genres'],
             ['overview'],
             ['overview'],
             [

--- a/tests/Functional/Formatting/FormattingTest.php
+++ b/tests/Functional/Formatting/FormattingTest.php
@@ -182,6 +182,42 @@ class FormattingTest extends TestCase
         $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
     }
 
+    /**
+     * @param array<string> $searchableAttributes
+     * @param array<string>|array<string,int> $attributesToTruncate
+     * @param array<string> $attributesToHighlight
+     * @param array<mixed> $expectedResults
+     */
+    #[DataProvider('truncationProvider')]
+    public function testTruncation(
+        string $query,
+        array $searchableAttributes,
+        array $attributesToTruncate,
+        array $attributesToHighlight,
+        array $expectedResults,
+        int $truncationLength = 250,
+        string $truncationMarker = '…',
+    ): void {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes($searchableAttributes)
+            ->withFilterableAttributes(['genres'])
+            ->withSortableAttributes(['title'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery($query)
+            ->withAttributesToTruncate($attributesToTruncate, $truncationLength, $truncationMarker)
+            ->withAttributesToHighlight($attributesToHighlight)
+            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
+            ->withSort(['title:asc'])
+        ;
+
+        $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
+    }
+
     public static function truncationProvider(): \Generator
     {
         yield 'Truncation shortens long values at word boundary with default marker' => [
@@ -273,41 +309,5 @@ class FormattingTest extends TestCase
             50,
             ' [...]',
         ];
-    }
-
-    /**
-     * @param array<string> $searchableAttributes
-     * @param array<string>|array<string,int> $attributesToTruncate
-     * @param array<string> $attributesToHighlight
-     * @param array<mixed> $expectedResults
-     */
-    #[DataProvider('truncationProvider')]
-    public function testTruncation(
-        string $query,
-        array $searchableAttributes,
-        array $attributesToTruncate,
-        array $attributesToHighlight,
-        array $expectedResults,
-        int $truncationLength = 250,
-        string $truncationMarker = '…',
-    ): void {
-        $configuration = Configuration::create()
-            ->withSearchableAttributes($searchableAttributes)
-            ->withFilterableAttributes(['genres'])
-            ->withSortableAttributes(['title'])
-        ;
-
-        $loupe = $this->createLoupe($configuration);
-        $this->indexFixture($loupe, 'movies');
-
-        $searchParameters = SearchParameters::create()
-            ->withQuery($query)
-            ->withAttributesToTruncate($attributesToTruncate, $truncationLength, $truncationMarker)
-            ->withAttributesToHighlight($attributesToHighlight)
-            ->withAttributesToRetrieve(['id', 'title', 'overview', 'genres'])
-            ->withSort(['title:asc'])
-        ;
-
-        $this->searchAndAssertResults($loupe, $searchParameters, $expectedResults);
     }
 }

--- a/tests/Unit/SearchParametersTest.php
+++ b/tests/Unit/SearchParametersTest.php
@@ -64,6 +64,8 @@ class SearchParametersTest extends TestCase
             ->withFilter("status = 'active'")
             ->withAttributesToRetrieve(['title', 'author'])
             ->withAttributesToHighlight(['title'], '<strong>', '</strong>')
+            ->withAttributesToCrop(['title'], 5, ' / ')
+            ->withAttributesToTruncate(['title'], 25, ' + ')
             ->withAttributesToSearchOn(['title'])
             ->withShowMatchesPosition(true)
             ->withShowRankingScore(true)


### PR DESCRIPTION
- Allow truncating specific attributes
- Make the length (250) and marker (...) adjustable
- One major overhaul was needed: allow returning formatted attributes without also returning their original value. Otherwise, the truncation has no effect on the final amount of data returned.

```php
$searchParameters = \Loupe\Loupe\SearchParameters::create()
    ->withAttributesToRetrieve(['id', 'title'])
    ->withAttributesToTruncate(['content']);
```