### PR TITLE
Fix phrase group search

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
-use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -26,6 +25,5 @@ return static function (ECSConfig $ecsConfig): void {
 
     $ecsConfig->ruleWithConfiguration(OrderedClassElementsFixer::class, ['sort_algorithm' => 'alpha']);
     $ecsConfig->rule(NativeFunctionInvocationFixer::class);
-    $ecsConfig->ruleWithConfiguration(NoExtraBlankLinesFixer::class, ['tokens' => ['curly_brace_block', 'extra']]);
     $ecsConfig->skip([NotOperatorWithSuccessorSpaceFixer::class]);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NativeFunctionInvocationFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -25,5 +26,6 @@ return static function (ECSConfig $ecsConfig): void {
 
     $ecsConfig->ruleWithConfiguration(OrderedClassElementsFixer::class, ['sort_algorithm' => 'alpha']);
     $ecsConfig->rule(NativeFunctionInvocationFixer::class);
+    $ecsConfig->ruleWithConfiguration(NoExtraBlankLinesFixer::class, ['tokens' => ['curly_brace_block', 'extra']]);
     $ecsConfig->skip([NotOperatorWithSuccessorSpaceFixer::class]);
 };

--- a/src/Internal/Search/Cte.php
+++ b/src/Internal/Search/Cte.php
@@ -17,6 +17,7 @@ class Cte
         private array $columnAliasList,
         private QueryBuilder $queryBuilder,
         private array $tags = [],
+        private ?bool $materialized = null,
     ) {
     }
 
@@ -44,5 +45,13 @@ class Cte
     public function getTags(): array
     {
         return $this->tags;
+    }
+
+    /**
+     * null = let SQLite decide, true = force MATERIALIZED, false = force NOT MATERIALIZED
+     */
+    public function isMaterialized(): ?bool
+    {
+        return $this->materialized;
     }
 }

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1471,10 +1471,16 @@ class Searcher
         if ($this->ctesByName !== []) {
             $queryParts[] = 'WITH';
             foreach ($this->ctesByName as $name => $cte) {
+                $materializedHint = match ($cte->isMaterialized()) {
+                    true => 'MATERIALIZED ',
+                    false => 'NOT MATERIALIZED ',
+                    null => '',
+                };
                 $queryParts[] = \sprintf(
-                    '%s (%s) AS (%s)',
+                    '%s (%s) AS %s(%s)',
                     $name,
                     implode(',', $cte->getColumnAliasList()),
+                    $materializedHint,
                     $cte->getQueryBuilder()->getSQL()
                 );
                 $queryParts[] = ',';

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -635,7 +635,7 @@ class Searcher
 
         $isPhraseContinuation = $token->isPartOfPhrase() && $previousPhraseToken !== null;
         if ($isPhraseContinuation) {
-            // Continuuing inside "a phrase": drive query from small materialized previous token's match CTE
+            // Continuing inside "a phrase": drive query from small materialized previous token's match CTE
             // Use CROSS JOIN instead of INNER JOIN to pin join order and avoid full scans for common words like "his"
             $previousPhraseCte = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken);
             $previousPhraseAlias = $previousPhraseCte . '_prev';

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -640,18 +640,26 @@ class Searcher
             $previousPhraseCte = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken);
             $previousPhraseAlias = $previousPhraseCte . '_prev';
             $cteSelectQb->from(\sprintf(
-                '%1$s %2$s'
-                . ' CROSS JOIN %3$s'
-                . ' CROSS JOIN %4$s %5$s INDEXED BY sqlite_autoindex_terms_documents_1'
-                . ' ON %3$s.id = %5$s.term'
-                . ' AND %5$s.document = %2$s.document'
-                . ' AND %5$s.attribute = %2$s.attribute'
-                . ' AND %5$s.position = %2$s.position + 1',
+                '%s %s'
+                . ' CROSS JOIN %s'
+                . ' CROSS JOIN %s %s INDEXED BY sqlite_autoindex_terms_documents_1'
+                . ' ON %s.id = %s.term'
+                . ' AND %s.document = %s.document'
+                . ' AND %s.attribute = %s.attribute'
+                . ' AND %s.position = %s.position + 1',
                 $previousPhraseCte,
                 $previousPhraseAlias,
                 $termMatchesCTE,
                 IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
                 $termsDocumentsAlias,
+                $termMatchesCTE,
+                $termsDocumentsAlias,
+                $termsDocumentsAlias,
+                $previousPhraseAlias,
+                $termsDocumentsAlias,
+                $previousPhraseAlias,
+                $termsDocumentsAlias,
+                $previousPhraseAlias,
             ));
         } else {
             // Join from term_matches CTE — not from terms_documents - to force primary key usage

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -628,18 +628,41 @@ class Searcher
             ));
         }
 
-        // Join from term_matches CTE — not from terms_documents - to force primary key usage
-        $cteSelectQb->from($termMatchesCTE);
-        $cteSelectQb->innerJoin(
-            $termMatchesCTE,
-            IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
-            $termsDocumentsAlias . ' INDEXED BY sqlite_autoindex_terms_documents_1',
-            \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias)
-        );
+        $isPhraseContinuation = $token->isPartOfPhrase() && $previousPhraseToken !== null;
+        if ($isPhraseContinuation) {
+            // Continuuing inside "a phrase": drive query from small materialized previous token's match CTE
+            // Use CROSS JOIN instead of INNER JOIN to pin join order and avoid full scans for common words like "his"
+            $previousPhraseCte = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken);
+            $previousPhraseAlias = $previousPhraseCte . '_prev';
+            $cteSelectQb->from(\sprintf(
+                '%1$s %2$s'
+                . ' CROSS JOIN %3$s'
+                . ' CROSS JOIN %4$s %5$s INDEXED BY sqlite_autoindex_terms_documents_1'
+                . ' ON %3$s.id = %5$s.term'
+                . ' AND %5$s.document = %2$s.document'
+                . ' AND %5$s.attribute = %2$s.attribute'
+                . ' AND %5$s.position = %2$s.position + 1',
+                $previousPhraseCte,
+                $previousPhraseAlias,
+                $termMatchesCTE,
+                IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+                $termsDocumentsAlias,
+            ));
+        } else {
+            // Join from term_matches CTE — not from terms_documents - to force primary key usage
+            $cteSelectQb->from($termMatchesCTE);
+            $cteSelectQb->innerJoin(
+                $termMatchesCTE,
+                IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+                $termsDocumentsAlias . ' INDEXED BY sqlite_autoindex_terms_documents_1',
+                \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias)
+            );
+        }
 
         // Restrict to shared candidate documents only for real multi-token queries.
         // For single-token queries this check is redundant and adds avoidable overhead.
-        if ($this->getSearchTokens()->count() > 1) {
+        // For phrase-continuation tokens, this filter is also redudandant and solved by the cross join above
+        if ($this->getSearchTokens()->count() > 1 && !$isPhraseContinuation) {
             $hasCandidateDocuments = $this->ensureSharedCandidateDocumentsCTE();
             if (!$hasCandidateDocuments) {
                 return;
@@ -659,23 +682,20 @@ class Searcher
             ));
         }
 
-        // Ensure phrase positions if any
-        if ($token->isPartOfPhrase() && $previousPhraseToken) {
-            $cteSelectQb->andWhere(\sprintf(
-                '%s.position IN (SELECT position + 1 FROM %s WHERE document=td.document AND attribute=td.attribute)',
-                $termsDocumentsAlias,
-                $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $previousPhraseToken),
-            ));
-        }
-
         $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
+
+        // loupe_levensthein calls prevent SQLite from materializing phrase-position subqueries
+        // so we force materialization to avoid re-evaluation per row and use temp b-trees instead
+        $materialized = $token->isPartOfPhrase() ? true : null;
 
         $this->addCTE(new Cte(
             $cteName,
             $needsFoldingState ?
                 ['document', 'attribute', 'position', 'start', 'end', 'typos', 'exact_match'] :
                 ['document', 'attribute', 'position', 'start', 'end', 'typos'],
-            $cteSelectQb
+            $cteSelectQb,
+            [],
+            $materialized
         ));
     }
 

--- a/tests/Benchmark/SearchBench.php
+++ b/tests/Benchmark/SearchBench.php
@@ -58,6 +58,36 @@ class SearchBench extends AbstractBench
         }
     }
 
+    #[Revs(1)]
+    public function benchNegatedTermQueries(): void
+    {
+        $queries = [
+            'family -therapist',
+            'duck -duffy',
+            'festival -cannes',
+        ];
+
+        foreach ($queries as $q) {
+            $this->loupe->search(SearchParameters::create()->withQuery($q));
+        }
+    }
+
+    #[Revs(1)]
+    public function benchPhraseGroupQueries(): void
+    {
+        $queries = [
+            '"by her family"',
+            '"every day"',
+            '"involved in"',
+            '"lead role"',
+            '"down on his luck"',
+        ];
+
+        foreach ($queries as $q) {
+            $this->loupe->search(SearchParameters::create()->withQuery($q));
+        }
+    }
+
     public function benchPlainQuery(): void
     {
         $this->loupe->search(
@@ -82,7 +112,6 @@ class SearchBench extends AbstractBench
         foreach ($queries as $q) {
             $this->loupe->search(SearchParameters::create()->withQuery($q));
         }
-
     }
 
     public function benchTypoQueryWithFacets(): void


### PR DESCRIPTION
Somewhere along the recent performance improvements, we slowed down "phrase group" searches catastrophically. They are fine in the latest release, but time out in the current state of the main branch.

This switches things around to use a cross join for checking phrase conditions. What's nice is we can skip the candidate-document query for all following tokens of a group since the first token already ensures the document, we just need to check the position.

Added phrase group benchmarks. We didn't have any, so that's why we missed the performance regression.

### Benchmarks

0.13.17: 1.617ms
main: 30s (timed out)
this: 35ms
