### PR TITLE
Increase term batch size to 16k for faster indexing

### DIFF
--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -27,10 +27,11 @@ class Indexer
      * heaviest queries. Technically, we might also do this for the number of other attributes that people want to filter
      * for, but it is rather unrealistic to have documents with thousands of values people want to filter (not search!) for.
      * The higher this number is, the faster the indexing process is going to be but the more memory is required. For now,
-     * tests have shown a good result with 2000 terms, but we might want to make this configurable one day.
+     * tests have shown a good result with 16_000 terms in our benchmark setup, balancing indexing throughput and
+     * memory usage, but we might want to make this configurable one day.
      * However, it's also a bit hard to document and understand so for now, let's keep this internal.
      */
-    private const MAX_TERMS_PER_BATCH = 2000;
+    private const MAX_TERMS_PER_BATCH = 16000;
 
     /**
      * @var array<int, callable>


### PR DESCRIPTION
TLDR:

- ~5–9% faster on small/medium workloads
- ~15–17% faster on large workloads
- Uses 0–3% more peak memory

Before:

```
+------------+----------------------+-----+------+-----+-----------+------------+--------+
| benchmark  | subject              | set | revs | its | mem_peak  | mode       | rstdev |
+------------+----------------------+-----+------+-----+-----------+------------+--------+
| IndexBench | benchAddDocuments    | 1k  | 1    | 1   | 62.101mb  | 216.48ms   | ±0.00% |
| IndexBench | benchAddDocuments    | 10k | 1    | 1   | 62.101mb  | 2,132.19ms | ±0.00% |
| IndexBench | benchAddDocuments    | all | 1    | 1   | 102.515mb | 8,398.51ms | ±0.00% |
| IndexBench | benchUpdateDocuments | 1k  | 1    | 1   | 63.504mb  | 196.69ms   | ±0.00% |
| IndexBench | benchUpdateDocuments | 10k | 1    | 1   | 76.055mb  | 2,163.05ms | ±0.00% |
| IndexBench | benchUpdateDocuments | all | 1    | 1   | 118.935mb | 8,529.24ms | ±0.00% |
+------------+----------------------+-----+------+-----+-----------+------------+--------+
```

After:

```
+------------+----------------------+-----+------+-----+-----------+------------+--------+
| benchmark  | subject              | set | revs | its | mem_peak  | mode       | rstdev |
+------------+----------------------+-----+------+-----+-----------+------------+--------+
| IndexBench | benchAddDocuments    | 1k  | 1    | 1   | 62.101mb  | 196.46ms   | ±0.00% |
| IndexBench | benchAddDocuments    | 10k | 1    | 1   | 62.101mb  | 2,015.06ms | ±0.00% |
| IndexBench | benchAddDocuments    | all | 1    | 1   | 105.788mb | 7,162.54ms | ±0.00% |
| IndexBench | benchUpdateDocuments | 1k  | 1    | 1   | 63.504mb  | 198.19ms   | ±0.00% |
| IndexBench | benchUpdateDocuments | 10k | 1    | 1   | 76.055mb  | 2,062.55ms | ±0.00% |
| IndexBench | benchUpdateDocuments | all | 1    | 1   | 120.111mb | 7,119.89ms | ±0.00% |
+------------+----------------------+-----+------+-----+-----------+------------+--------+
```