### PR TITLE
Add bench for attribute queries

### DIFF
--- a/tests/Benchmark/SearchBench.php
+++ b/tests/Benchmark/SearchBench.php
@@ -40,6 +40,42 @@ class SearchBench extends AbstractBench
     }
 
     #[Revs(1)]
+    public function benchMultiQueryOnAttributes(): void
+    {
+        $attributes = [
+            ['title'],
+            ['overview'],
+            ['title', 'overview'],
+        ];
+
+        foreach ($attributes as $attr) {
+            $this->loupe->search(
+                SearchParameters::create()
+                    ->withQuery('Anakin Skywalker')
+                    ->withAttributesToSearchOn($attr),
+            );
+        }
+    }
+
+    #[Revs(1)]
+    public function benchSingleQueryOnAttributes(): void
+    {
+        $attributes = [
+            ['title'],
+            ['overview'],
+            ['title', 'overview'],
+        ];
+
+        foreach ($attributes as $attr) {
+            $this->loupe->search(
+                SearchParameters::create()
+                    ->withQuery('knight')
+                    ->withAttributesToSearchOn($attr),
+            );
+        }
+    }
+
+    #[Revs(1)]
     public function benchMultiWordQueries(): void
     {
         $queries = [


### PR DESCRIPTION
Searching only in specific attributes is very slow currently. I do not fully understand why yet. 

Changing the primary of `terms_documents` to `term, attribute, document, position` would make `benchSingleQueryOnAttributes()` faster but still way slower than a regular query.

Anyway this pull request adds a benchmark for it, so that we can work on a fix.