### PR TITLE
Skip superfluous group-by for dedup

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -614,14 +614,14 @@ class Searcher
         $termsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_TERMS);
 
         if ($needsTypoCount) {
-            $cteSelectQb->addSelect(\sprintf('MIN(%s.typos) AS typos', $termMatchesCTE));
+            $cteSelectQb->addSelect(\sprintf('%s.typos AS typos', $termMatchesCTE));
         } else {
             $cteSelectQb->addSelect('0 AS typos');
         }
 
         if ($needsFoldingState) {
             $cteSelectQb->addSelect(\sprintf(
-                'MAX(CASE WHEN %s.is_exact_term = 1 AND %s.folded = %s THEN 1 ELSE 0 END) AS exact_match',
+                'CASE WHEN %s.is_exact_term = 1 AND %s.folded = %s THEN 1 ELSE 0 END AS exact_match',
                 $termMatchesCTE,
                 $termsDocumentsAlias,
                 $token->wasFolded() ? '1' : '0'
@@ -666,10 +666,6 @@ class Searcher
                 $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken),
             ));
         }
-
-        $cteSelectQb->groupBy($termsDocumentsAlias . '.document');
-        $cteSelectQb->addGroupBy($termsDocumentsAlias . '.attribute');
-        $cteSelectQb->addGroupBy($termsDocumentsAlias . '.position');
 
         $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
 


### PR DESCRIPTION
Another quick win :) The `group_concat` in `Relevance` is enough to ensure deduplication, so some group-bys in the searcher are no longer required. Removes a TEMP B-TREE sort per term, a somewhat expensive step in the relevance logic.

### Benchmarks

| Benchmark   | Subject                   | Before Mode | After Mode | Change  |
|-------------|---------------------------|-------------|------------|---------|
| SearchBench | benchExactQueryWithFacets | 8.94ms      | 8.87ms     | -0.78%  |
| SearchBench | benchMultiWordQueries     | 227.52ms    | 190.44ms   | -16.30% |
| SearchBench | benchPlainQuery           | 17.74ms     | 15.88ms    | -10.49% |
| SearchBench | benchSingleWordQueries    | 60.03ms     | 55.93ms    | -6.83%  |
| SearchBench | benchTypoQueryWithFacets  | 8.58ms      | 8.68ms     | +1.17%  |
| FilterBench | benchFilteredSortedSearch | 20.50ms     | 20.61ms    | +0.54%  |
