### PR TITLE
Skip tokenization for unchanged docs

### DIFF
--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -38,6 +38,13 @@ class Indexer
      */
     private array $changes = [];
 
+    /**
+     * Map of id => content hash loaded once per addDocuments() to skip expensive tokenization for unchanged documents
+     *
+     * @var array<string, string>
+     */
+    private array $existingHashes = [];
+
     public function __construct(
         private Engine $engine,
         private TicketHandler $ticketHandler
@@ -65,6 +72,9 @@ class Indexer
         foreach ($documents as $document) {
             $this->engine->getIndexInfo()->fixAndValidateDocument($document);
         }
+
+        // Pre-load existing content hashes so unchanged documents can skip tokenization
+        $this->existingHashes = $this->loadExistingHashes($documents);
 
         $processBatch = function (PreparedDocumentCollection $preparedDocuments): void {
             if ($preparedDocuments->empty()) {
@@ -528,6 +538,44 @@ class Indexer
     }
 
     /**
+     * @param array<array<string,mixed>> $documents
+     * @return array<string, string>
+     */
+    private function loadExistingHashes(array $documents): array
+    {
+        if ($this->engine->getIndexInfo()->needsSetup()) {
+            return [];
+        }
+
+        $primaryKey = $this->engine->getConfiguration()->getPrimaryKey();
+        $userIds = [];
+        foreach ($documents as $document) {
+            if (isset($document[$primaryKey])) {
+                $userIds[(string) $document[$primaryKey]] = true;
+            }
+        }
+
+        if ($userIds === []) {
+            return [];
+        }
+
+        $hashes = [];
+        foreach (array_chunk(array_keys($userIds), 5000) as $chunk) {
+            $rows = $this->engine->getConnection()->executeQuery(
+                \sprintf('SELECT _user_id, _hash FROM %s WHERE _user_id IN (?)', IndexInfo::TABLE_NAME_DOCUMENTS),
+                [$chunk],
+                [ArrayParameterType::STRING]
+            )->fetchAllKeyValue();
+
+            foreach ($rows as $userId => $hash) {
+                $hashes[(string) $userId] = $hash;
+            }
+        }
+
+        return $hashes;
+    }
+
+    /**
      * @param array<string, mixed> $document
      */
     private function migrateDatabase(array $document): void
@@ -622,11 +670,18 @@ class Indexer
 
         // Keep the primary key in persisted document data so reindex/migration can always rehydrate documents.
         $documentData[$primaryKey] = $document[$primaryKey];
+        $userId = (string) $document[$primaryKey];
 
         $preparedDocument = new PreparedDocument(
-            (string) $document[$primaryKey],
+            $userId,
             Util::encodeJson($documentData)
         );
+
+        // Unchanged documents (hash matches) are excluded by the SQL change detection
+        // Their terms and attributes are never used so we can skip expensive tokenization and attribute extraction
+        if (isset($this->existingHashes[$userId]) && $this->existingHashes[$userId] === $preparedDocument->getContentHash()) {
+            return $preparedDocument;
+        }
 
         $singleAttributes = [];
         $multiAttributes = [];

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -97,8 +97,16 @@ class Indexer
             $preparedDocuments = new PreparedDocumentCollection();
 
             foreach ($documents as $k => $document) {
-                $preparedDocuments->add($this->prepareDocument($document));
+                $preparedDocument = $this->prepareDocument($document);
+                $userId = $preparedDocument->getUserId();
                 unset($documents[$k]);
+
+                // Do not add unchanged documents to the batch: they only contain the base columns and violate NOT NULL constraints
+                if (isset($this->existingHashes[$userId]) && $this->existingHashes[$userId] === $preparedDocument->getContentHash()) {
+                    continue;
+                }
+
+                $preparedDocuments->add($preparedDocument);
 
                 if ($preparedDocuments->getTermsCount() >= self::MAX_TERMS_PER_BATCH) {
                     break;
@@ -677,8 +685,7 @@ class Indexer
             Util::encodeJson($documentData)
         );
 
-        // Unchanged documents (hash matches) are excluded by the SQL change detection
-        // Their terms and attributes are never used so we can skip expensive tokenization and attribute extraction
+        // Terms and attributes of unchanged documents are excluded by the SQL change detection: skip expensive tokenization & attribute extraction
         if (isset($this->existingHashes[$userId]) && $this->existingHashes[$userId] === $preparedDocument->getContentHash()) {
             return $preparedDocument;
         }

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -127,6 +127,82 @@ class IndexTest extends TestCase
         // values for null or empty string.
     }
 
+    public function testBatchWithMixOfUnchangedChangedAndNewDocuments(): void
+    {
+        // A single addDocuments() call that mixes an unchanged document (skip path) with a changed one and a brand new
+        // one. The skip path runs inside the batching loop, so we make sure it does not interfere with its neighbours.
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['firstname', 'lastname'])
+            ->withFilterableAttributes(['departments', 'gender'])
+            ->withSortableAttributes(['firstname'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([self::getSandraDocument(), self::getUtaDocument()]);
+
+        $unchangedDocument = self::getSandraDocument();
+
+        $changedDocument = array_merge(self::getUtaDocument(), [
+            'lastname' => 'Schmidt',
+        ]);
+
+        $newDocument = [
+            'id' => 3,
+            'firstname' => 'Nina',
+            'lastname' => 'Neumann',
+            'gender' => 'female',
+            'departments' => ['Development'],
+            'colors' => ['Blue'],
+            'age' => 33,
+        ];
+
+        $loupe->addDocuments([
+            $unchangedDocument, // unchanged -> skip path
+            $changedDocument,   // changed -> must be re-tokenized
+            $newDocument,       // new -> must be indexed
+        ]);
+
+        $this->assertSame(3, $loupe->countDocuments());
+
+        // Sandra (unchanged) untouched
+        $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('maier'))->getTotalHits());
+
+        // Uta's old term is gone, new term is searchable
+        $this->assertSame(0, $loupe->search(SearchParameters::create()->withQuery('koertig'))->getTotalHits());
+        $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('schmidt'))->getTotalHits());
+
+        // New document searchable
+        $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('neumann'))->getTotalHits());
+
+        // Filtering across all three still works
+        $params = SearchParameters::create()
+            ->withFilter("departments = 'Development'")
+            ->withAttributesToRetrieve(['id', 'firstname'])
+            ->withSort(['firstname:asc']);
+
+        $this->searchAndAssertResults($loupe, $params, [
+            'hits' => [
+                [
+                    'id' => 3,
+                    'firstname' => 'Nina',
+                ],
+                [
+                    'id' => 1,
+                    'firstname' => 'Sandra',
+                ],
+                [
+                    'id' => 2,
+                    'firstname' => 'Uta',
+                ],
+            ],
+            'query' => '',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 3,
+        ]);
+    }
+
     public function testCanFilterAndSortOnNonExistingSchema(): void
     {
         $configuration = Configuration::create()
@@ -299,6 +375,29 @@ class IndexTest extends TestCase
         $this->assertNull($loupe->getDocument('not_existing_identifier'));
     }
 
+    public function testIdenticalReAddDoesNotPoisonLaterRealUpdate(): void
+    {
+        // Re-add an identical document, then change it. The earlier skip must not prevent the real update from being applied
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['firstname', 'lastname'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocument(self::getSandraDocument());
+
+        // Identical re-add -> skip path
+        $loupe->addDocument(self::getSandraDocument());
+        $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('maier'))->getTotalHits());
+
+        // Now a real change to the same id
+        $loupe->addDocument(array_merge(self::getSandraDocument(), [
+            'lastname' => 'Schmidt',
+        ]));
+
+        $this->assertSame(0, $loupe->search(SearchParameters::create()->withQuery('maier'))->getTotalHits());
+        $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('schmidt'))->getTotalHits());
+    }
+
     public function testIndexingIdenticalDocumentWorksIfConfigChanges(): void
     {
         $dir = $this->createTemporaryDirectory();
@@ -443,6 +542,60 @@ class IndexTest extends TestCase
         ]);
 
         $this->assertSame(2, $loupe->countDocuments());
+    }
+
+    public function testReAddingIdenticalDocumentPreservesSearchFilterAndSort(): void
+    {
+        // Re-adding an identical document must not drop its terms, attributes or multi attributes
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['firstname', 'lastname'])
+            ->withFilterableAttributes(['departments', 'gender'])
+            ->withSortableAttributes(['firstname'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocument(self::getSandraDocument());
+        $loupe->addDocument(self::getUtaDocument());
+
+        $assetSearchResults = function () use (&$loupe): void {
+            // Terms (search) still present
+            $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('maier'))->getTotalHits());
+            $this->assertSame(1, $loupe->search(SearchParameters::create()->withQuery('koertig'))->getTotalHits());
+
+            // Multi attribute filter + single attribute sort still work
+            $params = SearchParameters::create()
+                ->withFilter("departments = 'Development'")
+                ->withAttributesToRetrieve(['id', 'firstname'])
+                ->withSort(['firstname:asc']);
+
+            $this->assertSame(2, $loupe->countDocuments());
+
+            $this->searchAndAssertResults($loupe, $params, [
+                'hits' => [
+                    [
+                        'id' => 1,
+                        'firstname' => 'Sandra',
+                    ],
+                    [
+                        'id' => 2,
+                        'firstname' => 'Uta',
+                    ],
+                ],
+                'query' => '',
+                'hitsPerPage' => 20,
+                'page' => 1,
+                'totalPages' => 1,
+                'totalHits' => 2,
+            ]);
+        };
+
+        // Baseline
+        $assetSearchResults();
+
+        // Re-add the exact same documents -> skip tokenization, should still work
+        $loupe->addDocument(self::getSandraDocument());
+        $loupe->addDocument(self::getUtaDocument());
+        $assetSearchResults();
     }
 
     public function testReindex(): void


### PR DESCRIPTION
- The SQL change detection already avoided a lot of work for unchanged documents
- This also skips expensive tokenization and attribute extraction, which are never used
- Added more tests covering new + changed + unchanged indexing operations

### Benchmarks

With #312 applied for accurate indexing benchmarks.

| benchmark  | subject | set | before      | after       | change     |
|------------|----------------------|-----------|-------------|-------------|------------|
| IndexBench | benchAddDocuments    | 1k  | 1,189ms  | 1,166ms  | ~ unchanged  |
| IndexBench | benchAddDocuments    | 10k | 10,940ms | 11,098ms | ~ unchanged  |
| IndexBench | benchAddDocuments    | all | 40,347ms | 40,985ms | ~ unchanged  |
| IndexBench | benchUpdateDocuments | 1k  | 315ms    | 30ms     | 🟢 -90.42% |
| IndexBench | benchUpdateDocuments | 10k | 3,104ms  | 208ms    | 🟢 -93.27% |
| IndexBench | benchUpdateDocuments | all | 10,899ms | 658ms    | 🟢 -93.95% |
