### PR TITLE
Make benchmarks more stable

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -7,6 +7,7 @@
         "XDEBUG_MODE": "off"
     },
     "runner.php_config": {
+        "apc.enable_cli": "0",
         "opcache.enable_cli": "1",
         "opcache.jit": "disable",
         "memory_limit": "256M"

--- a/phpbench.json
+++ b/phpbench.json
@@ -5,8 +5,7 @@
     "runner.file_pattern": "*Bench.php",
     "runner.php_config": {
         "opcache.enable_cli": "1",
-        "opcache.jit": "tracing",
-        "opcache.jit_buffer_size": "64M",
+        "opcache.jit": "disable",
         "memory_limit": "256M"
     }
 }

--- a/phpbench.json
+++ b/phpbench.json
@@ -3,6 +3,9 @@
     "runner.bootstrap": "vendor/autoload.php",
     "runner.path": "tests/Benchmark",
     "runner.file_pattern": "*Bench.php",
+    "runner.php_env": {
+        "XDEBUG_MODE": "off"
+    },
     "runner.php_config": {
         "opcache.enable_cli": "1",
         "opcache.jit": "disable",


### PR DESCRIPTION
JIT is incompatible with extensions like `xdebug` - see https://bugs.xdebug.org/view.php?id=2293.
I also think it's better for benchmarks anyway because it keeps them more stable.

Okay for you @daun?