### PR TITLE
Fix filter CTE cache issue

### DIFF
--- a/src/Internal/Search/Cte.php
+++ b/src/Internal/Search/Cte.php
@@ -15,7 +15,7 @@ class Cte
     public function __construct(
         private string $name,
         private array $columnAliasList,
-        private QueryBuilder $queryBuilder,
+        private string|QueryBuilder $query,
         private array $tags = [],
         private ?bool $materialized = null,
     ) {
@@ -34,9 +34,9 @@ class Cte
         return $this->name;
     }
 
-    public function getQueryBuilder(): QueryBuilder
+    public function getQuerySql(): string
     {
-        return $this->queryBuilder;
+        return $this->query instanceof QueryBuilder ? $this->query->getSQL() : $this->query;
     }
 
     /**

--- a/src/Internal/Search/FilterBuilder/FilterBuilder.php
+++ b/src/Internal/Search/FilterBuilder/FilterBuilder.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Search\FilterBuilder;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Types\Type;
 use Location\Bounds;
 use Loupe\Loupe\Internal\Cache\QueryCacheKey;
 use Loupe\Loupe\Internal\Engine;
@@ -28,7 +31,15 @@ class FilterBuilder
 {
     private const CTE_PREFIX = 'cte_fnode_';
 
-    private ?string $cachedBuildFrom = null;
+    /**
+     * @var array{
+     *     from: string,
+     *     ctes: array<int, array{name: string, columns: array<int, string>, sql: string, tags: array<int, string>, materialized: ?bool}>,
+     *     parameters: array<int<0, max>|string, mixed>,
+     *     parameterTypes: array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string>
+     * }|null
+     */
+    private ?array $cachedBuildFromResult = null;
 
     /**
      * @var array<string, array<string|float>>
@@ -45,8 +56,8 @@ class FilterBuilder
 
     public function buildFrom(): string
     {
-        if ($this->cachedBuildFrom !== null) {
-            return $this->cachedBuildFrom;
+        if ($this->cachedBuildFromResult !== null) {
+            return $this->cachedBuildFromResult['from'];
         }
 
         $cacheKey = $this->buildFromCacheKey();
@@ -55,9 +66,12 @@ class FilterBuilder
             try {
                 $cacheItem = $this->queryCache->getItem($cacheKey);
                 if ($cacheItem->isHit()) {
-                    $cachedValue = $cacheItem->get();
-                    if (\is_string($cachedValue)) {
-                        return $this->cachedBuildFrom = $cachedValue;
+                    $cachedValue = $this->hydrateCachedBuildFromResult($cacheItem->get());
+                    if ($cachedValue !== null) {
+                        $this->cachedBuildFromResult = $cachedValue;
+                        $this->restoreFilterBuildResult($cachedValue);
+
+                        return $cachedValue['from'];
                     }
                 }
             } catch (\Throwable) {
@@ -78,18 +92,20 @@ class FilterBuilder
         $this->handleFilterAstNode($this->filterAst->getRoot(), $froms);
 
         $from = implode(' ', $froms);
+        $result = $this->snapshotFilterBuildResult($from);
+        $this->cachedBuildFromResult = $result;
 
         if ($this->queryCache !== null) {
             try {
                 $cacheItem = $this->queryCache->getItem($cacheKey);
-                $cacheItem->set($from)->expiresAfter(QueryCacheKey::INTERACTIVE_TTL);
+                $cacheItem->set($result)->expiresAfter(QueryCacheKey::INTERACTIVE_TTL);
                 $this->queryCache->save($cacheItem);
             } catch (\Throwable) {
                 // Cache errors must never affect query execution.
             }
         }
 
-        return $this->cachedBuildFrom = $from;
+        return $from;
     }
 
     /**
@@ -116,27 +132,25 @@ class FilterBuilder
         $whereStatement[] = '!=';
         $whereStatement[] = $nullTerm;
 
-        if ($bounds === null) {
-            return $whereStatement;
+        if ($bounds !== null) {
+            $whereStatement[] = 'AND';
+
+            // Longitude
+            $whereStatement[] = $documentAlias . '.' . $attributeName . '_geo_lng';
+            $whereStatement[] = 'BETWEEN';
+            $whereStatement[] = $bounds->getWest();
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $bounds->getEast();
+
+            $whereStatement[] = 'AND';
+
+            // Latitude
+            $whereStatement[] = $documentAlias . '.' . $attributeName . '_geo_lat';
+            $whereStatement[] = 'BETWEEN';
+            $whereStatement[] = $bounds->getSouth();
+            $whereStatement[] = 'AND';
+            $whereStatement[] = $bounds->getNorth();
         }
-
-        $whereStatement[] = 'AND';
-
-        // Longitude
-        $whereStatement[] = $documentAlias . '.' . $attributeName . '_geo_lng';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getWest();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getEast();
-
-        $whereStatement[] = 'AND';
-
-        // Latitude
-        $whereStatement[] = $documentAlias . '.' . $attributeName . '_geo_lat';
-        $whereStatement[] = 'BETWEEN';
-        $whereStatement[] = $bounds->getSouth();
-        $whereStatement[] = 'AND';
-        $whereStatement[] = $bounds->getNorth();
 
         return $this->cachedGeoBoundingBoxWhereStatements[$cacheKey] = $whereStatement;
     }
@@ -430,5 +444,96 @@ class FilterBuilder
         if ($node instanceof Concatenator) {
             $froms[] = $node->getSetOperator();
         }
+    }
+
+    /**
+     * @return array{
+     *     from: string,
+     *     ctes: array<int, array{name: string, columns: array<int, string>, sql: string, tags: array<int, string>, materialized: ?bool}>,
+     *     parameters: array<int<0, max>|string, mixed>,
+     *     parameterTypes: array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string>
+     * }|null
+     */
+    private function hydrateCachedBuildFromResult(mixed $cachedValue): ?array
+    {
+        if (!\is_array($cachedValue)) {
+            return null;
+        }
+
+        if (
+            !isset($cachedValue['from']) ||
+            !\is_string($cachedValue['from']) ||
+            !isset($cachedValue['ctes']) ||
+            !\is_array($cachedValue['ctes']) ||
+            !isset($cachedValue['parameters']) ||
+            !\is_array($cachedValue['parameters']) ||
+            !isset($cachedValue['parameterTypes']) ||
+            !\is_array($cachedValue['parameterTypes'])
+        ) {
+            return null;
+        }
+
+        return [
+            'from' => $cachedValue['from'],
+            'ctes' => $cachedValue['ctes'],
+            'parameters' => $cachedValue['parameters'],
+            'parameterTypes' => $cachedValue['parameterTypes'],
+        ];
+    }
+
+    /**
+     * @param array{
+     *     from: string,
+     *     ctes: array<int, array{name: string, columns: array<int, string>, sql: string, tags: array<int, string>, materialized: ?bool}>,
+     *     parameters: array<int<0, max>|string, mixed>,
+     *     parameterTypes: array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string>
+     * } $result
+     */
+    private function restoreFilterBuildResult(array $result): void
+    {
+        foreach ($result['ctes'] as $cteDefinition) {
+            $this->searcher->addCTE(new Cte(
+                $cteDefinition['name'],
+                $cteDefinition['columns'],
+                $cteDefinition['sql'],
+                $cteDefinition['tags'],
+                $cteDefinition['materialized'],
+            ));
+        }
+
+        $this->searcher->getQueryBuilder()->setParameters(
+            $result['parameters'],
+            $result['parameterTypes']
+        );
+    }
+
+    /**
+     * @return array{
+     *     from: string,
+     *     ctes: array<int, array{name: string, columns: array<int, string>, sql: string, tags: array<int, string>, materialized: ?bool}>,
+     *     parameters: array<int<0, max>|string, mixed>,
+     *     parameterTypes: array<int<0, max>|string, ArrayParameterType|ParameterType|Type|string>
+     * }
+     */
+    private function snapshotFilterBuildResult(string $from): array
+    {
+        $ctes = [];
+
+        foreach ($this->searcher->getCtesByName() as $cte) {
+            $ctes[] = [
+                'name' => $cte->getName(),
+                'columns' => $cte->getColumnAliasList(),
+                'sql' => $cte->getQuerySql(),
+                'tags' => $cte->getTags(),
+                'materialized' => $cte->isMaterialized(),
+            ];
+        }
+
+        return [
+            'from' => $from,
+            'ctes' => $ctes,
+            'parameters' => $this->searcher->getQueryBuilder()->getParameters(),
+            'parameterTypes' => $this->searcher->getQueryBuilder()->getParameterTypes(),
+        ];
     }
 }

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1527,7 +1527,7 @@ class Searcher
                     $name,
                     implode(',', $cte->getColumnAliasList()),
                     $materializedHint,
-                    $cte->getQueryBuilder()->getSQL()
+                    $cte->getQuerySql()
                 );
                 $queryParts[] = ',';
             }

--- a/tests/Functional/SearchTest.php
+++ b/tests/Functional/SearchTest.php
@@ -8,6 +8,7 @@ use Loupe\Loupe\Config\TypoTolerance;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\SearchParameters;
 use Loupe\Loupe\Tests\StorageFixturesTestTrait;
+use Loupe\Loupe\Tests\Support\InMemoryCachePool;
 use Loupe\Loupe\Tests\Util;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -3058,6 +3059,40 @@ class SearchTest extends TestCase
             'totalPages' => 1,
             'totalHits' => 3,
         ]);
+    }
+
+    public function testRepeatedSearchWithQueryCacheKeepsFilterCTEsIntact(): void
+    {
+        $configuration = Configuration::create()
+            ->withQueryCache(new InMemoryCachePool());
+
+        $loupe = $this->setupLoupeWithDepartmentsFixture($configuration);
+
+        $searchParameters = SearchParameters::create()
+            ->withAttributesToRetrieve(['id', 'firstname'])
+            ->withFilter("departments = 'Backoffice'")
+            ->withSort(['firstname:asc']);
+
+        $expected = [
+            'hits' => [
+                [
+                    'id' => 6,
+                    'firstname' => 'Huckleberry',
+                ],
+                [
+                    'id' => 2,
+                    'firstname' => 'Uta',
+                ],
+            ],
+            'query' => '',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 2,
+        ];
+
+        $this->searchAndAssertResults($loupe, $searchParameters, $expected);
+        $this->searchAndAssertResults($loupe, $searchParameters, $expected);
     }
 
     public function testSearchingForAQueryThatMatchesWayTooManyDocumentsDoesNotTakeForeverAndAlsoStillReturnsTheMostRelevantDocument(): void

--- a/tests/Support/InMemoryCacheItem.php
+++ b/tests/Support/InMemoryCacheItem.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Support;
+
+use DateInterval;
+use DateTimeInterface;
+use Psr\Cache\CacheItemInterface;
+
+final class InMemoryCacheItem implements CacheItemInterface
+{
+    private bool $hit = false;
+
+    private mixed $value = null;
+
+    public function __construct(
+        private string $key,
+    ) {
+    }
+
+    public function expiresAfter(int|DateInterval|null $time): static
+    {
+        return $this;
+    }
+
+    public function expiresAt(?DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function isHit(): bool
+    {
+        return $this->hit;
+    }
+
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+        $this->hit = true;
+
+        return $this;
+    }
+}

--- a/tests/Support/InMemoryCachePool.php
+++ b/tests/Support/InMemoryCachePool.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Support;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class InMemoryCachePool implements CacheItemPoolInterface
+{
+    /**
+     * @var array<string, InMemoryCacheItem>
+     */
+    private array $items = [];
+
+    public function clear(): bool
+    {
+        $this->items = [];
+
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        return true;
+    }
+
+    public function deleteItem(string $key): bool
+    {
+        unset($this->items[$key]);
+
+        return true;
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        foreach ($keys as $key) {
+            unset($this->items[(string) $key]);
+        }
+
+        return true;
+    }
+
+    public function getItem(string $key): CacheItemInterface
+    {
+        if (!isset($this->items[$key])) {
+            $this->items[$key] = new InMemoryCacheItem($key);
+        }
+
+        return $this->items[$key];
+    }
+
+    /**
+     * @return iterable<string, CacheItemInterface>
+     */
+    public function getItems(array $keys = []): iterable
+    {
+        foreach ($keys as $key) {
+            $key = (string) $key;
+            yield $key => $this->getItem($key);
+        }
+    }
+
+    public function hasItem(string $key): bool
+    {
+        return isset($this->items[$key]) && $this->items[$key]->isHit();
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof InMemoryCacheItem) {
+            throw new \InvalidArgumentException('Unsupported cache item implementation.');
+        }
+
+        $this->items[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->save($item);
+    }
+}


### PR DESCRIPTION
Noticed that I had some `SQLSTATE[HY000]: General error: 1 no such table: cte_fnode_c446e7e9"` type of issues and tracked it down to the new query cache implementation.

So let's try to fix this by first having a failing test.
