### PR TITLE
Skip redundant candidate-doc filter for single-token queries

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -637,17 +637,20 @@ class Searcher
             \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias)
         );
 
-        // Restrict to documents matching any query term (shared candidate set)
-        $hasCandidateDocuments = $this->ensureSharedCandidateDocumentsCTE();
-        if (!$hasCandidateDocuments) {
-            return;
-        }
+        // Restrict to shared candidate documents only for real multi-token queries.
+        // For single-token queries this check is redundant and adds avoidable overhead.
+        if ($this->getSearchTokens()->count() > 1) {
+            $hasCandidateDocuments = $this->ensureSharedCandidateDocumentsCTE();
+            if (!$hasCandidateDocuments) {
+                return;
+            }
 
-        $cteSelectQb->where(\sprintf(
-            '%s.document IN (SELECT document FROM %s)',
-            $termsDocumentsAlias,
-            self::CTE_CANDIDATE_DOCUMENTS
-        ));
+            $cteSelectQb->where(\sprintf(
+                '%s.document IN (SELECT document FROM %s)',
+                $termsDocumentsAlias,
+                self::CTE_CANDIDATE_DOCUMENTS
+            ));
+        }
 
         if (['*'] !== $this->queryParameters->getAttributesToSearchOn()) {
             $cteSelectQb->andWhere(\sprintf(


### PR DESCRIPTION
Optimize single-token query execution by avoiding the `_cte_candidate_documents` membership filter in `addTermDocumentMatchesCTE()` when only one search token is present.
For single-token searches, this filter is redundant and adds unnecessary query work. We now keep it only for multi-token queries.
Benchmark impact:
* benchSingleWordQueries: ~51.5ms -> ~34.7ms
* benchMultiWordQueries: effectively unchanged

/cc @daun