### PR TITLE
Store attribute names in a separate table

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -22,6 +22,8 @@ class IndexInfo
 
     public const TABLE_NAME_INDEX_INFO = 'info';
 
+    public const TABLE_NAME_ATTRIBUTES = 'attributes';
+
     public const TABLE_NAME_MULTI_ATTRIBUTES = 'multi_attributes';
 
     public const TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS = 'multi_attributes_documents';
@@ -163,6 +165,7 @@ class IndexInfo
         return match ($table) {
             self::TABLE_NAME_DOCUMENTS => 'd',
             self::TABLE_NAME_INDEX_INFO => 'i',
+            self::TABLE_NAME_ATTRIBUTES => 'a',
             self::TABLE_NAME_MULTI_ATTRIBUTES => 'ma',
             self::TABLE_NAME_MULTI_ATTRIBUTES_DOCUMENTS => 'mad',
             self::TABLE_NAME_TERMS => 't',
@@ -528,6 +531,23 @@ class IndexInfo
         $table->addIndex(['document']);
     }
 
+    private function addAttributesToSchema(Schema $schema): void
+    {
+        $table = $schema->createTable(self::TABLE_NAME_ATTRIBUTES);
+
+        $table->addColumn('id', Types::INTEGER)
+            ->setNotnull(true)
+            ->setAutoincrement(true)
+        ;
+
+        $table->addColumn('attribute', Types::STRING)
+            ->setNotnull(true)
+        ;
+
+        $table->setPrimaryKey(['id']);
+        $table->addUniqueIndex(['attribute']);
+    }
+
     private function addMultiAttributesToSchema(Schema $schema): void
     {
         $table = $schema->createTable(self::TABLE_NAME_MULTI_ATTRIBUTES);
@@ -620,7 +640,7 @@ class IndexInfo
             ->setNotnull(true)
         ;
 
-        $table->addColumn('attribute', Types::STRING)
+        $table->addColumn('attribute', Types::INTEGER)
             ->setNotnull(true)
         ;
 
@@ -682,6 +702,7 @@ class IndexInfo
 
         $this->addIndexInfoToSchema($schema);
         $this->addDocumentsToSchema($schema);
+        $this->addAttributesToSchema($schema);
         $this->addMultiAttributesToSchema($schema);
         $this->addTermsToSchema($schema);
         $this->addPrefixesToSchema($schema);

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -479,6 +479,29 @@ class Indexer
                 return;
             }
 
+            $attributeStrings = [];
+
+            foreach ($preparedDocuments->all() as $document) {
+                foreach ($document->getTerms() as $term) {
+                    $attributeStrings[$term->getAttribute()] = true;
+                }
+            }
+
+            // Bulk insert attributes
+            $results = $this->engine->getBulkUpserterFactory()
+                ->create(BulkUpsertConfig::create(
+                    IndexInfo::TABLE_NAME_ATTRIBUTES,
+                    ['attribute'],
+                    array_map(static fn ($attr) => [$attr], array_keys($attributeStrings)),
+                    ['attribute'],
+                    ConflictMode::Ignore,
+                )->withReturningColumns(['attribute', 'id']))
+                ->execute()
+            ;
+
+            /** @var array<string, int> $attributesIdMapper */
+            $attributesIdMapper = BulkUpserter::convertResultsToKeyValueArray($results);
+
             // Key is the term, 0 the "document" (id), 1 the "attribute" (as string), 2 the document-global "position", 3 the "start", 4 the "end" of the match, 5 if folded - need to optimize for memory here
             $termsMapper = [];
             $knownTermRows = [];
@@ -494,7 +517,7 @@ class Indexer
                         $rows[] = [$term->getTerm(), $term->getTermLength(), 0];
                     }
 
-                    $termsMapper[$term->getTerm()][] = [$document->getInternalId(), $term->getAttribute(), $term->getPosition(), $term->getStart(), $term->getEnd(), $term->isVariant()];
+                    $termsMapper[$term->getTerm()][] = [$document->getInternalId(), $attributesIdMapper[$term->getAttribute()], $term->getPosition(), $term->getStart(), $term->getEnd(), $term->isVariant()];
 
                     // Prefix relevant terms must not be variants
                     if ($indexPrefixes && !$term->isVariant()) {


### PR DESCRIPTION
This would bring the `terms_documents` table down by 25% and should work great with the other pull requests as it also reduces the size of any index on `terms_documents.attribute`.

If you agree with this change I would try to update the query side as well. _(Currently only the index side is implemented)_