### PR TITLE
Add missing indexes for cleanup queries

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -517,6 +517,7 @@ class IndexInfo
             ->setNotnull(true);
 
         $table->setPrimaryKey(['attribute', 'document'], 'attribute_document');
+        $table->addIndex(['document']);
     }
 
     private function addMultiAttributesToSchema(Schema $schema): void
@@ -577,6 +578,7 @@ class IndexInfo
             ->setNotnull(true);
 
         $table->setPrimaryKey(['prefix', 'term']);
+        $table->addIndex(['term']);
     }
 
     private function addStateSetToSchema(Schema $schema): void


### PR DESCRIPTION
bench-index (current setup) improved from roughly:
 - add-all: ~7,217ms -> ~7,025ms
- update-all: ~7,229ms -> ~6,961ms