### PR TITLE
Add fallback for SQLite < 3.35.0 without RETURNING support

### DIFF
--- a/src/Internal/Index/BulkUpserter/BulkUpserter.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserter.php
@@ -11,10 +11,17 @@ use Loupe\Loupe\Internal\Util;
 
 class BulkUpserter
 {
+    /**
+     * The RETURNING clause was only introduced in SQLite 3.35.0. For older versions, a fallback
+     * without RETURNING is used.
+     */
+    public const MIN_SQLITE_VERSION_FOR_RETURNING = '3.35.0';
+
     public function __construct(
         private Connection $connection,
         private BulkUpsertConfig $bulkUpsertConfig,
         private int $variableLimit,
+        private string $sqliteVersion,
     ) {
 
     }
@@ -62,12 +69,16 @@ class BulkUpserter
         $updateColumns = array_values(array_diff($this->bulkUpsertConfig->getRowColumns(), $this->bulkUpsertConfig->getUniqueColumns()));
         $chunkSize = max((int) round($this->variableLimit / \count($this->bulkUpsertConfig->getRowColumns()), 0, PHP_ROUND_HALF_DOWN), 1);
         $results = [];
+        $supportsReturning = version_compare($this->sqliteVersion, self::MIN_SQLITE_VERSION_FOR_RETURNING, '>=');
 
         foreach (Util::arrayChunk($this->bulkUpsertConfig->getRows(), $chunkSize) as $chunk) {
-            // Modern path: INSERT .. ON CONFLICT .. DO UPDATE [RETURNING]
-            $results = [...$results, ...$this->executeModern($chunk, $updateColumns)];
+            $chunkResults = $supportsReturning
+                // Modern path: INSERT .. ON CONFLICT .. DO UPDATE [RETURNING]
+                ? $this->executeModern($chunk, $updateColumns)
+                // Legacy path for SQLite < 3.35.0 without RETURNING support
+                : $this->executeLegacy($chunk, $updateColumns);
 
-            // Depending on the version, we could introduce fallback solutions here
+            $results = [...$results, ...$chunkResults];
         }
 
         return $results;
@@ -75,20 +86,20 @@ class BulkUpserter
 
     /**
      * @param array<array<int, mixed>> $rows
+     * @param array<int|string> $columnKeys
      * @param array<int<0, max>|string, mixed> $parameters
      */
-    private function buildValuesClause(array $rows, array &$parameters): string
+    private function buildTuples(array $rows, array $columnKeys, array &$parameters): string
     {
-        $columnKeys = array_keys($this->bulkUpsertConfig->getRowColumns());
-        $columnsCount = \count($columnKeys);
-
+        $tuple = $this->placeholdersRow(\count($columnKeys));
         $tuples = [];
+
         foreach ($rows as $row) {
             foreach ($columnKeys as $columnKey) {
                 $parameters[] = $row[$columnKey] ?? null;
             }
 
-            $tuples[] = $this->placeholdersRow($columnsCount);
+            $tuples[] = $tuple;
         }
 
         return implode(',', $tuples);
@@ -97,21 +108,11 @@ class BulkUpserter
     /**
      * @param array<array<int, mixed>> $rows
      * @param array<string> $updateColumns
-     * @return array<mixed>
+     * @param array<int<0, max>|string, mixed> $parameters
      */
-    private function executeModern(array $rows, array $updateColumns): array
+    private function buildUpsertSql(array $rows, array $updateColumns, ConflictMode $conflictMode, array &$parameters): string
     {
-        $parameters = [];
-        $values = $this->buildValuesClause($rows, $parameters);
-        $conflictMode = $this->bulkUpsertConfig->getConflictMode();
-        $returningColumns = $this->bulkUpsertConfig->getReturningColumns();
-
-        // If returning columns are desired but there are no columns to update, this would not return any data.
-        // Hence, we have to force an UPDATE SET with the unique columns.
-        if ($returningColumns !== [] && $updateColumns === []) {
-            $conflictMode = ConflictMode::Update;
-            $updateColumns = $this->bulkUpsertConfig->getUniqueColumns();
-        }
+        $values = $this->buildTuples($rows, array_keys($this->bulkUpsertConfig->getRowColumns()), $parameters);
 
         $sql = \sprintf(
             'INSERT INTO %s (%s) VALUES %s ON CONFLICT (%s) DO ',
@@ -135,12 +136,60 @@ class BulkUpserter
             );
         }
 
+        return $sql;
+    }
+
+    /**
+     * Fallback for SQLite < 3.35.0 which does not support the RETURNING clause: executes the upsert
+     * without RETURNING and reconstructs the result with a follow-up SELECT over the unique columns
+     * of the just upserted rows.
+     *
+     * In contrast to the modern path, this cannot cheaply detect which conflicting rows were skipped
+     * because of the change detecting column, so it conservatively returns all upserted rows.
+     *
+     * @param array<array<int, mixed>> $rows
+     * @param array<string> $updateColumns
+     * @return array<mixed>
+     */
+    private function executeLegacy(array $rows, array $updateColumns): array
+    {
+        $parameters = [];
+        $sql = $this->buildUpsertSql($rows, $updateColumns, $this->bulkUpsertConfig->getConflictMode(), $parameters);
+        $this->executeStatement($sql, $parameters);
+
+        if ($this->bulkUpsertConfig->getReturningColumns() === []) {
+            return [];
+        }
+
+        return $this->selectReturningColumns($rows);
+    }
+
+    /**
+     * @param array<array<int, mixed>> $rows
+     * @param array<string> $updateColumns
+     * @return array<mixed>
+     */
+    private function executeModern(array $rows, array $updateColumns): array
+    {
+        $conflictMode = $this->bulkUpsertConfig->getConflictMode();
+        $returningColumns = $this->bulkUpsertConfig->getReturningColumns();
+
+        // If returning columns are desired but there are no columns to update, this would not return any data.
+        // Hence, we have to force an UPDATE SET with the unique columns.
+        if ($returningColumns !== [] && $updateColumns === []) {
+            $conflictMode = ConflictMode::Update;
+            $updateColumns = $this->bulkUpsertConfig->getUniqueColumns();
+        }
+
+        $parameters = [];
+        $sql = $this->buildUpsertSql($rows, $updateColumns, $conflictMode, $parameters);
+
         if ($returningColumns === []) {
             $this->executeStatement($sql, $parameters);
             return [];
         }
 
-        $sql .= ' RETURNING ' . implode(', ', $this->bulkUpsertConfig->getReturningColumns());
+        $sql .= ' RETURNING ' . implode(', ', $returningColumns);
         return $this->executeQuery($sql, $parameters)->fetchAllAssociative();
     }
 
@@ -182,6 +231,33 @@ class BulkUpserter
     private function placeholdersRow(int $n): string
     {
         return '(' . implode(',', array_fill(0, $n, '?')) . ')';
+    }
+
+    /**
+     * @param array<array<int, mixed>> $rows
+     * @return array<mixed>
+     */
+    private function selectReturningColumns(array $rows): array
+    {
+        $uniqueColumns = $this->bulkUpsertConfig->getUniqueColumns();
+        $columnKeysByName = array_flip($this->bulkUpsertConfig->getRowColumns());
+        $uniqueColumnKeys = [];
+
+        foreach ($uniqueColumns as $uniqueColumn) {
+            \assert(isset($columnKeysByName[$uniqueColumn]), 'Unique columns must be part of the row columns.');
+            $uniqueColumnKeys[] = $columnKeysByName[$uniqueColumn];
+        }
+
+        $parameters = [];
+        $sql = \sprintf(
+            'SELECT %s FROM %s WHERE (%s) IN (VALUES %s)',
+            implode(', ', $this->bulkUpsertConfig->getReturningColumns()),
+            $this->bulkUpsertConfig->getTable(),
+            implode(', ', $uniqueColumns),
+            $this->buildTuples($rows, $uniqueColumnKeys, $parameters),
+        );
+
+        return $this->executeQuery($sql, $parameters)->fetchAllAssociative();
     }
 
     /**

--- a/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
@@ -18,14 +18,23 @@ class BulkUpserterFactory
      */
     public const VARIABLE_LIMIT = 999;
 
+    /**
+     * @param string|null $sqliteVersion Automatically detected if null, can be overridden for testing purposes
+     */
     public function __construct(
-        private ConnectionPool $connectionPool
+        private ConnectionPool $connectionPool,
+        private string|null $sqliteVersion = null
     ) {
 
     }
 
     public function create(BulkUpsertConfig $bulkUpsertConfig): BulkUpserter
     {
-        return new BulkUpserter($this->connectionPool->loupeConnection, $bulkUpsertConfig, self::VARIABLE_LIMIT);
+        return new BulkUpserter($this->connectionPool->loupeConnection, $bulkUpsertConfig, self::VARIABLE_LIMIT, $this->getSqliteVersion());
+    }
+
+    private function getSqliteVersion(): string
+    {
+        return $this->sqliteVersion ??= (string) $this->connectionPool->loupeConnection->fetchOne('SELECT sqlite_version()');
     }
 }

--- a/tests/Unit/Internal/Index/BulkUpserter/BulkUpserterTest.php
+++ b/tests/Unit/Internal/Index/BulkUpserter/BulkUpserterTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit\Internal\Index\BulkUpserter;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\DsnParser;
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Internal\ConnectionPool;
+use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpsertConfig;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserter;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserterFactory;
+use Loupe\Loupe\Internal\Index\BulkUpserter\ConflictMode;
+use Loupe\Loupe\SearchParameters;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class BulkUpserterTest extends TestCase
+{
+    /**
+     * The last SQLite version without RETURNING support. Used to test the fallback no matter which
+     * SQLite version is actually installed.
+     */
+    private const SQLITE_VERSION_WITHOUT_RETURNING = '3.34.1';
+
+    public function testChangeDetectionOnBothPaths(): void
+    {
+        $config = BulkUpsertConfig::create(
+            'documents',
+            ['user_id', 'hash'],
+            [['unchanged', 'hash-1'], ['changed', 'hash-2-updated'], ['added', 'hash-3']],
+            ['user_id'],
+            ConflictMode::Update
+        )
+            ->withChangeDetectingColumn('hash')
+            ->withReturningColumns(['user_id', 'id']);
+
+        foreach ([null, self::SQLITE_VERSION_WITHOUT_RETURNING] as $sqliteVersion) {
+            $connection = $this->createInMemoryConnection();
+            $connection->executeStatement('CREATE TABLE documents (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id TEXT NOT NULL UNIQUE, hash TEXT NOT NULL)');
+            $connection->executeStatement("INSERT INTO documents (user_id, hash) VALUES ('unchanged', 'hash-1'), ('changed', 'hash-2')");
+
+            $results = $this->executeUpsert($connection, $config, $sqliteVersion);
+
+            $idsByUserId = BulkUpserter::convertResultsToKeyValueArray($connection->fetchAllAssociative('SELECT user_id, id FROM documents'));
+
+            $expectedKeys = $sqliteVersion === null
+                // The modern path does not return conflicting rows that were skipped via the change detecting column
+                ? ['added', 'changed']
+                // The fallback cannot cheaply detect skipped rows, so it conservatively returns all upserted rows
+                : ['added', 'changed', 'unchanged'];
+
+            $this->assertResultMap(array_intersect_key($idsByUserId, array_flip($expectedKeys)), $results);
+        }
+    }
+
+    public function testConflictModeIgnoreWithReturningColumnsOnBothPaths(): void
+    {
+        $config = BulkUpsertConfig::create(
+            'terms',
+            ['term', 'length', 'state'],
+            [['foo', 3, 10], ['baz', 3, 30], ['qux', 3, 40]],
+            ['term', 'state', 'length'], // Deliberately ordered differently than the row columns
+            ConflictMode::Ignore
+        )->withReturningColumns(['term', 'id']);
+
+        foreach ([null, self::SQLITE_VERSION_WITHOUT_RETURNING] as $sqliteVersion) {
+            $connection = $this->createInMemoryConnection();
+            $connection->executeStatement('CREATE TABLE terms (id INTEGER PRIMARY KEY AUTOINCREMENT, term TEXT NOT NULL, length INTEGER NOT NULL, state INTEGER NOT NULL, UNIQUE(term, state, length))');
+            $connection->executeStatement("INSERT INTO terms (term, length, state) VALUES ('foo', 3, 10), ('bar', 3, 20)");
+
+            // Both paths must return existing and newly inserted rows alike. Using a tiny variable
+            // limit to ensure the results are collected correctly across multiple chunks.
+            $results = $this->executeUpsert($connection, $config, $sqliteVersion, 6);
+
+            $idsByTerm = BulkUpserter::convertResultsToKeyValueArray($connection->fetchAllAssociative('SELECT term, id FROM terms'));
+
+            // The pre-existing row must have kept its ID
+            $this->assertSame(1, $idsByTerm['foo']);
+            $this->assertResultMap(array_intersect_key($idsByTerm, array_flip(['baz', 'foo', 'qux'])), $results);
+        }
+    }
+
+    public function testEngineIndexesAndSearchesWithoutReturningSupport(): void
+    {
+        $engine = $this->createTestEngine();
+        $this->forceSqliteVersionWithoutReturning($engine);
+
+        $engine->addDocuments([
+            [
+                'id' => 1,
+                'content' => 'John Doe',
+            ],
+            [
+                'id' => 2,
+                'content' => 'Jane Doe',
+            ],
+        ]);
+
+        $this->assertSame([1], $this->searchIds($engine, 'john'));
+        $this->assertSame([1, 2], $this->searchIds($engine, 'doe'));
+
+        // Re-adding an unchanged and an updated document must work as well (change detection)
+        $engine->addDocuments([
+            [
+                'id' => 1,
+                'content' => 'John Doe',
+            ],
+            [
+                'id' => 2,
+                'content' => 'Jane Rocket',
+            ],
+        ]);
+
+        $this->assertSame([1], $this->searchIds($engine, 'doe'));
+        $this->assertSame([2], $this->searchIds($engine, 'rocket'));
+
+        $engine->deleteDocuments([1]);
+
+        $this->assertSame([], $this->searchIds($engine, 'john'));
+        $this->assertSame([2], $this->searchIds($engine, 'jane'));
+    }
+
+    public function testWithoutReturningColumnsOnFallbackPath(): void
+    {
+        $connection = $this->createInMemoryConnection();
+        $connection->executeStatement('CREATE TABLE relations (a INTEGER NOT NULL, b INTEGER NOT NULL, UNIQUE(a, b))');
+        $connection->executeStatement('INSERT INTO relations (a, b) VALUES (1, 2)');
+
+        $config = BulkUpsertConfig::create(
+            'relations',
+            ['a', 'b'],
+            [[1, 2], [3, 4]],
+            ['a', 'b'],
+            ConflictMode::Ignore
+        );
+
+        $this->assertSame([], $this->executeUpsert($connection, $config, self::SQLITE_VERSION_WITHOUT_RETURNING));
+        $this->assertSame(2, (int) $connection->fetchOne('SELECT COUNT(*) FROM relations'));
+    }
+
+    /**
+     * @param array<string|int, mixed> $expected
+     * @param array<mixed> $results
+     */
+    private function assertResultMap(array $expected, array $results): void
+    {
+        $map = BulkUpserter::convertResultsToKeyValueArray($results);
+        ksort($map);
+        ksort($expected);
+
+        $this->assertSame($expected, $map);
+    }
+
+    private function createInMemoryConnection(): Connection
+    {
+        return DriverManager::getConnection((new DsnParser())->parse('pdo-sqlite:///:memory:'));
+    }
+
+    private function createTestEngine(): Engine
+    {
+        $connectionPool = new ConnectionPool($this->createInMemoryConnection(), $this->createInMemoryConnection());
+        $configuration = Configuration::create()->withSearchableAttributes(['content']);
+
+        return new Engine($connectionPool, $configuration, new NullLogger());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function executeUpsert(Connection $connection, BulkUpsertConfig $config, string|null $sqliteVersion, int $variableLimit = BulkUpserterFactory::VARIABLE_LIMIT): array
+    {
+        $sqliteVersion ??= (string) $connection->fetchOne('SELECT sqlite_version()');
+
+        return (new BulkUpserter($connection, $config, $variableLimit, $sqliteVersion))->execute();
+    }
+
+    private function forceSqliteVersionWithoutReturning(Engine $engine): void
+    {
+        $connectionPool = (new \ReflectionProperty($engine, 'connectionPool'))->getValue($engine);
+        \assert($connectionPool instanceof ConnectionPool);
+
+        (new \ReflectionProperty($engine, 'bulkUpserterFactory'))->setValue(
+            $engine,
+            new BulkUpserterFactory($connectionPool, self::SQLITE_VERSION_WITHOUT_RETURNING)
+        );
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function searchIds(Engine $engine, string $query): array
+    {
+        $hits = $engine->search(SearchParameters::create()->withQuery($query))->toArray()['hits'] ?? [];
+        $ids = array_column($hits, 'id');
+        sort($ids);
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
Fixes #325

First of all: thank you for Loupe! It's a fantastic library, and the fact that it runs anywhere PHP and SQLite run is exactly why this PR exists. 🙂

## Re: "SQLite >= 3.35.0 is enforced through composer.json"

I read your reply on #325, and I fully understand the constraint. I'd still like to propose this PR, because `composer.json` can only enforce the requirement on the machine where `composer install` runs, not on the machine where Loupe actually executes. On shared hosting these aren't necessarily the same: `vendor/` gets built locally or in CI (with a modern SQLite) and then deployed, or ships bundled with a CMS plugin. In the reported case, Loupe 0.13.21 was installed and running on the host despite the constraint and then crashed on the first index write.

So this PR deliberately does **not** touch `composer.json`: SQLite >= 3.35.0 stays the official, documented, fast-path requirement. It only adds a runtime fallback so that Loupe degrades gracefully instead of throwing on every write when the runtime SQLite is older, filling in the placeholder that was already in the code (`// Depending on the version, we could introduce fallback solutions here`). A runtime version check with a clear exception message would fail more loudly than the current syntax error, but it wouldn't help anyone actually deploying to such hosts — with the fallback, Loupe just works there.

## Problem

Since 0.13, `BulkUpserter::execute()` unconditionally uses the `RETURNING` clause, which requires SQLite >= 3.35.0 (2021-03-12). On hosts whose PHP is linked against an older SQLite, not uncommon on shared hosting, where the runtime environment often differs from the machine that built `vendor/`, every index write throws:

```
PDOException: SQLSTATE[HY000]: General error: 1 near "RETURNING": syntax error
```

Reported reproduction: IONOS shared hosting, PHP 8.4.22, PDO_SQLite 3.34.1 (one release below 3.35.0). Loupe 0.12 worked on the same host.

## Strategy

- `BulkUpserterFactory` now determines the runtime SQLite version once per engine (`SELECT sqlite_version()`, lazily cached) and passes it to each `BulkUpserter`.
- On SQLite >= 3.35.0 nothing changes: the modern `RETURNING` path stays the default, and the SQL it produces is identical to before — no performance regression for the common case.
- On older SQLite, the upsert is executed without `RETURNING`, and when returning columns are requested, the result is reconstructed with a follow-up `SELECT <returningColumns> FROM <table> WHERE (<uniqueColumns>) IN (VALUES ...)` over the unique-column values of the just-upserted rows. The result has the exact shape and keying the `Indexer` expects.

### Trade-off: change detection

The modern path's `RETURNING` omits rows skipped by the change-detecting column (`WHERE _hash IS NOT excluded._hash`). The fallback cannot cheaply detect which rows were skipped, so it conservatively returns **all** upserted rows. The write-skipping `WHERE` itself still applies on the fallback path, and the practical impact is small: `Indexer::addDocuments()` already pre-filters unchanged documents against the stored hashes before the bulk upsert, and re-processing is idempotent (`ConflictMode::Ignore` everywhere downstream). This is documented in the `executeLegacy()` docblock.

### Effective version floor

The fallback's follow-up `SELECT` uses row-value `IN (VALUES ...)` (SQLite >= 3.15.0), which is subsumed by the `INSERT ... ON CONFLICT` upsert syntax both paths already require (SQLite >= 3.24.0). So the fallback effectively supports SQLite 3.24.0–3.34.x.

## Tests

- Unit tests compare the modern and fallback paths on the same data for all three shapes the `Indexer` uses (update with change detection + returning, conflict-ignore with returning and differently-ordered unique columns across multiple chunks, no returning columns).
- An engine-level test drives indexing, re-indexing (unchanged + updated document), search, and deletion end-to-end with the fallback forced.
- Since CI's SQLite is >= 3.35, truly exercising the `< 3.35` branch needs the version check to be overridable: `BulkUpserterFactory` takes an optional `$sqliteVersion` constructor argument (auto-detected when `null`), so the fallback branch is testable regardless of the installed SQLite. The engine-level test swaps the factory via reflection to avoid widening `Engine`'s constructor.

`composer phpstan`, `composer cs-fixer` (ecs) and the unit/functional/slow suites are green.

## Deliberately out of scope

- As said above, `composer.json` and the README are untouched, 3.35.0 remains the official requirement.
- Phrase search separately emits `MATERIALIZED`/`NOT MATERIALIZED` CTE hints, which are also 3.35.0+. Fully supporting older SQLite end-to-end would need those gated as well — happy to do that as a follow-up if you want it, but I kept this PR minimal and localized to the `BulkUpserter`.

Thanks for taking a look!