### PR TITLE
Added support for a query cache with APCu support out-of-the-box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "wamania/php-stemmer": "^4.0",
         "doctrine/lexer": "^2.0 || ^3.0",
         "mjaschen/phpgeo": "^5.0 || ^6.0",
-        "toflar/state-set-index": "^3.0",
+        "toflar/state-set-index": "^3.3",
+        "psr/cache": "^2.0 || ^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
         "loupe/matcher": "^0.2.3"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,30 @@ $configuration = \Loupe\Loupe\Configuration::create()
 
 If you need to browse all the documents and ignore this limit, use [the browse API][Browse].
 
+## Query cache
+
+Loupe can cache internal query artifacts (such as state-set lookups during typo tolerant search) through
+a PSR-6 cache pool:
+
+```php
+$cachePool = new \Symfony\Component\Cache\Adapter\RedisAdapter($redisConnection);
+
+$configuration = \Loupe\Loupe\Configuration::create()
+    ->withQueryCache($cachePool)
+;
+```
+
+If no query cache is configured and APCu is available, Loupe automatically enables an internal APCu-backed
+PSR-6 cache pool out of the box.
+
+To explicitly disable query caching:
+
+```php
+$configuration = \Loupe\Loupe\Configuration::create()
+    ->withQueryCache(null)
+;
+```
+
 ## Debugging
 
 You may pass a PSR-3 logger to Loupe. For the sake of simplicity, Loupe also ships with a very simple 
@@ -242,7 +266,7 @@ $serialized = $configuration->toString();
 $reconstructed = \Loupe\Loupe\Configuration::fromString($serialized);
 ```
 
-Note that this does not work for instances such as the "logger".
+Note that this does not work for instances such as the "logger" or "query cache".
 
 [Browse]: browsing.md
 [Paper]: https://hpi.de/oldsite/fileadmin/user_upload/fachgebiete/naumann/publications/PDFs/2012_fenz_efficient.pdf

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -108,6 +108,27 @@ $configuration = \Loupe\Loupe\Configuration::create()
 Note: The paper works using the Levenshtein algorithm. Loupe includes adjustments built on top of that paper to support
 Damerau-Levenshtein.
 
+## Query cache backend
+
+Loupe can cache internal query artifacts (especially state-set lookups for typo tolerance) via a PSR-6 cache pool.
+By default, Loupe auto-enables an APCu-backed pool when APCu is available. This is intentionally zero-config and
+gives an immediate speedup in many real-world typeahead/autosubmit setups.
+
+Why APCu is the default:
+
+- no setup or external service required
+- very fast local in-process/shared-memory access
+- good default for single-node deployments
+
+Why Redis or Memcached can be the better fit:
+
+- shared cache across multiple PHP workers/containers/hosts
+- cache survives individual worker restarts better
+- centralized memory and eviction policy control
+
+In short: APCu is used by default because it is better than no cache and requires zero setup. If you already run
+Redis or Memcached, plug a PSR-6 pool into `withQueryCache()` to get cross-process cache reuse.
+
 ## Limit the languages to detect
 
 You can read more about what the tokenizer does in the [respective docs](tokenizer.md) but basically, if you know 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -6,7 +6,9 @@ namespace Loupe\Loupe;
 
 use Loupe\Loupe\Config\TypoTolerance;
 use Loupe\Loupe\Exception\InvalidConfigurationException;
+use Loupe\Loupe\Internal\Cache\ApcuCachePool;
 use Loupe\Loupe\Internal\Search\Sorting\Relevance;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 
 final class Configuration
@@ -50,6 +52,8 @@ final class Configuration
      */
     private string|null $processName = null;
 
+    private ?CacheItemPoolInterface $queryCache = null;
+
     /**
      * @var array<string>
      */
@@ -86,6 +90,10 @@ final class Configuration
     public function __construct()
     {
         $this->typoTolerance = new TypoTolerance();
+
+        if (\function_exists('apcu_fetch') && \function_exists('apcu_store')) {
+            $this->queryCache = new ApcuCachePool();
+        }
     }
 
     public static function create(): self
@@ -273,6 +281,11 @@ final class Configuration
         }
 
         return $this->processName;
+    }
+
+    public function getQueryCache(): ?CacheItemPoolInterface
+    {
+        return $this->queryCache;
     }
 
     /**
@@ -466,6 +479,14 @@ final class Configuration
     {
         $clone = clone $this;
         $clone->processName = $processName;
+        return $clone;
+    }
+
+    public function withQueryCache(?CacheItemPoolInterface $queryCache): self
+    {
+        $clone = clone $this;
+        $clone->queryCache = $queryCache;
+
         return $clone;
     }
 

--- a/src/Internal/Cache/ApcuCacheItem.php
+++ b/src/Internal/Cache/ApcuCacheItem.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+use DateInterval;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+
+final class ApcuCacheItem implements CacheItemInterface
+{
+    private bool $hit;
+
+    private ?int $ttl = null;
+
+    private mixed $value;
+
+    public function __construct(
+        private string $key,
+        mixed $value = null,
+        bool $hit = false
+    ) {
+        $this->value = $value;
+        $this->hit = $hit;
+    }
+
+    public function expiresAfter(int|DateInterval|null $time): static
+    {
+        if ($time === null) {
+            $this->ttl = null;
+            return $this;
+        }
+
+        if ($time instanceof DateInterval) {
+            $now = new \DateTimeImmutable();
+            $this->ttl = max(0, $now->add($time)->getTimestamp() - $now->getTimestamp());
+            return $this;
+        }
+
+        $this->ttl = max(0, $time);
+
+        return $this;
+    }
+
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        if ($expiration === null) {
+            $this->ttl = null;
+            return $this;
+        }
+
+        $ttl = $expiration->getTimestamp() - time();
+        $this->ttl = max(0, $ttl);
+
+        return $this;
+    }
+
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getTtl(): ?int
+    {
+        return $this->ttl;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->hit;
+    }
+
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+        $this->hit = true;
+
+        return $this;
+    }
+}

--- a/src/Internal/Cache/ApcuCachePool.php
+++ b/src/Internal/Cache/ApcuCachePool.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class ApcuCachePool implements CacheItemPoolInterface
+{
+    /**
+     * @var array<string, ApcuCacheItem>
+     */
+    private array $deferred = [];
+
+    public function clear(): bool
+    {
+        $this->deferred = [];
+        return apcu_clear_cache();
+    }
+
+    public function commit(): bool
+    {
+        $ok = true;
+
+        foreach ($this->deferred as $key => $item) {
+            if (!$this->save($item)) {
+                $ok = false;
+            }
+            unset($this->deferred[$key]);
+        }
+
+        return $ok;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        self::assertValidKey($key);
+        unset($this->deferred[$key]);
+        return (bool) apcu_delete($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        $ok = true;
+        foreach ($keys as $key) {
+            if (!$this->deleteItem((string) $key)) {
+                $ok = false;
+            }
+        }
+
+        return $ok;
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        self::assertValidKey($key);
+
+        if (isset($this->deferred[$key])) {
+            return $this->deferred[$key];
+        }
+
+        $value = apcu_fetch($key, $success);
+        if ($success) {
+            return new ApcuCacheItem($key, $value, true);
+        }
+
+        return new ApcuCacheItem($key, null, false);
+    }
+
+    /**
+     * @return iterable<string, CacheItemInterface>
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        foreach ($keys as $key) {
+            yield $key => $this->getItem($key);
+        }
+    }
+
+    public function hasItem(string $key): bool
+    {
+        self::assertValidKey($key);
+        return isset($this->deferred[$key]) || apcu_exists($key);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof ApcuCacheItem) {
+            throw new InvalidArgumentException('Unsupported cache item implementation.');
+        }
+
+        $ttl = $item->getTtl() ?? 0;
+        return apcu_store($item->getKey(), $item->get(), $ttl);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof ApcuCacheItem) {
+            throw new InvalidArgumentException('Unsupported cache item implementation.');
+        }
+
+        $this->deferred[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    private static function assertValidKey(string $key): void
+    {
+        if ($key === '' || preg_match('/[{}()\/\\\\@:]/', $key)) {
+            throw new InvalidArgumentException('Invalid cache key: ' . $key);
+        }
+    }
+}

--- a/src/Internal/Cache/InvalidArgumentException.php
+++ b/src/Internal/Cache/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+final class InvalidArgumentException extends \InvalidArgumentException implements \Psr\Cache\InvalidArgumentException
+{
+}

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -19,7 +19,10 @@ use Loupe\Loupe\Internal\LanguageDetection\NitotmLanguageDetector;
 use Loupe\Loupe\Internal\LanguageDetection\PreselectedLanguageDetector;
 use Loupe\Loupe\Internal\Search\Searcher;
 use Loupe\Loupe\Internal\Search\Sorting\Relevance;
+use Loupe\Loupe\Internal\StateSetIndex\CachedStateSetIndex;
+use Loupe\Loupe\Internal\StateSetIndex\DefaultStateSetIndex;
 use Loupe\Loupe\Internal\StateSetIndex\StateSet;
+use Loupe\Loupe\Internal\StateSetIndex\StateSetIndexInterface;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
 use Loupe\Loupe\SearchParameters;
 use Loupe\Loupe\SearchResult;
@@ -60,7 +63,7 @@ class Engine
 
     private IndexInfo $indexInfo;
 
-    private StateSetIndex $stateSetIndex;
+    private StateSetIndexInterface $stateSetIndex;
 
     private StopwordsInterface $stopwords;
 
@@ -75,7 +78,7 @@ class Engine
         private ?string $dataDir = null
     ) {
         $this->indexInfo = new IndexInfo($this);
-        $this->stateSetIndex = new StateSetIndex(
+        $stateSetIndex = new StateSetIndex(
             new Config(
                 $this->configuration->getTypoTolerance()->getIndexLength(),
                 $this->configuration->getTypoTolerance()->getAlphabetSize(),
@@ -84,6 +87,7 @@ class Engine
             new StateSet($this),
             new NullDataStore()
         );
+        $this->stateSetIndex = new DefaultStateSetIndex($stateSetIndex);
         $this->ticketHandler = new TicketHandler($this->connectionPool, $this->getLogger());
         $this->indexer = new Indexer($this, $this->ticketHandler);
         $this->stopwords = new InMemoryStopWords($this->configuration->getStopWords());
@@ -120,6 +124,8 @@ class Engine
         if ($this->getIndexInfo()->needsSetup()) {
             return BrowseResult::createEmptyFromBrowseParameters($parameters);
         }
+
+        $this->maybeWrapStateSetIndexWithCache();
 
         try {
             return (new Searcher($this, $this->filterParser, $parameters))->fetchResult();
@@ -254,7 +260,7 @@ class Engine
         return $this->logger;
     }
 
-    public function getStateSetIndex(): StateSetIndex
+    public function getStateSetIndex(): StateSetIndexInterface
     {
         return $this->stateSetIndex;
     }
@@ -310,6 +316,8 @@ class Engine
             return SearchResult::createEmptyFromSearchParameters($parameters);
         }
 
+        $this->maybeWrapStateSetIndexWithCache();
+
         try {
             return (new Searcher($this, $this->filterParser, $parameters))->fetchResult();
         } catch (Exception $exception) {
@@ -331,6 +339,25 @@ class Engine
         return (int) $this->getConnection()
             ->executeQuery('SELECT (SELECT page_count FROM pragma_page_count) * (SELECT page_size FROM pragma_page_size)')
             ->fetchOne();
+    }
+
+    private function maybeWrapStateSetIndexWithCache(): void
+    {
+        if ($this->stateSetIndex instanceof CachedStateSetIndex) {
+            return;
+        }
+
+        $queryCache = $this->configuration->getQueryCache();
+        if ($queryCache === null || $this->indexInfo->needsSetup()) {
+            return;
+        }
+
+        $this->stateSetIndex = new CachedStateSetIndex(
+            $this->stateSetIndex,
+            $this->configuration->getTypoTolerance(),
+            $queryCache,
+            $this->indexInfo->getIndexUid(),
+        );
     }
 
     private function registerSQLiteFunctions(Connection $connection): void

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -41,6 +41,8 @@ class IndexInfo
      */
     private ?array $documentSchema = null;
 
+    private ?string $indexUid = null;
+
     private ?bool $needsSetup = null;
 
     public function __construct(
@@ -88,6 +90,17 @@ class IndexInfo
                     ConflictMode::Update
                 ))
                 ->execute();
+
+            $this->engine->getConnection()->executeStatement(
+                \sprintf(
+                    "INSERT INTO %s (key, value) VALUES ('%s', :uid) ON CONFLICT(key) DO NOTHING",
+                    self::TABLE_NAME_INDEX_INFO,
+                    'indexUid'
+                ),
+                [
+                    'uid' => $this->generateIndexUid(),
+                ]
+            );
 
             $this->needsSetup = false;
         });
@@ -256,6 +269,47 @@ class IndexInfo
         return array_flip(array_intersect_key(array_flip($this->engine->getConfiguration()->getFilterableAttributes()), $this->getDocumentSchema()));
     }
 
+    public function getIndexUid(): string
+    {
+        if ($this->indexUid !== null) {
+            return $this->indexUid;
+        }
+
+        $uid = $this->engine->getConnection()
+            ->createQueryBuilder()
+            ->select('value')
+            ->from(self::TABLE_NAME_INDEX_INFO)
+            ->where("key = 'indexUid'")
+            ->fetchOne();
+
+        if ($uid === false) {
+            $uid = $this->generateIndexUid();
+            $this->engine->getConnection()->executeStatement(
+                \sprintf(
+                    "INSERT INTO %s (key, value) VALUES ('%s', :uid) ON CONFLICT(key) DO NOTHING",
+                    self::TABLE_NAME_INDEX_INFO,
+                    'indexUid'
+                ),
+                [
+                    'uid' => $uid,
+                ]
+            );
+
+            $uid = $this->engine->getConnection()
+                ->createQueryBuilder()
+                ->select('value')
+                ->from(self::TABLE_NAME_INDEX_INFO)
+                ->where("key = 'indexUid'")
+                ->fetchOne();
+        }
+
+        if (!\is_string($uid) || $uid === '') {
+            throw new \LogicException('Could not determine index UID.');
+        }
+
+        return $this->indexUid = $uid;
+    }
+
     public function getLoupeTypeForAttribute(string $attributeName): string
     {
         if (!\array_key_exists($attributeName, $this->getDocumentSchema())) {
@@ -367,6 +421,7 @@ class IndexInfo
     public function reset(): void
     {
         $this->documentSchema = null;
+        $this->indexUid = null;
         $this->needsSetup = null;
     }
 
@@ -585,6 +640,11 @@ class IndexInfo
         $table->addUniqueIndex(['term', 'state', 'length']);
         $table->addIndex(['state']);
         $table->addIndex(['length']);
+    }
+
+    private function generateIndexUid(): string
+    {
+        return bin2hex(random_bytes(8));
     }
 
     private function getSchema(): Schema

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -58,6 +58,13 @@ class Searcher
     public const RELEVANCE_ALIAS = '_relevance';
 
     /**
+     * Limit how many leading chars we may trim for the last token when looking
+     * up cached snapshots. This improves cache reuse for incremental typing by
+     * allowing matches from a recent shorter suffix (up to 2 chars trimmed).
+     */
+    private const MAX_PREFIX_CHARS_TO_TRIM_FOR_LAST_TOKEN_CACHE_REUSE = 2;
+
+    /**
      * @var array<string, Cte>
      */
     private array $ctesByName = [];
@@ -732,12 +739,12 @@ class Searcher
     private function addTermMatchesCTE(Token $token, bool $isLastToken): void
     {
         $selects = [];
-        $selects[] = $this->createTermMatchesSelect($token->getTerm(), false, $token->isPartOfPhrase());
+        $selects[] = $this->createTermMatchesSelect($token->getTerm(), false, $token->isPartOfPhrase(), $isLastToken);
 
         // Consider variants only if not part of a phrase search
         if (!$token->isPartOfPhrase()) {
             foreach ($token->getVariants() as $term) {
-                $selects[] = $this->createTermMatchesSelect($term, false, false);
+                $selects[] = $this->createTermMatchesSelect($term, false, false, $isLastToken);
             }
         }
 
@@ -748,9 +755,9 @@ class Searcher
         ) {
             // With typo tolerance on prefix search requires searching the prefix tables as well
             if ($this->engine->getConfiguration()->getTypoTolerance()->isEnabledForPrefixSearch()) {
-                $selects[] = $this->createTermMatchesSelect($token->getTerm(), true, false);
+                $selects[] = $this->createTermMatchesSelect($token->getTerm(), true, false, $isLastToken);
             } else {
-                $selects[] = $this->createTermMatchesSelect($token->getTerm(), false, false, true);
+                $selects[] = $this->createTermMatchesSelect($token->getTerm(), false, false, $isLastToken, true);
             }
         }
 
@@ -1002,7 +1009,7 @@ class Searcher
         );
     }
 
-    private function createTermMatchesSelect(string $term, bool $prefix, bool $disableTypoTolerance, bool $prefixLikeOnly = false): string
+    private function createTermMatchesSelect(string $term, bool $prefix, bool $disableTypoTolerance, bool $isLastToken, bool $prefixLikeOnly = false): string
     {
         $termsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS);
         $qb = $this->engine->getConnection()->createQueryBuilder();
@@ -1016,13 +1023,13 @@ class Searcher
                 $this->createNamedParameter($term . '*')
             ));
         } else {
-            $qb->where($this->createWherePartForTerm($term, $prefix, $disableTypoTolerance));
+            $qb->where($this->createWherePartForTerm($term, $prefix, $disableTypoTolerance, $isLastToken));
         }
 
         return $qb->getSQL();
     }
 
-    private function createWherePartForTerm(string $term, bool $prefix, bool $disableTypoTolerance): string
+    private function createWherePartForTerm(string $term, bool $prefix, bool $disableTypoTolerance, bool $isLastToken): string
     {
         $where = [];
         $termParameter = $this->createNamedParameter($term);
@@ -1070,7 +1077,12 @@ class Searcher
             return implode(' ', $where);
         }
 
-        $states = $this->engine->getStateSetIndex()->findMatchingStates($term, $levenshteinDistance, 1);
+        $states = $this->engine->getStateSetIndex()->findMatchingStates(
+            $term,
+            $levenshteinDistance,
+            1,
+            $isLastToken ? self::MAX_PREFIX_CHARS_TO_TRIM_FOR_LAST_TOKEN_CACHE_REUSE : 0
+        );
 
         // No result possible, we add AND 1=0 to ensure no results
         if ($states === []) {

--- a/src/Internal/StateSetIndex/CachedStateSetIndex.php
+++ b/src/Internal/StateSetIndex/CachedStateSetIndex.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\StateSetIndex;
+
+use Loupe\Loupe\Config\TypoTolerance;
+use Psr\Cache\CacheItemPoolInterface;
+use Toflar\StateSetIndex\Alphabet\AlphabetInterface;
+use Toflar\StateSetIndex\Config;
+use Toflar\StateSetIndex\MatchingStatesSnapshot;
+use Toflar\StateSetIndex\StateSet\StateSetInterface;
+
+final class CachedStateSetIndex implements StateSetIndexInterface
+{
+    /**
+     * 60 seconds matches typical typeahead/search interaction windows.
+     * Enough reuse while users iterate, short enough to naturally shed stale prefixes quickly.
+     */
+    private const CACHE_TTL = 60;
+
+    /**
+     * Version namespace rollover guard.
+     * With a 60s TTL, even a very write-heavy index will not realistically hit this value within one TTL window.
+     * It allows us to keep the version prefixes short.
+     */
+    private const CACHE_VERSION_MAX = 10_000;
+
+    private int $cacheVersion = 0;
+
+    public function __construct(
+        private StateSetIndexInterface $inner,
+        private TypoTolerance $typoTolerance,
+        private CacheItemPoolInterface $cachePool,
+        private string $indexUid,
+    ) {
+        $this->cacheVersion = $this->loadCacheVersion();
+    }
+
+    public function continueMatchingStatesSnapshot(string $string, MatchingStatesSnapshot $snapshot): MatchingStatesSnapshot
+    {
+        return $this->inner->continueMatchingStatesSnapshot($string, $snapshot);
+    }
+
+    public function createMatchingStatesSnapshot(string $string, int $editDistance, int $transpositionCost): MatchingStatesSnapshot
+    {
+        return $this->findOrBuildSnapshot($string, $editDistance, $transpositionCost, 2);
+    }
+
+    public function findMatchingStates(string $string, int $editDistance, int $transpositionCost, int $maxPrefixCharsToTrimForCacheReuse = 2): array
+    {
+        $cacheItem = $this->cachePool->getItem($this->buildCacheKey($string, $editDistance, $transpositionCost));
+        if ($cacheItem->isHit()) {
+            $value = $cacheItem->get();
+            if (\is_array($value)) {
+                try {
+                    $snapshot = MatchingStatesSnapshot::fromArray($value);
+                    return $snapshot->matchingStates();
+                } catch (\InvalidArgumentException) {
+                    // Ignore invalid cache payloads and treat as cache miss.
+                }
+            }
+        }
+
+        $snapshot = $this->findOrBuildSnapshot($string, $editDistance, $transpositionCost, $maxPrefixCharsToTrimForCacheReuse);
+        $cacheItem->set($snapshot->toArray())->expiresAfter(self::CACHE_TTL);
+        $this->cachePool->save($cacheItem);
+
+        return $snapshot->matchingStates();
+    }
+
+    public function getAlphabet(): AlphabetInterface
+    {
+        return $this->inner->getAlphabet();
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->inner->getConfig();
+    }
+
+    public function getStateSet(): StateSetInterface
+    {
+        return $this->inner->getStateSet();
+    }
+
+    public function index(array $strings): array
+    {
+        $this->bumpVersion();
+
+        return $this->inner->index($strings);
+    }
+
+    public function removeFromIndex(array $strings): void
+    {
+        $this->bumpVersion();
+
+        $this->inner->removeFromIndex($strings);
+    }
+
+    private function buildCacheKey(string $term, int $levenshteinDistance, int $transpositionCost): string
+    {
+        return 'states.'
+            . $this->indexUid
+            . '.'
+            . $this->cacheVersion
+            . '.'
+            . $this->typoTolerance->getAlphabetSize()
+            . '.'
+            . $this->typoTolerance->getIndexLength()
+            . '.'
+            . $levenshteinDistance
+            . '.'
+            . $transpositionCost
+            . '.'
+            . rawurlencode($term);
+    }
+
+    private function buildVersionKey(): string
+    {
+        return 'states.version.'
+            . $this->indexUid
+            . '.'
+            . $this->typoTolerance->getAlphabetSize()
+            . '.'
+            . $this->typoTolerance->getIndexLength();
+    }
+
+    private function bumpVersion(): void
+    {
+        $versionItem = $this->cachePool->getItem($this->buildVersionKey());
+        $newVersion = ((int) ($versionItem->isHit() ? $versionItem->get() : 0)) + 1;
+
+        if ($newVersion > self::CACHE_VERSION_MAX) {
+            $newVersion = 1;
+        }
+
+        $versionItem->set($newVersion)->expiresAfter(self::CACHE_TTL);
+        $this->cachePool->save($versionItem);
+        $this->cacheVersion = $newVersion;
+    }
+
+    private function findOrBuildSnapshot(string $string, int $editDistance, int $transpositionCost, int $maxPrefixCharsToTrimForCacheReuse): MatchingStatesSnapshot
+    {
+        if ($maxPrefixCharsToTrimForCacheReuse <= 0) {
+            return $this->inner->createMatchingStatesSnapshot($string, $editDistance, $transpositionCost);
+        }
+
+        $termLength = mb_strlen($string);
+        $maxTrim = min($maxPrefixCharsToTrimForCacheReuse, $termLength - 1);
+        for ($trim = 1; $trim <= $maxTrim; ++$trim) {
+            if ($termLength <= $trim) {
+                break;
+            }
+
+            $prefix = mb_substr($string, 0, $termLength - $trim);
+            $prefixItem = $this->cachePool->getItem($this->buildCacheKey($prefix, $editDistance, $transpositionCost));
+            if (!$prefixItem->isHit()) {
+                continue;
+            }
+
+            $prefixValue = $prefixItem->get();
+            if (\is_array($prefixValue)) {
+                try {
+                    $snapshot = MatchingStatesSnapshot::fromArray($prefixValue);
+                    return $this->inner->continueMatchingStatesSnapshot($string, $snapshot);
+                } catch (\InvalidArgumentException) {
+                    continue;
+                }
+            }
+        }
+
+        return $this->inner->createMatchingStatesSnapshot($string, $editDistance, $transpositionCost);
+    }
+
+    private function loadCacheVersion(): int
+    {
+        $versionItem = $this->cachePool->getItem($this->buildVersionKey());
+        if (!$versionItem->isHit()) {
+            return 0;
+        }
+
+        $value = $versionItem->get();
+        if (!\is_int($value) || $value < 0 || $value > self::CACHE_VERSION_MAX) {
+            return 0;
+        }
+
+        return $value;
+    }
+}

--- a/src/Internal/StateSetIndex/DefaultStateSetIndex.php
+++ b/src/Internal/StateSetIndex/DefaultStateSetIndex.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\StateSetIndex;
+
+use Toflar\StateSetIndex\Alphabet\AlphabetInterface;
+use Toflar\StateSetIndex\Config;
+use Toflar\StateSetIndex\MatchingStatesSnapshot;
+use Toflar\StateSetIndex\StateSet\StateSetInterface;
+use Toflar\StateSetIndex\StateSetIndex;
+
+final class DefaultStateSetIndex implements StateSetIndexInterface
+{
+    public function __construct(
+        private StateSetIndex $inner,
+    ) {
+    }
+
+    public function continueMatchingStatesSnapshot(string $string, MatchingStatesSnapshot $snapshot): MatchingStatesSnapshot
+    {
+        return $this->inner->continueMatchingStatesSnapshot($string, $snapshot);
+    }
+
+    public function createMatchingStatesSnapshot(string $string, int $editDistance, int $transpositionCost): MatchingStatesSnapshot
+    {
+        return $this->inner->createMatchingStatesSnapshot($string, $editDistance, $transpositionCost);
+    }
+
+    public function findMatchingStates(string $string, int $editDistance, int $transpositionCost, int $maxPrefixCharsToTrimForCacheReuse = 2): array
+    {
+        return $this->inner->findMatchingStates($string, $editDistance, $transpositionCost);
+    }
+
+    public function getAlphabet(): AlphabetInterface
+    {
+        return $this->inner->getAlphabet();
+    }
+
+    public function getConfig(): Config
+    {
+        return $this->inner->getConfig();
+    }
+
+    public function getStateSet(): StateSetInterface
+    {
+        return $this->inner->getStateSet();
+    }
+
+    public function index(array $strings): array
+    {
+        return $this->inner->index($strings);
+    }
+
+    public function removeFromIndex(array $strings): void
+    {
+        $this->inner->removeFromIndex($strings);
+    }
+}

--- a/src/Internal/StateSetIndex/StateSetIndexInterface.php
+++ b/src/Internal/StateSetIndex/StateSetIndexInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\StateSetIndex;
+
+use Toflar\StateSetIndex\Alphabet\AlphabetInterface;
+use Toflar\StateSetIndex\Config;
+use Toflar\StateSetIndex\MatchingStatesSnapshot;
+use Toflar\StateSetIndex\StateSet\StateSetInterface;
+
+interface StateSetIndexInterface
+{
+    public function continueMatchingStatesSnapshot(string $string, MatchingStatesSnapshot $snapshot): MatchingStatesSnapshot;
+
+    public function createMatchingStatesSnapshot(string $string, int $editDistance, int $transpositionCost): MatchingStatesSnapshot;
+
+    /**
+     * @return array<int>
+     */
+    public function findMatchingStates(string $string, int $editDistance, int $transpositionCost, int $maxPrefixCharsToTrimForCacheReuse = 0): array;
+
+    public function getAlphabet(): AlphabetInterface;
+
+    public function getConfig(): Config;
+
+    public function getStateSet(): StateSetInterface;
+
+    /**
+     * @param array<string> $strings
+     * @return array<string, int>
+     */
+    public function index(array $strings): array;
+
+    /**
+     * @param array<string> $strings
+     */
+    public function removeFromIndex(array $strings): void;
+}

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -9,6 +9,7 @@ use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidConfigurationException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
 
 class ConfigurationTest extends TestCase
 {
@@ -110,5 +111,20 @@ class ConfigurationTest extends TestCase
         );
 
         Configuration::create()->withFilterableAttributes([$attributeName]);
+    }
+
+    public function testQueryCacheCanBeConfigured(): void
+    {
+        $cachePool = $this->createStub(CacheItemPoolInterface::class);
+        $configuration = Configuration::create()->withQueryCache($cachePool);
+
+        $this->assertSame($cachePool, $configuration->getQueryCache());
+    }
+
+    public function testQueryCacheCanBeDisabledExplicitly(): void
+    {
+        $configuration = Configuration::create()->withQueryCache(null);
+
+        $this->assertNull($configuration->getQueryCache());
     }
 }

--- a/tests/Unit/Internal/StateSetIndex/StateSetTest.php
+++ b/tests/Unit/Internal/StateSetIndex/StateSetTest.php
@@ -10,10 +10,10 @@ use Doctrine\DBAL\Tools\DsnParser;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\ConnectionPool;
 use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\StateSetIndex\StateSetIndexInterface;
 use Loupe\Loupe\Tests\StorageFixturesTestTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use Toflar\StateSetIndex\StateSetIndex;
 
 class StateSetTest extends TestCase
 {
@@ -86,7 +86,7 @@ class StateSetTest extends TestCase
     {
         $engine = $this->createTestEngine();
 
-        $this->assertInstanceOf(StateSetIndex::class, $engine->getStateSetIndex());
+        $this->assertInstanceOf(StateSetIndexInterface::class, $engine->getStateSetIndex());
     }
 
     public function testStateSetIndexRevisedAfterDocumentDeleted(): void


### PR DESCRIPTION
This PR adds query-time state-set cache reuse for typo-tolerant search, with a zero-config acceleration when APCu is available.

I intentionally called it `query cache` so should we have other cacheable information in the future, we can add that to the same cache but for now, it's basically "only" caching state set caculation. It depends on https://github.com/Toflar/state-set-index/pull/21 which contains the feature to calculate a state snapshot and calculate the states from a given snaphsot.

Why do I want to do that?

Autosubmit/typeahead queries are highly similar (`thoma` -> `thomas`, `amakin dkywalke` -> `amakin dkywalker`).  
Without reuse, state-set matching is recalculated for each request. This is especially wasteful for multi-term queries where usually only the last term changes vs. a prior request.
This PR reuses prior prefix state snapshots within a short TTL window of 60 seconds.

Changes summarized:

- Introduced a query cache in configuration via PSR-6
- Added default internal APCu PSR-6 pool (auto-enabled when APCu is available, disable with `withQueryCache(null)`)
- Added index-UID namespacing to avoid cross-index cache key collisions
- Added versioned cache invalidation on `index()` / `removeFromIndex()`
- Added bounded prefix reuse for typeahead (`-1`, `-2`) and only for the last query term. This means that when searching for `thomas` we can re-use a previous `thoma` cache in case this was already calculated.

Performance is a bit hard to measure and very much depends on the query (longer terms = more typos are tolerated = more states need to be calculated = caching helps a lot more).
I tried with our `php bin/bench/search.php` example (so the `Amakin Dkywalke` vs  `Amakin Dkywalker`) tests in a web environment (because on CLI there's no APCu request cache sharing) and was able to get about **35% to 40%** faster search results as of the second search request 🚀 😎 
