### PR TITLE
Analyze database to help query planner

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -693,9 +693,13 @@ class IndexInfo
 
     private function updateSchema(): void
     {
-        $schemaManager = $this->engine->getConnection()
-            ->createSchemaManager();
+        $connection = $this->engine->getConnection();
+        $schemaManager = $connection->createSchemaManager();
         $comparator = $schemaManager->createComparator();
+
+        // Schema changes invalidate query planner statistics; drop them before introspecting
+        $connection->executeStatement('DROP TABLE IF EXISTS sqlite_stat1');
+        $connection->executeStatement('DROP TABLE IF EXISTS sqlite_stat4');
 
         $schemaDiff = $comparator->compareSchemas($schemaManager->introspectSchema(), $this->getSchema());
         $schemaManager->alterSchema($schemaDiff);

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -154,6 +154,27 @@ class Indexer
         $this->changes[] = $change;
     }
 
+    /**
+     * Refresh SQLite's table statistics so the query planner can pick good join orders and indexes.
+     * Without statistics, the planner misestimates the term_documents joins for queries with common. terms (e.g. "iron man").
+     * The first build is always analyzed, afterwards the statistics are refreshed occasionally
+     * Uses a full ANALYZE (analysis_limit=0) since a sampled ANALYZE (analysis_limit>0) still misleads the planner.
+     */
+    private function analyzeDatabase(): void
+    {
+        if (!$this->needsAnalyze()) {
+            return;
+        }
+
+        try {
+            $connection = $this->engine->getConnection();
+            $connection->executeStatement('PRAGMA analysis_limit=0');
+            $connection->executeStatement('ANALYZE');
+        } catch (\Throwable) {
+            // Ignore failures, analyze is pure optimization
+        }
+    }
+
     private function bulkInsertDocuments(PreparedDocumentCollection $preparedDocuments): PreparedDocumentCollection
     {
         $rowColumns = ['_user_id', '_document', '_hash'];
@@ -586,6 +607,25 @@ class Indexer
         $this->engine->getConnection()->executeStatement('DROP TABLE IF EXISTS documents_migration');
     }
 
+    private function needsAnalyze(): bool
+    {
+        if ($this->engine->getIndexInfo()->needsSetup()) {
+            return false;
+        }
+
+        // Always analyze when statistics are missing (usually after initial bulk insert)
+        $hasStats = (bool) $this->engine->getConnection()
+            ->executeQuery("SELECT 1 FROM sqlite_master WHERE type='table' AND name='sqlite_stat1'")
+            ->fetchOne();
+
+        if (!$hasStats) {
+            return true;
+        }
+
+        // Otherwise analyze only occasionally, reusing vacuum probability
+        return random_int(1, 100) <= $this->engine->getConfiguration()->getVacuumProbability();
+    }
+
     private function needsVacuum(): bool
     {
         if ($this->engine->getIndexInfo()->needsSetup()) {
@@ -842,6 +882,7 @@ class Indexer
         $this->removeOrphans();
         $this->persistStateSet();
         $this->vacuumDatabase();
+        $this->analyzeDatabase();
     }
 
     private function vacuumDatabase(): void

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1560,5 +1560,8 @@ class Searcher
     private function sortDocuments(): void
     {
         $this->sorting->applySorters($this);
+
+        // Append document id as final stable tiebreaker to ensure deterministic order regardless of query plan
+        $this->addOrderBy(self::DOCUMENT_ID_ALIAS, 'ASC');
     }
 }


### PR DESCRIPTION
Turns out running a full `ANALYZE` after indexing really helps the query planner with some edge cases around joins. Some common terms go from 120 to 30ms ("iron man"), others are unchanged, but across the whole dataset it's a noticable difference.

One thing I'm not sure about: whether to run vacuum and analyze at different times (current change) or whether we should run them at the same time since we're already "wasting time" optimizing things.

### Search benchmarks

| benchmark   | subject                   | set | revs | its | before   | after    | change   |
|-------------|---------------------------|-----|------|-----|----------|----------|----------|
| SearchBench | benchExactQueryWithFacets |     | 3    | 5   | 8.37ms   | 8.27ms   | -1.19%   |
| SearchBench | benchMultiWordQueries     |     | 1    | 5   | 256.33ms | 157.29ms | -38.64%  |
| SearchBench | benchPlainQuery           |     | 3    | 5   | 19.55ms  | 15.14ms  | -22.56%  |
| SearchBench | benchSingleWordQueries    |     | 1    | 5   | 71.04ms  | 46.60ms  | -34.40%  |
| SearchBench | benchTypoQueryWithFacets  |     | 3    | 5   | 8.58ms   | 8.29ms   | -3.38%   |
| FilterBench | benchFilteredSortedSearch |     | 3    | 5   | 19.71ms  | 20.67ms  | +4.87%   |

### Index benchmarks

The `analyze` query after indexing adds around 3-7% to initial indexing, so quite good value I think :)

| benchmark  | subject              | set | revs | its | before      | after       | change   |
|------------|----------------------|-----|------|-----|-------------|-------------|----------|
| IndexBench | benchAddDocuments    | 1k  | 1    | 1   | 1,155.96ms  | 1,235.87ms  | +6.91%  |
| IndexBench | benchAddDocuments    | 10k | 1    | 1   | 11,109.75ms | 11,345.28ms | +2.12%  |
| IndexBench | benchAddDocuments    | all | 1    | 1   | 39,510.22ms | 40,987.65ms | +3.74%  |
| IndexBench | benchUpdateDocuments | 1k  | 1    | 1   | 20.49ms     | 21.29ms     | +3.91%   |
| IndexBench | benchUpdateDocuments | 10k | 1    | 1   | 127.37ms    | 230.04ms    | +55.36% |
| IndexBench | benchUpdateDocuments | all | 1    | 1   | 305.14ms    | 378.47ms    | +24.03%  |