### PR TITLE
Use shared candidate document set

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -33,6 +33,8 @@ class Searcher
 {
     public const CTE_ALL_MULTI_FILTERS_PREFIX = '_cte_mf_all_';
 
+    public const CTE_CANDIDATE_DOCUMENTS = '_cte_candidate_documents';
+
     public const CTE_MATCHES = '_cte_matches';
 
     public const CTE_TERM_DOCUMENT_MATCHES_PREFIX = '_cte_term_document_matches_';
@@ -630,20 +632,16 @@ class Searcher
         $cteSelectQb->from(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS, $termsDocumentsAlias);
 
         // Get documents that match any of our terms
-        $documentConditions = [];
-        foreach ($this->getTokens()->all() as $otherToken) {
-            $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENTS_PREFIX, $otherToken);
-            if (!$this->hasCTE($cteName)) {
-                continue;
-            }
-            $documentConditions[] = \sprintf('%s.document IN (SELECT document FROM %s)', $termsDocumentsAlias, $cteName);
-        }
-
-        if ($documentConditions === []) {
+        if (!$this->ensureCandidateDocumentsCTE()) {
             return;
         }
 
-        $cteSelectQb->where('(' . implode(' OR ', $documentConditions) . ')');
+        $cteSelectQb->where(\sprintf(
+            '%s.document IN (SELECT document FROM %s)',
+            $termsDocumentsAlias,
+            self::CTE_CANDIDATE_DOCUMENTS
+        ));
+
         $cteSelectQb->andWhere(\sprintf($termsDocumentsAlias . '.term IN (SELECT id FROM %s)', $termMatchesCTE));
 
         if (['*'] !== $this->queryParameters->getAttributesToSearchOn()) {
@@ -1149,6 +1147,34 @@ class Searcher
         }
 
         return implode(' ', $where);
+    }
+
+    private function ensureCandidateDocumentsCTE(): bool
+    {
+        if ($this->hasCTE(self::CTE_CANDIDATE_DOCUMENTS)) {
+            return true;
+        }
+
+        $unionParts = [];
+        foreach ($this->getTokens()->all() as $otherToken) {
+            $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENTS_PREFIX, $otherToken);
+            if (!$this->hasCTE($cteName)) {
+                continue;
+            }
+            $unionParts[] = 'SELECT document FROM ' . $cteName;
+        }
+
+        if ($unionParts === []) {
+            return false;
+        }
+
+        $cteSelectQb = $this->engine->getConnection()->createQueryBuilder();
+        $cteSelectQb->select('document');
+        $cteSelectQb->from('(' . implode(' UNION ', $unionParts) . ')');
+
+        $this->addCTE(new Cte(self::CTE_CANDIDATE_DOCUMENTS, ['document'], $cteSelectQb));
+
+        return true;
     }
 
     private function filterDocuments(TokenCollection $tokenCollection): void

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -27,6 +27,18 @@ use Loupe\Matcher\Tokenizer\Token;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 
 /**
+ * Searcher class.
+ *
+ * Builds and runs the search SQL as a chain of CTEs.
+ *
+ * Per-token pipeline:
+ *
+ *   _cte_term_matches_<token> (term ids matching the token, including typo/prefix variants)
+ *     -> _cte_term_documents_<token> (distinct documents containing any of those terms)
+ *          -> _cte_candidate_documents (UNION of every token's term-documents = "matches any term")
+ *               -> _cte_term_document_matches_<token> (per-token positional matches, restricted to candidate documents)
+ *                    -> _cte_matches (final per-document aggregation feeding ranking/selection)
+ *
  * @template T of AbstractQueryParameters
  */
 class Searcher

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -631,8 +631,9 @@ class Searcher
 
         $cteSelectQb->from(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS, $termsDocumentsAlias);
 
-        // Get documents that match any of our terms
-        if (!$this->ensureCandidateDocumentsCTE()) {
+        // Restrict to documents matching any query term (shared candidate set)
+        $hasCandidateDocuments = $this->ensureSharedCandidateDocumentsCTE();
+        if (!$hasCandidateDocuments) {
             return;
         }
 
@@ -1149,12 +1150,20 @@ class Searcher
         return implode(' ', $where);
     }
 
-    private function ensureCandidateDocumentsCTE(): bool
+    /**
+     * Lazily build the shared "_cte_candidate_documents" CTE: set of documents matching ANY query term
+     * (the UNION of every token's _cte_term_documents_* list), and reports whether such a set exists.
+     * Done so that SQLite can satisfy each token with a single index lookup by computing the union once.
+     *
+     * @return bool true when a candidate set exists, false when no token has a term-documents CTE
+     */
+    private function ensureSharedCandidateDocumentsCTE(): bool
     {
         if ($this->hasCTE(self::CTE_CANDIDATE_DOCUMENTS)) {
             return true;
         }
 
+        // Collect each token's document list (their UNION is the "matches any term" candidate set)
         $unionParts = [];
         foreach ($this->getTokens()->all() as $otherToken) {
             $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENTS_PREFIX, $otherToken);
@@ -1170,7 +1179,7 @@ class Searcher
 
         $cteSelectQb = $this->engine->getConnection()->createQueryBuilder();
         $cteSelectQb->select('document');
-        $cteSelectQb->from('(' . implode(' UNION ', $unionParts) . ')');
+        $cteSelectQb->from('(' . implode(' UNION ', $unionParts) . ') candidates');
 
         $this->addCTE(new Cte(self::CTE_CANDIDATE_DOCUMENTS, ['document'], $cteSelectQb));
 

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -927,6 +927,16 @@ class Searcher
             MatchingStrategy::Any => ' OR ',
         };
 
+        // Fast path: "any" strategy, only positive single-token groups: use _cte_candidate_documents directly
+        if ($strategy === MatchingStrategy::Any
+            && $negativeConditions === []
+            && $positiveConditions !== []
+            && $this->hasCTE(self::CTE_CANDIDATE_DOCUMENTS)
+            && array_filter($positiveConditions, fn ($s) => \count($s) !== 1) === []
+        ) {
+            return \sprintf('SELECT document AS document_id FROM %s', self::CTE_CANDIDATE_DOCUMENTS);
+        }
+
         $where = implode($positiveOperator, array_map(
             fn ($statements) => '(' . implode(' AND ', $statements) . ')',
             $positiveConditions


### PR DESCRIPTION
- Compute a shared `_cte_candidate_documents` CTE across all tokens
- The matches-any-term set is now materialized & indexed once instead of being derived in every token match CTE
- Speedup of around 35% for multi-term & 3% for single-word queries

### Why

- The candidate-document set is the union, over all tokens, of each token's `_cte_term_documents_<token>` row
- Currently, that set is built inline in every per-token match CTE as a subquery
- With this change, the union is built once as a shared CTE, and each per-token match CTE references it a single time
- It's the same logical filter, but computed once over a materialized indexable set and checked once per token
- Bonus: we can now short-circuit positive single-token group searches to use that new CTE

### Benchmark

| Subject | Before | After | Change |
|---|---|---|---|
| benchExactQueryWithFacets | 33,71ms | 23,15ms | **31% faster** |
| benchMultiWordQueries | 1.602,61ms | 994,57ms | **38% faster** |
| benchPlainQuery | 209,66ms | 123,34ms | **41% faster** |
| benchSingleWordQueries | 282,32ms | 273,06ms | **3% faster** |
| benchTypoQueryWithFacets | 32,03ms | 23,39ms | **27% faster** |
| benchFilteredSortedSearch | 31,21ms | 31,32ms | **0,4% slower** (margin of error) |

### Notes

I've added an explanation of the current CTE pipeline at the top because I kept forgetting which CTE does what :)
