### PR TITLE
Optimize multi-token relevance CTE aggregation in search

### DIFF
--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -59,23 +59,14 @@ class Relevance extends AbstractSorter
             // Create the relevance CTE
             $qb = $engine->getConnection()->createQueryBuilder();
             $qb
-                ->addSelect(Searcher::CTE_MATCHES . '.document_id AS document')
-                // COALESCE() makes sure that if the token does not match a document, we don't have NULL but a 0 which is important
-                // for the relevance split. Otherwise, the relevance calculation cannot know which of the documents did not match
-                // because it's just a ";" separated list.
-                ->from(Searcher::CTE_MATCHES)
-                ->leftJoin(
-                    Searcher::CTE_MATCHES,
-                    $cteName,
-                    'dm',
-                    \sprintf('dm.document = %s.document_id', Searcher::CTE_MATCHES)
-                )
-                ->groupBy(Searcher::CTE_MATCHES . '.document_id');
+                ->addSelect('dm.document AS document')
+                ->from($cteName, 'dm')
+                ->groupBy('dm.document');
 
             if ($needsFoldingState) {
-                $qb->addSelect("COALESCE(group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos), '0') || '|' || COALESCE(MAX(dm.exact_match), 0) AS relevance");
+                $qb->addSelect("group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos) || '|' || COALESCE(MAX(dm.exact_match), 0) AS relevance");
             } else {
-                $qb->addSelect("COALESCE(group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos), '0' ) AS relevance");
+                $qb->addSelect("group_concat(dm.position || ':' || dm.attribute || ':' || dm.typos) AS relevance");
             }
 
             $searcher->addCTE(new Cte($termRelevanceCTE, ['document_id', 'relevance_per_term'], $qb));
@@ -90,9 +81,14 @@ class Relevance extends AbstractSorter
 
         // CTE for all documents
         $qb = $engine->getConnection()->createQueryBuilder();
+        $relevancesWithFallback = array_map(
+            static fn (string $relevance): string => \sprintf("COALESCE(%s, '0')", $relevance),
+            $relevances
+        );
+
         $qb
             ->addSelect(Searcher::CTE_MATCHES . '.document_id AS document')
-            ->addSelect(implode(" || ';' || ", $relevances) . ' AS relevance_per_term')
+            ->addSelect(implode(" || ';' || ", $relevancesWithFallback) . ' AS relevance_per_term')
             ->from(Searcher::CTE_MATCHES)
         ;
 


### PR DESCRIPTION
Improve query performance by simplifying relevance aggregation for multi-token searches.
Instead of rebuilding per-token relevance by left-joining `_cte_matches` for every token, we now aggregate each token directly from its `_cte_term_document_matches_*` CTE and only apply the `'0'` fallback once when composing the final relevance string. This removes repeated scans/grouping over `_cte_matches` and reduces CTE work on the hot path.

Before:

```
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
| benchmark   | subject                   | set | revs | its | mem_peak | mode     | rstdev |
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
| SearchBench | benchExactQueryWithFacets |     | 3    | 5   | 7.175mb  | 7.59ms   | ±3.22% |
| SearchBench | benchMultiWordQueries     |     | 1    | 5   | 7.537mb  | 478.14ms | ±0.71% |
| SearchBench | benchPlainQuery           |     | 3    | 5   | 1.997mb  | 77.58ms  | ±1.10% |
| SearchBench | benchSingleWordQueries    |     | 1    | 5   | 7.175mb  | 112.71ms | ±1.61% |
| SearchBench | benchTypoQueryWithFacets  |     | 3    | 5   | 7.175mb  | 7.58ms   | ±3.35% |
| FilterBench | benchFilteredSortedSearch |     | 3    | 5   | 7.252mb  | 10.93ms  | ±8.72% |
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
```

After:

```
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
| benchmark   | subject                   | set | revs | its | mem_peak | mode     | rstdev |
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
| SearchBench | benchExactQueryWithFacets |     | 3    | 5   | 7.175mb  | 7.01ms   | ±2.06% |
| SearchBench | benchMultiWordQueries     |     | 1    | 5   | 7.464mb  | 418.65ms | ±1.16% |
| SearchBench | benchPlainQuery           |     | 3    | 5   | 1.997mb  | 69.99ms  | ±0.68% |
| SearchBench | benchSingleWordQueries    |     | 1    | 5   | 7.175mb  | 103.52ms | ±1.03% |
| SearchBench | benchTypoQueryWithFacets  |     | 3    | 5   | 7.175mb  | 6.95ms   | ±1.31% |
| FilterBench | benchFilteredSortedSearch |     | 3    | 5   | 7.252mb  | 10.69ms  | ±4.53% |
+-------------+---------------------------+-----+------+-----+----------+----------+--------+
```