### PR TITLE
Cache built filters in query cache

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,8 +218,8 @@ If you need to browse all the documents and ignore this limit, use [the browse A
 
 ## Query cache
 
-Loupe can cache internal query artifacts (such as state-set lookups during typo tolerant search) through
-a PSR-6 cache pool:
+Loupe can cache internal query artifacts (such as state-set lookups during typo tolerant search and parsed
+filter strings) through a PSR-6 cache pool:
 
 ```php
 $cachePool = new \Symfony\Component\Cache\Adapter\RedisAdapter($redisConnection);

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -110,7 +110,8 @@ Damerau-Levenshtein.
 
 ## Query cache backend
 
-Loupe can cache internal query artifacts (especially state-set lookups for typo tolerance) via a PSR-6 cache pool.
+Loupe can cache internal query artifacts (especially state-set lookups for typo tolerance and parsed filter strings)
+via a PSR-6 cache pool.
 By default, Loupe auto-enables an APCu-backed pool when APCu is available. This is intentionally zero-config and
 gives an immediate speedup in many real-world typeahead/autosubmit setups.
 

--- a/src/Internal/Cache/NamespacedCacheItem.php
+++ b/src/Internal/Cache/NamespacedCacheItem.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+use DateInterval;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+
+final class NamespacedCacheItem implements CacheItemInterface
+{
+    public function __construct(
+        private string $key,
+        private CacheItemInterface $inner,
+    ) {
+    }
+
+    public function expiresAfter(int|DateInterval|null $time): static
+    {
+        $this->inner->expiresAfter($time);
+
+        return $this;
+    }
+
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        $this->inner->expiresAt($expiration);
+
+        return $this;
+    }
+
+    public function get(): mixed
+    {
+        return $this->inner->get();
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->inner->isHit();
+    }
+
+    public function set(mixed $value): static
+    {
+        $this->inner->set($value);
+
+        return $this;
+    }
+
+    public function unwrap(): CacheItemInterface
+    {
+        return $this->inner;
+    }
+}

--- a/src/Internal/Cache/NamespacedCachePool.php
+++ b/src/Internal/Cache/NamespacedCachePool.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class NamespacedCachePool implements CacheItemPoolInterface
+{
+    private string $namespace;
+
+    public function __construct(
+        private CacheItemPoolInterface $inner,
+        string $namespace,
+    ) {
+        $this->namespace = rawurlencode($namespace);
+    }
+
+    public function clear(): bool
+    {
+        return $this->inner->clear();
+    }
+
+    public function commit(): bool
+    {
+        return $this->inner->commit();
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        return $this->inner->deleteItem($this->mapKey($key));
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        $mapped = [];
+        foreach ($keys as $key) {
+            $mapped[] = $this->mapKey((string) $key);
+        }
+
+        return $this->inner->deleteItems($mapped);
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        return new NamespacedCacheItem($key, $this->inner->getItem($this->mapKey($key)));
+    }
+
+    /**
+     * @return iterable<string, CacheItemInterface>
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        foreach ($keys as $key) {
+            $key = (string) $key;
+            yield $key => $this->getItem($key);
+        }
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return $this->inner->hasItem($this->mapKey($key));
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        if ($item instanceof NamespacedCacheItem) {
+            return $this->inner->save($item->unwrap());
+        }
+
+        return $this->inner->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        if ($item instanceof NamespacedCacheItem) {
+            return $this->inner->saveDeferred($item->unwrap());
+        }
+
+        return $this->inner->saveDeferred($item);
+    }
+
+    private function mapKey(string $key): string
+    {
+        return $this->namespace . '.' . $key;
+    }
+}

--- a/src/Internal/Cache/QueryCacheKey.php
+++ b/src/Internal/Cache/QueryCacheKey.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Cache;
+
+final class QueryCacheKey
+{
+    /**
+     * 60 seconds matches interactive search/typeahead usage.
+     */
+    public const INTERACTIVE_TTL = 60;
+
+    /**
+     * @param list<bool|int|string> $parts
+     */
+    public static function build(string $prefix, string|int $version, array $parts = []): string
+    {
+        return self::join([
+            $prefix,
+            $version,
+            ...$parts,
+        ]);
+    }
+
+    /**
+     * @param list<bool|int|string> $parts
+     */
+    private static function join(array $parts): string
+    {
+        $normalized = array_map(
+            static fn (bool|int|string $part): string => rawurlencode((string) $part),
+            $parts
+        );
+
+        return implode('.', $normalized);
+    }
+}

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -11,6 +11,7 @@ use Loupe\Loupe\BrowseParameters;
 use Loupe\Loupe\BrowseResult;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidDocumentException;
+use Loupe\Loupe\Internal\Cache\NamespacedCachePool;
 use Loupe\Loupe\Internal\Filter\Parser;
 use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserterFactory;
 use Loupe\Loupe\Internal\Index\Indexer;
@@ -31,6 +32,7 @@ use Loupe\Matcher\Matcher;
 use Loupe\Matcher\StopWords\InMemoryStopWords;
 use Loupe\Matcher\StopWords\StopWordsInterface;
 use Pdo\Sqlite;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
 use Toflar\StateSetIndex\Alphabet\Utf8Alphabet;
 use Toflar\StateSetIndex\Config;
@@ -62,6 +64,8 @@ class Engine
     private Indexer $indexer;
 
     private IndexInfo $indexInfo;
+
+    private ?CacheItemPoolInterface $namespacedQueryCache = null;
 
     private StateSetIndexInterface $stateSetIndex;
 
@@ -260,6 +264,23 @@ class Engine
         return $this->logger;
     }
 
+    public function getQueryCache(): ?CacheItemPoolInterface
+    {
+        if ($this->namespacedQueryCache instanceof CacheItemPoolInterface) {
+            return $this->namespacedQueryCache;
+        }
+
+        $queryCache = $this->configuration->getQueryCache();
+        if ($queryCache === null) {
+            return null;
+        }
+
+        return $this->namespacedQueryCache = new NamespacedCachePool(
+            $queryCache,
+            $this->getIndexInfo()->getIndexUid()
+        );
+    }
+
     public function getStateSetIndex(): StateSetIndexInterface
     {
         return $this->stateSetIndex;
@@ -347,8 +368,11 @@ class Engine
             return;
         }
 
-        $queryCache = $this->configuration->getQueryCache();
-        if ($queryCache === null || $this->indexInfo->needsSetup()) {
+        if ($this->indexInfo->needsSetup()) {
+            return;
+        }
+        $queryCache = $this->getQueryCache();
+        if ($queryCache === null) {
             return;
         }
 
@@ -356,7 +380,6 @@ class Engine
             $this->stateSetIndex,
             $this->configuration->getTypoTolerance(),
             $queryCache,
-            $this->indexInfo->getIndexUid(),
         );
     }
 

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -6,6 +6,7 @@ namespace Loupe\Loupe\Internal\Search\FilterBuilder;
 
 use Doctrine\DBAL\Query\QueryBuilder;
 use Location\Bounds;
+use Loupe\Loupe\Internal\Cache\QueryCacheKey;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Filter\Ast\Ast;
 use Loupe\Loupe\Internal\Filter\Ast\AttributeFilterInterface;
@@ -20,20 +21,50 @@ use Loupe\Loupe\Internal\LoupeTypes;
 use Loupe\Loupe\Internal\Search\Cte;
 use Loupe\Loupe\Internal\Search\Searcher;
 use Loupe\Loupe\Internal\Search\Sorting;
+use Loupe\Loupe\SearchParameters;
+use Psr\Cache\CacheItemPoolInterface;
 
 class FilterBuilder
 {
     private const CTE_PREFIX = 'cte_fnode_';
 
+    private ?string $cachedBuildFrom = null;
+
+    /**
+     * @var array<string, array<string|float>>
+     */
+    private array $cachedGeoBoundingBoxWhereStatements = [];
+
     public function __construct(
         private Engine $engine,
         private Searcher $searcher,
         private Ast $filterAst,
+        private ?CacheItemPoolInterface $queryCache = null,
     ) {
     }
 
     public function buildFrom(): string
     {
+        if ($this->cachedBuildFrom !== null) {
+            return $this->cachedBuildFrom;
+        }
+
+        $cacheKey = $this->buildFromCacheKey();
+
+        if ($this->queryCache !== null) {
+            try {
+                $cacheItem = $this->queryCache->getItem($cacheKey);
+                if ($cacheItem->isHit()) {
+                    $cachedValue = $cacheItem->get();
+                    if (\is_string($cachedValue)) {
+                        return $this->cachedBuildFrom = $cachedValue;
+                    }
+                }
+            } catch (\Throwable) {
+                // Cache errors must never affect query execution.
+            }
+        }
+
         $froms = [];
 
         /**
@@ -46,7 +77,19 @@ class FilterBuilder
          */
         $this->handleFilterAstNode($this->filterAst->getRoot(), $froms);
 
-        return implode(' ', $froms);
+        $from = implode(' ', $froms);
+
+        if ($this->queryCache !== null) {
+            try {
+                $cacheItem = $this->queryCache->getItem($cacheKey);
+                $cacheItem->set($from)->expiresAfter(QueryCacheKey::INTERACTIVE_TTL);
+                $this->queryCache->save($cacheItem);
+            } catch (\Throwable) {
+                // Cache errors must never affect query execution.
+            }
+        }
+
+        return $this->cachedBuildFrom = $from;
     }
 
     /**
@@ -54,6 +97,12 @@ class FilterBuilder
      */
     public function createGeoBoundingBoxWhereStatement(string $attributeName, Bounds|null $bounds = null): array
     {
+        $cacheKey = $this->buildGeoBoundingBoxCacheKey($attributeName, $bounds);
+
+        if (isset($this->cachedGeoBoundingBoxWhereStatements[$cacheKey])) {
+            return $this->cachedGeoBoundingBoxWhereStatements[$cacheKey];
+        }
+
         $documentAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
         $whereStatement = [];
 
@@ -89,7 +138,7 @@ class FilterBuilder
         $whereStatement[] = 'AND';
         $whereStatement[] = $bounds->getNorth();
 
-        return $whereStatement;
+        return $this->cachedGeoBoundingBoxWhereStatements[$cacheKey] = $whereStatement;
     }
 
     /**
@@ -118,6 +167,37 @@ class FilterBuilder
             ->where($where);
 
         return $this->addCTEForNode($node, $qb);
+    }
+
+    private function buildFromCacheKey(): string
+    {
+        $sort = [];
+        $queryParameters = $this->searcher->getQueryParameters();
+
+        if ($queryParameters instanceof SearchParameters) {
+            $sort = $queryParameters->getSort();
+        }
+
+        return QueryCacheKey::build('filter.from', Engine::VERSION . ':' . $this->engine->getDependencyHash(), [
+            hash('xxh3', (string) json_encode([
+                'filter' => $this->filterAst->toArray(),
+                'sort' => $sort,
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+    }
+
+    private function buildGeoBoundingBoxCacheKey(string $attributeName, ?Bounds $bounds): string
+    {
+        if ($bounds === null) {
+            return $attributeName . '|null';
+        }
+
+        return $attributeName . '|' . hash('xxh3', (string) json_encode([
+            $bounds->getNorth(),
+            $bounds->getEast(),
+            $bounds->getSouth(),
+            $bounds->getWest(),
+        ], JSON_THROW_ON_ERROR));
     }
 
     private function createQueryBuilderForSingleAttribute(): QueryBuilder

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -123,7 +123,12 @@ class Searcher
         }
 
         $this->queryBuilder = $this->engine->getConnection()->createQueryBuilder();
-        $this->filterBuilder = new FilterBuilder($this->engine, $this, $filterParser->getAst($this->queryParameters->getFilter()));
+        $this->filterBuilder = new FilterBuilder(
+            $this->engine,
+            $this,
+            $filterParser->getAst($this->queryParameters->getFilter()),
+            $this->engine->getQueryCache()
+        );
     }
 
     /**

--- a/src/Internal/StateSetIndex/CachedStateSetIndex.php
+++ b/src/Internal/StateSetIndex/CachedStateSetIndex.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Loupe\Internal\StateSetIndex;
 
 use Loupe\Loupe\Config\TypoTolerance;
+use Loupe\Loupe\Internal\Cache\QueryCacheKey;
 use Psr\Cache\CacheItemPoolInterface;
 use Toflar\StateSetIndex\Alphabet\AlphabetInterface;
 use Toflar\StateSetIndex\Config;
@@ -13,12 +14,6 @@ use Toflar\StateSetIndex\StateSet\StateSetInterface;
 
 final class CachedStateSetIndex implements StateSetIndexInterface
 {
-    /**
-     * 60 seconds matches typical typeahead/search interaction windows.
-     * Enough reuse while users iterate, short enough to naturally shed stale prefixes quickly.
-     */
-    private const CACHE_TTL = 60;
-
     /**
      * Version namespace rollover guard.
      * With a 60s TTL, even a very write-heavy index will not realistically hit this value within one TTL window.
@@ -32,7 +27,6 @@ final class CachedStateSetIndex implements StateSetIndexInterface
         private StateSetIndexInterface $inner,
         private TypoTolerance $typoTolerance,
         private CacheItemPoolInterface $cachePool,
-        private string $indexUid,
     ) {
         $this->cacheVersion = $this->loadCacheVersion();
     }
@@ -63,7 +57,7 @@ final class CachedStateSetIndex implements StateSetIndexInterface
         }
 
         $snapshot = $this->findOrBuildSnapshot($string, $editDistance, $transpositionCost, $maxPrefixCharsToTrimForCacheReuse);
-        $cacheItem->set($snapshot->toArray())->expiresAfter(self::CACHE_TTL);
+        $cacheItem->set($snapshot->toArray())->expiresAfter(QueryCacheKey::INTERACTIVE_TTL);
         $this->cachePool->save($cacheItem);
 
         return $snapshot->matchingStates();
@@ -100,30 +94,21 @@ final class CachedStateSetIndex implements StateSetIndexInterface
 
     private function buildCacheKey(string $term, int $levenshteinDistance, int $transpositionCost): string
     {
-        return 'states.'
-            . $this->indexUid
-            . '.'
-            . $this->cacheVersion
-            . '.'
-            . $this->typoTolerance->getAlphabetSize()
-            . '.'
-            . $this->typoTolerance->getIndexLength()
-            . '.'
-            . $levenshteinDistance
-            . '.'
-            . $transpositionCost
-            . '.'
-            . rawurlencode($term);
+        return QueryCacheKey::build('states', $this->cacheVersion, [
+            $this->typoTolerance->getAlphabetSize(),
+            $this->typoTolerance->getIndexLength(),
+            $levenshteinDistance,
+            $transpositionCost,
+            $term,
+        ]);
     }
 
     private function buildVersionKey(): string
     {
-        return 'states.version.'
-            . $this->indexUid
-            . '.'
-            . $this->typoTolerance->getAlphabetSize()
-            . '.'
-            . $this->typoTolerance->getIndexLength();
+        return QueryCacheKey::build('states.version', 1, [
+            $this->typoTolerance->getAlphabetSize(),
+            $this->typoTolerance->getIndexLength(),
+        ]);
     }
 
     private function bumpVersion(): void
@@ -135,7 +120,7 @@ final class CachedStateSetIndex implements StateSetIndexInterface
             $newVersion = 1;
         }
 
-        $versionItem->set($newVersion)->expiresAfter(self::CACHE_TTL);
+        $versionItem->set($newVersion)->expiresAfter(QueryCacheKey::INTERACTIVE_TTL);
         $this->cachePool->save($versionItem);
         $this->cacheVersion = $newVersion;
     }


### PR DESCRIPTION
This generalizes the query cache from currently only caching the state set calculation to also caching the filter strings. Those often don't change between search requests (e.g. you filtered in the UI and now you start typing your query -> multiple search requests, always the same filter) 😊 