### PR TITLE
Make term positions global per document

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -41,7 +41,7 @@ use Toflar\StateSetIndex\StateSetIndex;
 
 class Engine
 {
-    public const VERSION = '0.13.1'; // Increase this whenever a re-index of all documents is needed
+    public const VERSION = '0.13.2'; // Increase this whenever a re-index of all documents is needed
 
     private const DEPENDENCY_HASH_RELEVANT_PACKAGES = [
         'wamania/php-stemmer', // Stemming algorithms might change

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -640,7 +640,7 @@ class IndexInfo
             ->setNotnull(true)
         ;
 
-        $table->setPrimaryKey(['term', 'document', 'attribute', 'position']);
+        $table->setPrimaryKey(['term', 'document', 'position']);
         $table->addIndex(['document']);
     }
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -479,7 +479,7 @@ class Indexer
                 return;
             }
 
-            // Key is the term, 0 the "document" (id), 1 the "attribute" (as string), 2 the "position", 3 the "start", 4 the "end" of the match, 5 if folded - need to optimize for memory here
+            // Key is the term, 0 the "document" (id), 1 the "attribute" (as string), 2 the document-global "position", 3 the "start", 4 the "end" of the match, 5 if folded - need to optimize for memory here
             $termsMapper = [];
             $knownTermRows = [];
             // 0 is the "term" (as string), 1 the "length", 2 the "state" - need to optimize for memory here
@@ -555,7 +555,7 @@ class Indexer
                     IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
                     ['document', 'attribute', 'position', 'start', 'end', 'folded', 'term'],
                     $relationRows,
-                    ['term', 'document', 'attribute', 'position'],
+                    ['term', 'document', 'position'],
                     ConflictMode::Ignore,
                 ))
                 ->execute()
@@ -819,9 +819,9 @@ class Indexer
 
         $tokensPerAttribute = $this->engine->getTokenizer()->tokenizeDocument($cleanedDocument);
 
-        foreach ($tokensPerAttribute as $attributeName => $tokenCollection) {
-            $termPosition = 1;
+        $termPosition = 1;
 
+        foreach ($tokensPerAttribute as $attributeName => $tokenCollection) {
             foreach ($tokenCollection->all() as $token) {
                 // Index the main term
                 $terms[] = new Term($token->getTerm(), $attributeName, $termPosition, $token->getOriginalStartPosition(), $token->getOriginalEndPosition(), $token->wasFolded());

--- a/tests/Benchmark/AbstractBench.php
+++ b/tests/Benchmark/AbstractBench.php
@@ -83,6 +83,10 @@ abstract class AbstractBench
             return;
         }
 
+        // Rebuild from an empty database so schema benchmarks do not include freelist pages from the previous index.
+        unset($loupe);
+        self::clearDir($dataDir);
+
         $movies = self::loadMovies();
         self::progress(\sprintf(
             'Building shared search index (%d documents, one-time) ...',
@@ -90,7 +94,7 @@ abstract class AbstractBench
         ));
         $start = microtime(true);
 
-        $loupe->deleteAllDocuments();
+        $loupe = self::loupe($dataDir);
         $loupe->addDocuments($movies);
 
         self::progress(\sprintf('Index built in %.1fs', microtime(true) - $start));


### PR DESCRIPTION
```
\Loupe\Loupe\Tests\Benchmark\SearchBench

    benchExactQueryWithFacets...............I4 - Mo6.13ms (±1.66%)
    benchMultiWordQueries...................I4 - Mo108.68ms (±0.91%)
    benchNegatedTermQueries.................I4 - Mo13.42ms (±4.02%)
    benchPhraseGroupQueries.................I4 - Mo19.88ms (±38.09%)
    benchPlainQuery.........................I4 - Mo4.96ms (±2.29%)
    benchSingleWordQueries..................I4 - Mo30.17ms (±2.70%)
    benchTypoQueryWithFacets................I4 - Mo5.94ms (±2.15%)

\Loupe\Loupe\Tests\Benchmark\FilterBench

    benchFilteredSortedSearch...............I4 - Mo11.42ms (±3.48%)

Subjects: 8, Assertions: 0, Failures: 0, Errors: 0
+-------------+---------------------------+-----+------+-----+----------+----------+---------+
| benchmark   | subject                   | set | revs | its | mem_peak | mode     | rstdev  |
+-------------+---------------------------+-----+------+-----+----------+----------+---------+
| SearchBench | benchExactQueryWithFacets |     | 3    | 5   | 10.116mb | 6.13ms   | ±1.66%  |
| SearchBench | benchMultiWordQueries     |     | 1    | 5   | 10.472mb | 108.68ms | ±0.91%  |
| SearchBench | benchNegatedTermQueries   |     | 1    | 5   | 10.116mb | 13.42ms  | ±4.02%  |
| SearchBench | benchPhraseGroupQueries   |     | 1    | 5   | 5.048mb  | 19.88ms  | ±38.09% |
| SearchBench | benchPlainQuery           |     | 3    | 5   | 4.678mb  | 4.96ms   | ±2.29%  |
| SearchBench | benchSingleWordQueries    |     | 1    | 5   | 10.116mb | 30.17ms  | ±2.70%  |
| SearchBench | benchTypoQueryWithFacets  |     | 3    | 5   | 10.116mb | 5.94ms   | ±2.15%  |
| FilterBench | benchFilteredSortedSearch |     | 3    | 5   | 10.124mb | 11.42ms  | ±3.48%  |
+-------------+---------------------------+-----+------+-----+----------+----------+---------+


Database storage
================

 ----------------------------------------------- ---------- ---------------------------- ----------- -------- 
  Object                                          Type       Table                        Bytes       MiB     
 ----------------------------------------------- ---------- ---------------------------- ----------- -------- 
  Database file                                   database   -                            198221824   189.04  
  Free pages                                      free       -                                    0     0.00  
  terms_documents                                 table      terms_documents               84828160    80.90  
  sqlite_autoindex_terms_documents_1              index      terms_documents               50003968    47.69  
  IDX_54BE7654D8698A76                            index      terms_documents               34217984    32.63  
  documents                                       table      documents                     18358272    17.51  
  UNIQ_88A23F71A50FE78DA393D2FB17D9EB2            index      terms                          1859584     1.77  
  terms                                           table      terms                          1679360     1.60  
  sqlite_autoindex_multi_attributes_documents_1   index      multi_attributes_documents      991232     0.95  
  IDX_88A23F71A393D2FB                            index      terms                           966656     0.92  
  IDX_88A23F7117D9EB2                             index      terms                           876544     0.84  
  IDX_63D2B928D8698A76                            index      multi_attributes_documents      860160     0.82  
  UNIQ_A2B072888C9D12A3                           index      documents                       851968     0.81  
  multi_attributes_documents                      table      multi_attributes_documents      835584     0.80  
  state_set                                       table      state_set                       483328     0.46  
  UNIQ_A2B07288D32632E8                           index      documents                       475136     0.45  
  IDX_A2B07288E769876D                            index      documents                       434176     0.41  
  IDX_A2B07288A8EBE516                            index      documents                       335872     0.32  
  sqlite_stat4                                    table      sqlite_stat4                     40960     0.04  
  IDX_3184ADFA17D9EB2                             index      prefixes                          8192     0.01  
  IDX_3184ADFAA393D2FB                            index      prefixes                          8192     0.01  
  IDX_79B61C7EA50FE78D                            index      prefixes_terms                    8192     0.01  
  UNIQ_3184ADFA93B1868EA393D2FB17D9EB2            index      prefixes                          8192     0.01  
  UNIQ_B9A261C7FA7AEFFB66246133                   index      multi_attributes                  8192     0.01  
  UNIQ_B9A261C7FA7AEFFBC97B03A9                   index      multi_attributes                  8192     0.01  
  UNIQ_CB8931578A90ABA9                           index      info                              8192     0.01  
  info                                            table      info                              8192     0.01  
  multi_attributes                                table      multi_attributes                  8192     0.01  
  prefixes                                        table      prefixes                          8192     0.01  
  prefixes_terms                                  table      prefixes_terms                    8192     0.01  
  sqlite_autoindex_prefixes_terms_1               index      prefixes_terms                    8192     0.01  
  sqlite_schema                                   internal   -                                 8192     0.01  
  sqlite_sequence                                 table      sqlite_sequence                   8192     0.01  
  sqlite_stat1                                    table      sqlite_stat1                      8192     0.01  
 ----------------------------------------------- ---------- ---------------------------- ----------- -------- 
```

This makes the position of a term global per document instead of relative to its attribute which is an information not required for the search results. This again allows us to drop the `attribute` from the index reducing the `sqlite_autoindex_terms_documents_1` index from `74.56 MB` to `47.69 MB` and thus about `30 MB`. Search speed also improves a bit.