### PR TITLE
Add covering index for term document searches

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -41,7 +41,7 @@ use Toflar\StateSetIndex\StateSetIndex;
 
 class Engine
 {
-    public const VERSION = '0.13.2'; // Increase this whenever a re-index of all documents is needed
+    public const VERSION = '0.13.3'; // Increase this whenever a re-index of all documents is needed
 
     private const DEPENDENCY_HASH_RELEVANT_PACKAGES = [
         'wamania/php-stemmer', // Stemming algorithms might change

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -18,6 +18,8 @@ use Loupe\Loupe\Internal\Util;
 
 class IndexInfo
 {
+    public const INDEX_NAME_TERMS_DOCUMENTS_SEARCH = 'terms_documents_search';
+
     public const TABLE_NAME_DOCUMENTS = 'documents';
 
     public const TABLE_NAME_INDEX_INFO = 'info';
@@ -642,6 +644,10 @@ class IndexInfo
 
         $table->setPrimaryKey(['term', 'document', 'position']);
         $table->addIndex(['document']);
+        $table->addIndex(
+            ['term', 'document', 'attribute', 'position', 'folded'],
+            self::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
+        );
     }
 
     private function addTermsToSchema(Schema $schema): void

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -18,6 +18,8 @@ use Loupe\Loupe\Internal\Util;
 
 class IndexInfo
 {
+    public const INDEX_NAME_TERMS_DOCUMENTS_SEARCH = 'terms_documents_search';
+
     public const TABLE_NAME_DOCUMENTS = 'documents';
 
     public const TABLE_NAME_INDEX_INFO = 'info';
@@ -648,6 +650,10 @@ class IndexInfo
 
         $table->setPrimaryKey(['term', 'document', 'position']);
         $table->addIndex(['document']);
+        $table->addIndex(
+            ['term', 'document', 'attribute', 'position', 'folded'],
+            self::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
+        );
     }
 
     private function addTermsToSchema(Schema $schema): void

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -652,7 +652,7 @@ class Searcher
             $cteSelectQb->from(\sprintf(
                 '%s %s'
                 .' CROSS JOIN %s'
-                .' CROSS JOIN %s %s INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS)
+                .' CROSS JOIN %s %s INDEXED BY '.IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH
                 .' ON %s.id = %s.term'
                 .' AND %s.document = %s.document'
                 .' AND %s.attribute = %s.attribute'
@@ -744,7 +744,7 @@ class Searcher
         $queryBuilder->innerJoin(
             $termMatchesCTE,
             IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
-            $termsDocumentsAlias.' INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS),
+            $termsDocumentsAlias.' INDEXED BY '.IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
             \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias),
         );
     }

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -649,7 +649,7 @@ class Searcher
             $cteSelectQb->from(\sprintf(
                 '%s %s'
                 .' CROSS JOIN %s'
-                .' CROSS JOIN %s %s INDEXED BY sqlite_autoindex_terms_documents_1'
+                .' CROSS JOIN %s %s INDEXED BY '.IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH
                 .' ON %s.id = %s.term'
                 .' AND %s.document = %s.document'
                 .' AND %s.attribute = %s.attribute'
@@ -669,12 +669,12 @@ class Searcher
                 $previousPhraseAlias,
             ));
         } else {
-            // Join from term_matches CTE — not from terms_documents - to force primary key usage
+            // Join from term_matches CTE — not from terms_documents - to force the intended occurrence index usage
             $cteSelectQb->from($termMatchesCTE);
             $cteSelectQb->innerJoin(
                 $termMatchesCTE,
                 IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
-                $termsDocumentsAlias.' INDEXED BY sqlite_autoindex_terms_documents_1',
+                $termsDocumentsAlias.' INDEXED BY '.IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
                 \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias),
             );
         }


### PR DESCRIPTION
Compared with the `main` branch:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Multi-word queries | 111.68 ms | 102.84 ms | -7.9% |
| Phrase group queries | 21.43 ms | 20.30 ms | -5.3% |
| Plain query | 5.78 ms | 5.30 ms | -8.3% |
| Single-word queries | 34.29 ms | 25.92 ms | -24.4% |

All other benchmarks remain effectively unchanged.

But this would make the database even bigger... @ausi 