### PR TITLE
Reduce database size using `WITHOUT ROWID`

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -641,7 +641,6 @@ class IndexInfo
         ;
 
         $table->setPrimaryKey(['term', 'document', 'attribute', 'position']);
-        $table->addIndex(['document']);
     }
 
     private function addTermsToSchema(Schema $schema): void
@@ -730,6 +729,28 @@ class IndexInfo
         // Schema changes invalidate query planner statistics; drop them before introspecting
         $connection->executeStatement('DROP TABLE IF EXISTS sqlite_stat1');
         $connection->executeStatement('DROP TABLE IF EXISTS sqlite_stat4');
+
+        $schemaDiff = $comparator->compareSchemas($schemaManager->introspectSchema(), $this->getSchema());
+
+        foreach ($schemaDiff->getCreatedTables() as $table) {
+            if (
+                in_array(
+                    $table->getObjectName()->getUnqualifiedName()->getValue(),
+                    [
+                        self::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS,
+                        self::TABLE_NAME_TERMS_DOCUMENTS,
+                        self::TABLE_NAME_PREFIXES_TERMS,
+                    ],
+                )
+            ) {
+                foreach ($connection->getDatabasePlatform()->getCreateTableSQL($table) as $statement) {
+                    if (str_starts_with($statement, 'CREATE TABLE')) {
+                        $statement .= ' WITHOUT ROWID';
+                    }
+                    $connection->executeStatement($statement);
+                }
+            }
+        }
 
         $schemaDiff = $comparator->compareSchemas($schemaManager->introspectSchema(), $this->getSchema());
         $schemaManager->alterSchema($schemaDiff);


### PR DESCRIPTION
SQLite supports using clustered indexes using the `WITHOUT ROWID` keywords. This is especially helpful for tables with a composite primary key. See <https://sqlite.org/withoutrowid.html>

This shrinks the bench database from 216 MB by 50% down to 108 MB and reduces query time up to 26%.

```
+-------------+---------------------------+-----+------+-----+----------------+------------------+----------------+
| benchmark   | subject                   | set | revs | its | mem_peak       | mode             | rstdev         |
+-------------+---------------------------+-----+------+-----+----------------+------------------+----------------+
| SearchBench | benchExactQueryWithFacets |     | 3    | 5   | 9.750mb 0.00%  | 4.61ms -2.31%    | ±2.54% -18.46% |
| SearchBench | benchMultiWordQueries     |     | 1    | 5   | 10.079mb 0.00% | 101.17ms -14.20% | ±0.77% -72.79% |
| SearchBench | benchNegatedTermQueries   |     | 1    | 5   | 9.750mb 0.00%  | 11.33ms -5.75%   | ±3.69% +12.43% |
| SearchBench | benchPhraseGroupQueries   |     | 1    | 5   | 4.689mb 0.00%  | 21.62ms -1.60%   | ±1.73% -54.54% |
| SearchBench | benchPlainQuery           |     | 3    | 5   | 4.318mb 0.00%  | 5.09ms -7.20%    | ±3.43% +58.99% |
| SearchBench | benchSingleWordQueries    |     | 1    | 5   | 9.750mb 0.00%  | 22.34ms -26.01%  | ±4.23% -10.22% |
| SearchBench | benchTypoQueryWithFacets  |     | 3    | 5   | 9.750mb 0.00%  | 4.43ms -0.07%    | ±2.20% -32.42% |
| FilterBench | benchFilteredSortedSearch |     | 3    | 5   | 9.762mb 0.00%  | 15.17ms -2.40%   | ±3.28% -12.43% |
+-------------+---------------------------+-----+------+-----+----------------+------------------+----------------+
```

Sadly doctrine does not seem to support the `WITHOUT ROWID` table option for SQLite, but I could try to open a pull request for that there.