### PR TITLE
Skip redundant where clause already enforced by join

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -649,8 +649,6 @@ class Searcher
             self::CTE_CANDIDATE_DOCUMENTS
         ));
 
-        $cteSelectQb->andWhere(\sprintf($termsDocumentsAlias . '.term IN (SELECT id FROM %s)', $termMatchesCTE));
-
         if (['*'] !== $this->queryParameters->getAttributesToSearchOn()) {
             $cteSelectQb->andWhere(\sprintf(
                 $termsDocumentsAlias . '.attribute IN (%s)',


### PR DESCRIPTION
Remove a redundant where clause from the term_document_matches CTE.
It's already enforced by the join, so the work is not required.

### Benchmarks

| Benchmark   | Subject                   | Before Mode | After Mode | Change  |
|-------------|---------------------------|-------------|------------|---------|
| SearchBench | benchExactQueryWithFacets | 9.13ms      | 8.20ms     | -10.19% |
| SearchBench | benchMultiWordQueries     | 235.43ms    | 208.04ms   | -11.63% |
| SearchBench | benchPlainQuery           | 19.82ms     | 17.78ms    | -10.29% |
| SearchBench | benchSingleWordQueries    | 65.98ms     | 64.14ms    | -2.79%  |
| SearchBench | benchTypoQueryWithFacets  | 8.78ms      | 8.13ms     | -7.40%  |
| FilterBench | benchFilteredSortedSearch | 21.03ms     | 20.39ms    | -3.04%  |