### PR TITLE
Skip unchanged state set persistence

### DIFF
--- a/src/Internal/StateSetIndex/StateSet.php
+++ b/src/Internal/StateSetIndex/StateSet.php
@@ -12,6 +12,8 @@ use Toflar\StateSetIndex\StateSet\StateSetInterface;
 
 class StateSet implements StateSetInterface
 {
+    private bool $dirty = false;
+
     private bool $initialized = false;
 
     private InMemoryStateSet $inMemoryStateSet;
@@ -23,7 +25,13 @@ class StateSet implements StateSetInterface
     public function add(int $state): void
     {
         $this->initialize();
+
+        if ($this->inMemoryStateSet->has($state)) {
+            return;
+        }
+
         $this->inMemoryStateSet->add($state);
+        $this->dirty = true;
     }
 
     public function all(): array
@@ -36,7 +44,13 @@ class StateSet implements StateSetInterface
     public function clear(): void
     {
         $this->initialize();
+
+        if ([] === $this->inMemoryStateSet->all()) {
+            return;
+        }
+
         $this->inMemoryStateSet = new InMemoryStateSet([]);
+        $this->dirty = true;
     }
 
     public function has(int $state): bool
@@ -49,6 +63,11 @@ class StateSet implements StateSetInterface
     public function persist(): void
     {
         $this->initialize();
+
+        if (!$this->dirty) {
+            return;
+        }
+
         $this->engine->getConnection()->executeStatement('DELETE FROM '.IndexInfo::TABLE_NAME_STATE_SET);
         $this->engine->getConnection()->executeStatement('DELETE FROM sqlite_sequence WHERE name = ?', [IndexInfo::TABLE_NAME_STATE_SET]);
         $values = [];
@@ -64,12 +83,19 @@ class StateSet implements StateSetInterface
         $all = $this->inMemoryStateSet->all();
         $all = array_combine($this->inMemoryStateSet->all(), array_fill(0, \count($all), true));
         $this->dumpStateSetCache($all);
+        $this->dirty = false;
     }
 
     public function remove(int $state): void
     {
         $this->initialize();
+
+        if (!$this->inMemoryStateSet->has($state)) {
+            return;
+        }
+
         $this->inMemoryStateSet->remove($state);
+        $this->dirty = true;
     }
 
     /**

--- a/tests/Unit/Internal/StateSetIndex/StateSetTest.php
+++ b/tests/Unit/Internal/StateSetIndex/StateSetTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Tools\DsnParser;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\ConnectionPool;
 use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Tests\StorageFixturesTestTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -79,6 +80,27 @@ final class StateSetTest extends TestCase
             // Jane
             3, 14, 59, 238,
         ]);
+    }
+
+    public function testStateSetIsNotPersistedWhenDocumentsAreUnchanged(): void
+    {
+        $engine = $this->createTestEngine();
+        $documents = [
+            [
+                'id' => 1,
+                'content' => 'John Doe',
+            ],
+        ];
+
+        $engine->addDocuments($documents);
+        $engine->getConnection()->executeStatement(
+            'CREATE TRIGGER prevent_state_set_rewrite BEFORE DELETE ON '.IndexInfo::TABLE_NAME_STATE_SET.
+            " BEGIN SELECT RAISE(ABORT, 'State set must not be rewritten.'); END",
+        );
+
+        $engine->addDocuments($documents);
+
+        $this->assertStateSetContents($engine, [3, 16, 65, 263, 1, 8, 34]);
     }
 
     public function testStateSetIndexRevisedAfterDocumentDeleted(): void


### PR DESCRIPTION
Avoid rewriting the persisted state set when indexing does not change it. This speeds up updates that leave searchable terms unchanged.