### PR TITLE
Keep highlighted attributes in _formatted

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -308,7 +308,7 @@ class Searcher
             }
 
             if ($needsHitFormatting && $displayTokens !== null) {
-                $this->formatHit($hit, $result, $displayTokens);
+                $this->formatHit($hit, $document, $result, $displayTokens);
             }
 
             $hits[] = $hit;
@@ -1342,22 +1342,23 @@ class Searcher
 
     /**
      * @param array<mixed> $hit
+     * @param array<string, mixed> $document
      * @param array<mixed> $queryResult
      */
-    private function formatHit(array &$hit, array $queryResult, TokenCollection $queryTerms): void
+    private function formatHit(array &$hit, array $document, array $queryResult, TokenCollection $queryTerms): void
     {
         if (!$this->queryParameters instanceof SearchParameters) {
             return;
         }
 
         $searchableAttributes = ['*'] === $this->engine->getConfiguration()->getSearchableAttributes()
-            ? array_keys($hit)
+            ? array_keys($document)
             : $this->engine->getConfiguration()->getSearchableAttributes();
         $attributesToCrop = ['*'] === $this->queryParameters->getAttributesToCrop()
             ? array_keys($hit)
             : array_keys($this->queryParameters->getAttributesToCrop());
         $attributesToHighlight = ['*'] === $this->queryParameters->getAttributesToHighlight()
-            ? array_keys($hit)
+            ? $searchableAttributes
             : $this->queryParameters->getAttributesToHighlight();
 
         $options = (new FormatterOptions())
@@ -1400,8 +1401,18 @@ class Searcher
         $matchesPosition = [];
 
         foreach ($searchableAttributes as $attribute) {
-            // Do not include any attribute not required by the result (limited by attributesToRetrieve)
-            if (!isset($hit[$attribute])) {
+            $hasAttributeInHit = \array_key_exists($attribute, $hit);
+
+            // Do not include any attribute not required by the result unless it must be highlighted.
+            if (!$hasAttributeInHit) {
+                if (!\in_array($attribute, $attributesToHighlight, true) || !\array_key_exists($attribute, $document)) {
+                    continue;
+                }
+
+                $formatted[$attribute] = $document[$attribute];
+            }
+
+            if (!\array_key_exists($attribute, $formatted)) {
                 continue;
             }
 

--- a/tests/Functional/Formatting/HighlightingTest.php
+++ b/tests/Functional/Formatting/HighlightingTest.php
@@ -385,4 +385,39 @@ class HighlightingTest extends TestCase
             'totalHits' => 1,
         ]);
     }
+
+    public function testHighlightingIncludesAttributesThatAreNotRetrieved(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title', 'overview'])
+            ->withFilterableAttributes(['genres'])
+            ->withSortableAttributes(['title']);
+
+        $loupe = $this->createLoupe($configuration);
+        $this->indexFixture($loupe, 'movies');
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('Rooms')
+            ->withAttributesToRetrieve(['id', 'overview'])
+            ->withAttributesToHighlight(['title']);
+
+        $this->searchAndAssertResults($loupe, $searchParameters, [
+            'hits' => [
+                [
+                    'id' => 5,
+                    'overview' => 'It\'s Ted the Bellhop\'s first night on the job...and the hotel\'s very unusual guests are about to place him in some outrageous predicaments. It seems that this evening\'s room service is serving up one unbelievable happening after another.',
+                    '_formatted' => [
+                        'id' => 5,
+                        'overview' => 'It\'s Ted the Bellhop\'s first night on the job...and the hotel\'s very unusual guests are about to place him in some outrageous predicaments. It seems that this evening\'s room service is serving up one unbelievable happening after another.',
+                        'title' => 'Four <em>Rooms</em>',
+                    ],
+                ],
+            ],
+            'query' => 'Rooms',
+            'hitsPerPage' => 20,
+            'page' => 1,
+            'totalPages' => 1,
+            'totalHits' => 1,
+        ]);
+    }
 }


### PR DESCRIPTION
This change makes `_formatted` include attributes that are requested for highlighting even when they are not part of `attributesToRetrieve`. The formatter now uses the full document as the source for highlightable attributes, so hidden fields can still be emitted in `_formatted` with their highlighted content.

See https://github.com/PHP-CMSIG/search/pull/698