### PR TITLE
Synonyms

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,36 @@ $configuration = \Loupe\Loupe\Configuration::create()
 ;
 ```
 
+## Synonyms
+
+Synonyms let you define terms that should additionally match other terms during search. They are read **query-side**
+and are **one-way**. In the example below, searching for `jacket` also finds documents containing `parka` or `windbreaker`,
+but searching for `parka` does NOT find generic jackets.
+
+```php
+$configuration = \Loupe\Loupe\Configuration::create()
+    ->withSynonyms([
+        'jacket' => ['parka', 'windbreaker'],
+    ])
+;
+```
+
+Two-way synonyms are expressed by listing both directions explicitly.
+
+```php
+$configuration = \Loupe\Loupe\Configuration::create()
+    ->withSynonyms([
+        'couch' => ['sofa'],
+        'sofa' => ['couch'],
+    ])
+;
+```
+
+A few things to keep in mind:
+
+- **Single-word only.** Every synonym source and target must be a single word. Multi-word entries are unsupported.
+- **Changing synonyms requires a reindex.** The synonyms are resolved during indexing and only take effect after a reindex.
+- **Literal matches rank above synonym matches**. A document containing the original term outranks one that only matches via a synonym.
 
 ## Minimum length for prefix search
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,9 +81,9 @@ $configuration = \Loupe\Loupe\Configuration::create()
 
 ## Synonyms
 
-Synonyms let you define terms that should additionally match other terms during search. They are read **query-side**
-and are **one-way**. In the example below, searching for `jacket` also finds documents containing `parka` or `windbreaker`,
-but searching for `parka` does NOT find generic jackets.
+Synonyms let terms match other terms during search. Each mapping is **one-way**: the key is a query term and its values
+are matching document terms. In this example, searching for `jacket` also finds documents containing `parka` or
+`windbreaker`, but searching for `parka` does not find generic jackets.
 
 ```php
 $configuration = \Loupe\Loupe\Configuration::create()
@@ -103,8 +103,6 @@ $configuration = \Loupe\Loupe\Configuration::create()
     ])
 ;
 ```
-
-A few things to keep in mind:
 
 - **Single-word only.** Every synonym source and target must be a single word. Multi-word entries are unsupported.
 - **Changing synonyms requires a reindex.** The synonyms are resolved during indexing and only take effect after a reindex.

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -81,6 +81,8 @@ final class Configuration
     private array $stopWords = [];
 
     /**
+     * Synonyms of terms: 'search term' => ['additional', 'terms', 'to', 'match']
+     *
      * @var array<string, array<string>>
      */
     private array $synonyms = [];

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -592,7 +592,7 @@ final class Configuration
 
         foreach ($synonyms as $key => $values) {
             if (!\is_string($key) || !self::isValidSynonymTerm($key)) {
-                throw InvalidConfigurationException::becauseInvalidSynonym(\is_string($key) ? $key : (string) $key);
+                throw InvalidConfigurationException::becauseInvalidSynonym((string) $key);
             }
 
             if (!\is_array($values) || !array_is_list($values) || [] === $values) {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -80,6 +80,11 @@ final class Configuration
      */
     private array $stopWords = [];
 
+    /**
+     * @var array<string, array<string>>
+     */
+    private array $synonyms = [];
+
     private TypoTolerance $typoTolerance;
 
     /**
@@ -114,6 +119,7 @@ final class Configuration
      *     searchableAttributes?: array<string>,
      *     sortableAttributes?: array<string>,
      *     stopWords?: array<string>,
+     *     synonyms?: array<string, array<string>>,
      *     processName: ?string,
      *     typoTolerance?: array{
      *         alphabetSize?: int,
@@ -171,6 +177,10 @@ final class Configuration
 
         if (isset($data['stopWords'])) {
             $instance = $instance->withStopWords($data['stopWords']);
+        }
+
+        if (isset($data['synonyms'])) {
+            $instance = $instance->withSynonyms($data['synonyms']);
         }
 
         if (isset($data['processName'])) {
@@ -232,6 +242,7 @@ final class Configuration
         $hash[] = json_encode($this->getMaxTotalHits());
         $hash[] = json_encode($this->getSortableAttributes());
         $hash[] = json_encode($this->getStopWords());
+        $hash[] = json_encode($this->getSynonyms());
 
         $hash[] = $this->getTypoTolerance()->isDisabled() ? 'disabled' : 'enabled';
         $hash[] = $this->getTypoTolerance()->getAlphabetSize();
@@ -320,6 +331,14 @@ final class Configuration
         return $this->stopWords;
     }
 
+    /**
+     * @return array<string, array<string>>
+     */
+    public function getSynonyms(): array
+    {
+        return $this->synonyms;
+    }
+
     public function getTypoTolerance(): TypoTolerance
     {
         return $this->typoTolerance;
@@ -348,6 +367,7 @@ final class Configuration
      *     searchableAttributes: array<string>,
      *     sortableAttributes: array<string>,
      *     stopWords: array<string>,
+     *     synonyms: array<string, array<string>>,
      *     processName: ?string,
      *     typoTolerance: array{
      *         alphabetSize: int,
@@ -373,6 +393,7 @@ final class Configuration
             'searchableAttributes' => $this->searchableAttributes,
             'sortableAttributes' => $this->sortableAttributes,
             'stopWords' => $this->stopWords,
+            'synonyms' => $this->synonyms,
             'processName' => $this->processName,
             'typoTolerance' => $this->typoTolerance->toArray(),
         ];
@@ -562,6 +583,40 @@ final class Configuration
         return $clone;
     }
 
+    /**
+     * @param array<string, array<string>> $synonyms
+     */
+    public function withSynonyms(array $synonyms): self
+    {
+        $validated = [];
+
+        foreach ($synonyms as $key => $values) {
+            if (!\is_string($key) || !self::isValidSynonymTerm($key)) {
+                throw InvalidConfigurationException::becauseInvalidSynonym(\is_string($key) ? $key : (string) $key);
+            }
+
+            if (!\is_array($values) || !array_is_list($values) || [] === $values) {
+                throw InvalidConfigurationException::becauseInvalidSynonym($key);
+            }
+
+            foreach ($values as $value) {
+                if (!\is_string($value) || !self::isValidSynonymTerm($value)) {
+                    throw InvalidConfigurationException::becauseInvalidSynonym(\is_string($value) ? $value : $key);
+                }
+            }
+
+            sort($values);
+            $validated[$key] = $values;
+        }
+
+        ksort($validated);
+
+        $clone = clone $this;
+        $clone->synonyms = $validated;
+
+        return $clone;
+    }
+
     public function withTypoTolerance(TypoTolerance $tolerance): self
     {
         $clone = clone $this;
@@ -587,6 +642,11 @@ final class Configuration
         $clone->vacuumProbability = $probability;
 
         return $clone;
+    }
+
+    private static function isValidSynonymTerm(string $term): bool
+    {
+        return '' !== $term && !preg_match('/\s/u', $term);
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -81,7 +81,7 @@ final class Configuration
     private array $stopWords = [];
 
     /**
-     * Synonyms of terms: 'search term' => ['additional', 'terms', 'to', 'match']
+     * Synonyms of terms: 'search term' => ['additional', 'terms', 'to', 'match'].
      *
      * @var array<string, array<string>>
      */
@@ -598,7 +598,7 @@ final class Configuration
             }
 
             if (!\is_array($values) || !array_is_list($values) || [] === $values) {
-                throw InvalidConfigurationException::becauseInvalidSynonymValue(\is_scalar($values) ? (string) $values : get_debug_type($values));
+                throw InvalidConfigurationException::becauseInvalidSynonymValue(get_debug_type($values));
             }
 
             foreach ($values as $value) {

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -81,8 +81,6 @@ final class Configuration
     private array $stopWords = [];
 
     /**
-     * Synonyms of terms: 'search term' => ['additional', 'terms', 'to', 'match'].
-     *
      * @var array<string, array<string>>
      */
     private array $synonyms = [];

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -588,8 +588,6 @@ final class Configuration
      */
     public function withSynonyms(array $synonyms): self
     {
-        $validated = [];
-
         foreach ($synonyms as $key => $values) {
             if (!\is_string($key) || !self::isValidSynonymTerm($key)) {
                 throw InvalidConfigurationException::becauseInvalidSynonymKey((string) $key);
@@ -606,13 +604,13 @@ final class Configuration
             }
 
             sort($values);
-            $validated[$key] = $values;
+            $synonyms[$key] = $values;
         }
 
-        ksort($validated);
+        ksort($synonyms);
 
         $clone = clone $this;
-        $clone->synonyms = $validated;
+        $clone->synonyms = $synonyms;
 
         return $clone;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -594,16 +594,16 @@ final class Configuration
 
         foreach ($synonyms as $key => $values) {
             if (!\is_string($key) || !self::isValidSynonymTerm($key)) {
-                throw InvalidConfigurationException::becauseInvalidSynonym((string) $key);
+                throw InvalidConfigurationException::becauseInvalidSynonymKey((string) $key);
             }
 
             if (!\is_array($values) || !array_is_list($values) || [] === $values) {
-                throw InvalidConfigurationException::becauseInvalidSynonym($key);
+                throw InvalidConfigurationException::becauseInvalidSynonymValue(\is_scalar($values) ? (string) $values : get_debug_type($values));
             }
 
             foreach ($values as $value) {
                 if (!\is_string($value) || !self::isValidSynonymTerm($value)) {
-                    throw InvalidConfigurationException::becauseInvalidSynonym(\is_string($value) ? $value : $key);
+                    throw InvalidConfigurationException::becauseInvalidSynonymValue(\is_scalar($value) ? (string) $value : get_debug_type($value));
                 }
             }
 

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -29,11 +29,21 @@ class InvalidConfigurationException extends \InvalidArgumentException implements
         );
     }
 
-    public static function becauseInvalidSynonym(string $value): self
+    public static function becauseInvalidSynonymKey(string $key): self
     {
         return new self(
             \sprintf(
-                'A valid synonym key or value is a non-empty single-word string (no whitespace). "%s" given.',
+                'A valid synonym key is a non-empty single-word string. "%s" given.',
+                $key,
+            ),
+        );
+    }
+
+    public static function becauseInvalidSynonymValue(string $value): self
+    {
+        return new self(
+            \sprintf(
+                'A valid synonym value is an array of non-empty single-word strings. "%s" given.',
                 $value,
             ),
         );

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -29,6 +29,16 @@ class InvalidConfigurationException extends \InvalidArgumentException implements
         );
     }
 
+    public static function becauseInvalidSynonym(string $value): self
+    {
+        return new self(
+            \sprintf(
+                'A valid synonym key or value is a non-empty single-word string (no whitespace). "%s" given.',
+                $value,
+            ),
+        );
+    }
+
     public static function becauseRequiredDataDirMissing(): self
     {
         return new self('Data directory argument is required and cannot be empty.');

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -8,6 +8,7 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\LanguageDetection\LanguageDetectorInterface;
 use Loupe\Loupe\Internal\Levenshtein;
 use Loupe\Matcher\Locale;
+use Loupe\Matcher\Tokenizer\Normalizer\Normalizer;
 use Loupe\Matcher\Tokenizer\Token;
 use Loupe\Matcher\Tokenizer\TokenCollection;
 use Loupe\Matcher\Tokenizer\Tokenizer as LoupeMatcherTokenizer;
@@ -18,6 +19,11 @@ use Wamania\Snowball\StemmerFactory;
 
 class Tokenizer implements TokenizerInterface
 {
+    /**
+     * @var array<string, list<string>>|null
+     */
+    private array|null $synonymLookup = null;
+
     /**
      * @var array<string, LoupeMatcherTokenizer>
      */
@@ -173,10 +179,52 @@ class Tokenizer implements TokenizerInterface
                 }
             }
 
-            $tokenCollectionWithVariants->add($token->withAddedVariants($variants));
+            $token = $token->withAddedVariants($variants);
+            $synonymLookup = $this->getSynonymLookup();
+            if ([] !== $synonymLookup) {
+                $synonymVariants = [];
+
+                foreach ($token->allTerms() as $term) {
+                    foreach ($synonymLookup[$term] ?? [] as $searchTerm) {
+                        $synonymVariants[] = $searchTerm;
+                    }
+                }
+                $token = $token->withAddedVariants($synonymVariants);
+            }
+
+            $tokenCollectionWithVariants->add($token);
         }
 
         return $tokenCollectionWithVariants;
+    }
+
+    /**
+     * Build (and cache) the inverted synonym lookup from the configuration.
+     *
+     * @return array<string, list<string>>
+     */
+    private function getSynonymLookup(): array
+    {
+        if (null !== $this->synonymLookup) {
+            return $this->synonymLookup;
+        }
+
+        $normalizer = new Normalizer();
+        $lookup = [];
+
+        foreach ($this->engine->getConfiguration()->getSynonyms() as $searchTerm => $documentTerms) {
+            $normalizedSearchTerm = $normalizer->normalize($searchTerm);
+
+            foreach ($documentTerms as $documentTerm) {
+                $lookup[$normalizer->normalize($documentTerm)][] = $normalizedSearchTerm;
+            }
+        }
+
+        foreach ($lookup as $documentTerm => $searchTerms) {
+            $lookup[$documentTerm] = array_values(array_unique($searchTerms));
+        }
+
+        return $this->synonymLookup = $lookup;
     }
 
     private function getStemmerForLanguage(string $language): Stemmer|null

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -198,35 +198,6 @@ class Tokenizer implements TokenizerInterface
         return $tokenCollectionWithVariants;
     }
 
-    /**
-     * Build (and cache) the inverted synonym lookup from the configuration.
-     *
-     * @return array<string, list<string>>
-     */
-    private function getSynonymLookup(): array
-    {
-        if (null !== $this->synonymLookup) {
-            return $this->synonymLookup;
-        }
-
-        $normalizer = new Normalizer();
-        $lookup = [];
-
-        foreach ($this->engine->getConfiguration()->getSynonyms() as $searchTerm => $documentTerms) {
-            $normalizedSearchTerm = $normalizer->normalize($searchTerm);
-
-            foreach ($documentTerms as $documentTerm) {
-                $lookup[$normalizer->normalize($documentTerm)][] = $normalizedSearchTerm;
-            }
-        }
-
-        foreach ($lookup as $documentTerm => $searchTerms) {
-            $lookup[$documentTerm] = array_values(array_unique($searchTerms));
-        }
-
-        return $this->synonymLookup = $lookup;
-    }
-
     private function getStemmerForLanguage(string $language): Stemmer|null
     {
         if (\array_key_exists($language, $this->stemmers)) {
@@ -255,5 +226,32 @@ class Tokenizer implements TokenizerInterface
         }
 
         return $this->stemmerCache[$language][$term] = mb_strtolower($stemmer->stem($term), 'UTF-8');
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function getSynonymLookup(): array
+    {
+        if (null !== $this->synonymLookup) {
+            return $this->synonymLookup;
+        }
+
+        $normalizer = new Normalizer();
+        $lookup = [];
+
+        foreach ($this->engine->getConfiguration()->getSynonyms() as $searchTerm => $documentTerms) {
+            $normalizedSearchTerm = $normalizer->normalize($searchTerm);
+
+            foreach ($documentTerms as $documentTerm) {
+                $lookup[$normalizer->normalize($documentTerm)][] = $normalizedSearchTerm;
+            }
+        }
+
+        foreach ($lookup as $documentTerm => $searchTerms) {
+            $lookup[$documentTerm] = array_values(array_unique($searchTerms));
+        }
+
+        return $this->synonymLookup = $lookup;
     }
 }

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -163,6 +163,7 @@ class Tokenizer implements TokenizerInterface
     {
         $tokenCollection = $this->getLanguageTokenizer($language)->tokenize($string, true, $maxTokens);
         $tokenCollectionWithVariants = new TokenCollection();
+        $synonymLookup = $this->getSynonymLookup();
 
         foreach ($tokenCollection->all() as $token) {
             $variants = [];
@@ -180,7 +181,6 @@ class Tokenizer implements TokenizerInterface
             }
 
             $token = $token->withAddedVariants($variants);
-            $synonymLookup = $this->getSynonymLookup();
             if ([] !== $synonymLookup) {
                 $synonymVariants = [];
 

--- a/tests/Functional/SynonymTest.php
+++ b/tests/Functional/SynonymTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Functional;
+
+use Loupe\Loupe\Config\TypoTolerance;
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Loupe;
+use Loupe\Loupe\SearchParameters;
+use Loupe\Loupe\Tests\StorageFixturesTestTrait;
+use PHPUnit\Framework\TestCase;
+
+final class SynonymTest extends TestCase
+{
+    use FunctionalTestTrait;
+    use StorageFixturesTestTrait;
+
+    public function testExactnessRanksLiteralMatchAboveSynonym(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'tv' => ['television'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'television set'],
+            ['id' => 2, 'title' => 'tv set'],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('tv')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withShowRankingScore(true)
+        ;
+
+        $results = $loupe->search($searchParameters)->toArray();
+
+        $this->assertSame([2, 1], array_column($results['hits'], 'id'));
+        $this->assertGreaterThan($results['hits'][1]['_rankingScore'], $results['hits'][0]['_rankingScore']);
+    }
+
+    public function testHighlightingArrayAttribute(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title', 'tags'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'tv' => ['television'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'gadget', 'tags' => ['brand new television', 'electronics']],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('tv')
+            ->withAttributesToRetrieve(['id', 'title', 'tags'])
+            ->withAttributesToHighlight(['tags'])
+        ;
+
+        $results = $loupe->search($searchParameters)->toArray();
+
+        $this->assertSame(
+            ['brand new <em>television</em>', 'electronics'],
+            $results['hits'][0]['_formatted']['tags'],
+        );
+    }
+
+    public function testHighlightingStringAttribute(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'tv' => ['television'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'television set'],
+        ]);
+
+        $searchParameters = SearchParameters::create()
+            ->withQuery('tv')
+            ->withAttributesToRetrieve(['id', 'title'])
+            ->withAttributesToHighlight(['title'])
+            ->withShowMatchesPosition(true)
+        ;
+
+        $results = $loupe->search($searchParameters)->toArray();
+
+        $this->assertSame('<em>television</em> set', $results['hits'][0]['_formatted']['title']);
+
+        $this->assertSame(
+            [['start' => 0, 'length' => 10 ]],
+            $results['hits'][0]['_matchesPosition']['title'],
+        );
+    }
+
+    public function testOneWayMatch(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'phone' => ['iphone'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'iphone 15 pro'],
+            ['id' => 2, 'title' => 'android phone'],
+        ]);
+
+        // Searching the synonym key "phone" matches both the generic phone and the iphone reached via the synonym.
+        $this->assertSame([1, 2], $this->searchIds($loupe, 'phone'));
+
+        // Searching "iphone" stays specific: it only matches the iphone document, not generic phones.
+        $this->assertSame([1], $this->searchIds($loupe, 'iphone'));
+    }
+
+    public function testTwoWayMatch(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'couch' => ['sofa'],
+                'sofa' => ['couch'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'comfortable couch'],
+            ['id' => 2, 'title' => 'leather sofa'],
+        ]);
+
+        $this->assertSame([1, 2], $this->searchIds($loupe, 'couch'));
+        $this->assertSame([1, 2], $this->searchIds($loupe, 'sofa'));
+    }
+
+    public function testTypoOnQueryHitsSynonym(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withSynonyms([
+                'television' => ['tv'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'tv set'],
+        ]);
+
+        $this->assertSame([1], $this->searchIds($loupe, 'televsion'));
+    }
+
+    /**
+     * @return array<int>
+     */
+    private function searchIds(Loupe $loupe, string $query): array
+    {
+        $searchParameters = SearchParameters::create()
+            ->withQuery($query)
+            ->withAttributesToRetrieve(['id'])
+        ;
+
+        $ids = array_column($loupe->search($searchParameters)->toArray()['hits'], 'id');
+        sort($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Functional/SynonymTest.php
+++ b/tests/Functional/SynonymTest.php
@@ -20,7 +20,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'tv' => ['television'],
             ])
@@ -48,7 +47,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title', 'tags'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'tv' => ['television'],
             ])
@@ -77,7 +75,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'tv' => ['television'],
             ])
@@ -109,7 +106,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'phone' => ['iphone'],
             ])
@@ -121,10 +117,7 @@ final class SynonymTest extends TestCase
             ['id' => 2, 'title' => 'android phone'],
         ]);
 
-        // Searching the synonym key "phone" matches both the generic phone and the iphone reached via the synonym.
         $this->assertSame([1, 2], $this->searchIds($loupe, 'phone'));
-
-        // Searching "iphone" stays specific: it only matches the iphone document, not generic phones.
         $this->assertSame([1], $this->searchIds($loupe, 'iphone'));
     }
 
@@ -160,7 +153,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'couch' => ['sofa'],
                 'sofa' => ['couch'],
@@ -181,7 +173,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withSynonyms([
                 'television' => ['tv'],
             ])
@@ -199,7 +190,6 @@ final class SynonymTest extends TestCase
     {
         $configuration = Configuration::create()
             ->withSearchableAttributes(['title'])
-            ->withSortableAttributes(['title'])
             ->withTypoTolerance(TypoTolerance::disabled())
             ->withSynonyms([
                 'phone' => ['iphone'],

--- a/tests/Functional/SynonymTest.php
+++ b/tests/Functional/SynonymTest.php
@@ -167,6 +167,27 @@ final class SynonymTest extends TestCase
         $this->assertSame([1], $this->searchIds($loupe, 'televsion'));
     }
 
+    public function testTypoToleranceDisabledStillMatchesSynonym(): void
+    {
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSortableAttributes(['title'])
+            ->withTypoTolerance(TypoTolerance::disabled())
+            ->withSynonyms([
+                'phone' => ['iphone'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'iphone 15 pro'],
+            ['id' => 2, 'title' => 'android phone'],
+        ]);
+
+        $this->assertSame([1, 2], $this->searchIds($loupe, 'phone'));
+        $this->assertSame([1], $this->searchIds($loupe, 'iphone'));
+    }
+
     /**
      * @return array<int>
      */

--- a/tests/Functional/SynonymTest.php
+++ b/tests/Functional/SynonymTest.php
@@ -128,6 +128,34 @@ final class SynonymTest extends TestCase
         $this->assertSame([1], $this->searchIds($loupe, 'iphone'));
     }
 
+    public function testReindexIsRequiredWhenSynonymsChange(): void
+    {
+        $dataDir = $this->createTemporaryDirectory();
+
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSynonyms([
+                'phone' => ['iphone'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration, $dataDir);
+        $loupe->addDocument(['id' => 1, 'title' => 'iphone 15 pro']);
+
+        $this->assertFalse($loupe->needsReindex());
+
+        $configuration = Configuration::create()
+            ->withSearchableAttributes(['title'])
+            ->withSynonyms([
+                'phone' => ['iphone', 'smartphone'],
+            ])
+        ;
+
+        $loupe = $this->createLoupe($configuration, $dataDir);
+
+        $this->assertTrue($loupe->needsReindex());
+    }
+
     public function testTwoWayMatch(): void
     {
         $configuration = Configuration::create()

--- a/tests/Functional/SynonymTest.php
+++ b/tests/Functional/SynonymTest.php
@@ -100,7 +100,7 @@ final class SynonymTest extends TestCase
         $this->assertSame('<em>television</em> set', $results['hits'][0]['_formatted']['title']);
 
         $this->assertSame(
-            [['start' => 0, 'length' => 10 ]],
+            [['start' => 0, 'length' => 10]],
             $results['hits'][0]['_matchesPosition']['title'],
         );
     }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -72,6 +72,36 @@ final class ConfigurationTest extends TestCase
             false,
         ];
 
+        yield 'Synonyms are relevant' => [
+            Configuration::create(),
+            Configuration::create()->withSynonyms([
+                'tv' => ['television'],
+            ]),
+            false,
+        ];
+
+        yield 'Differing synonyms produce differing hashes' => [
+            Configuration::create()->withSynonyms([
+                'tv' => ['television'],
+            ]),
+            Configuration::create()->withSynonyms([
+                'tv' => ['telly'],
+            ]),
+            false,
+        ];
+
+        yield 'Same synonyms in different order produce the same hash' => [
+            Configuration::create()->withSynonyms([
+                'sofa' => ['couch'],
+                'couch' => ['sofa', 'settee'],
+            ]),
+            Configuration::create()->withSynonyms([
+                'couch' => ['settee', 'sofa'],
+                'sofa' => ['couch'],
+            ]),
+            true,
+        ];
+
         yield 'Typo thresholds are irrelevant' => [
             Configuration::create(),
             Configuration::create()->withTypoTolerance(TypoTolerance::create()->withTypoThresholds([
@@ -98,10 +128,59 @@ final class ConfigurationTest extends TestCase
         yield ['invalid-dash'];
     }
 
+    /**
+     * @return iterable<array-key, array<mixed>>
+     */
+    public static function invalidSynonymProvider(): iterable
+    {
+        yield 'Multi-word key' => [['san francisco' => ['sf']]];
+        yield 'Multi-word value' => [['sf' => ['san francisco']]];
+        yield 'Empty string key' => [['' => ['x']]];
+        yield 'Empty string value' => [['x' => ['']]];
+        yield 'Non-string value in list' => [['x' => [123]]];
+        yield 'Empty value list' => [['x' => []]];
+        yield 'Non-list value' => [['x' => ['a' => 'b']]];
+    }
+
+    public function testSynonymsRoundTrip(): void
+    {
+        $synonyms = [
+            'jacket' => ['parka', 'windbreaker'],
+            'couch' => ['sofa'],
+        ];
+
+        $configuration = Configuration::create()->withSynonyms($synonyms);
+
+        $this->assertSame(
+            [
+                'couch' => ['sofa'],
+                'jacket' => ['parka', 'windbreaker'],
+            ],
+            $configuration->getSynonyms(),
+        );
+
+        $roundTripped = Configuration::fromArray($configuration->toArray());
+
+        $this->assertSame($configuration->getSynonyms(), $roundTripped->getSynonyms());
+        $this->assertSame($configuration->toArray()['synonyms'], $roundTripped->toArray()['synonyms']);
+    }
+
     #[DataProvider('indexHashProvider')]
     public function testGetIndexHash(Configuration $configurationA, Configuration $configurationB, bool $hashesShouldMatch): void
     {
         $this->assertSame($hashesShouldMatch, $configurationA->getIndexHash() === $configurationB->getIndexHash());
+    }
+
+    /**
+     * @param array<mixed> $synonyms
+     */
+    #[DataProvider('invalidSynonymProvider')]
+    public function testInvalidSynonyms(array $synonyms): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        // @phpstan-ignore-next-line intentionally invalid input
+        Configuration::create()->withSynonyms($synonyms);
     }
 
     #[DataProvider('invalidAttributeNameProvider')]

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -287,6 +287,22 @@ final class TokenizerTest extends TestCase
         $this->assertContains('tv', $tokens->allTermsWithVariants());
     }
 
+    public function testSynonymChainsOffStemVariant(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()
+                ->withLanguages(['en'])
+                ->withSynonyms([
+                    'go' => ['run'],
+                ]),
+        );
+
+        $token = $this->findToken($tokenizer->tokenize('running fast'), 'running');
+
+        $this->assertContains('run', $token->getVariants());
+        $this->assertContains('go', $token->getVariants());
+    }
+
     public function testSynonymDirectionIsOneWay(): void
     {
         $tokenizer = $this->createTokenizer(

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -10,6 +10,8 @@ use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\LanguageDetection\NitotmLanguageDetector;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
 use Loupe\Matcher\StopWords\InMemoryStopWords;
+use Loupe\Matcher\Tokenizer\Token;
+use Loupe\Matcher\Tokenizer\TokenCollection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -231,6 +233,89 @@ final class TokenizerTest extends TestCase
         $this->assertSame(['ist', 'oder', 'nicht'], $tokensWithStopWordsOnly->allTermsWithVariants());
     }
 
+    public function testSynonymsAreNormalized(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()->withSynonyms([
+                'TV' => ['Télévision'],
+            ]),
+        );
+
+        $token = $this->findToken($tokenizer->tokenize('télévision'), 'television');
+
+        $this->assertContains('tv', $token->getVariants());
+    }
+
+    public function testSynonymsAreNotAppliedToQueries(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()->withSynonyms([
+                'tv' => ['television'],
+            ]),
+        );
+
+        $this->assertSame(['television'], $tokenizer->tokenizeQuery('television')->allTermsWithVariants());
+    }
+
+    public function testSynonymsAreNotChainedRecursively(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()->withSynonyms([
+                'a' => ['b'],
+                'b' => ['c'],
+            ]),
+        );
+
+        $token = $this->findToken($tokenizer->tokenize('c'), 'c');
+
+        $this->assertContains('b', $token->getVariants());
+        $this->assertNotContains('a', $token->getVariants());
+    }
+
+    public function testSynonymsExpandDocumentTokens(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()->withSynonyms([
+                'tv' => ['television'],
+            ]),
+        );
+
+        $tokens = $tokenizer->tokenize('my television is broken');
+        $token = $this->findToken($tokens, 'television');
+
+        $this->assertContains('tv', $token->getVariants());
+        $this->assertContains('tv', $tokens->allTermsWithVariants());
+    }
+
+    public function testSynonymDirectionIsOneWay(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()->withSynonyms([
+                'tv' => ['television'],
+            ]),
+        );
+
+        $token = $this->findToken($tokenizer->tokenize('watching tv tonight'), 'tv');
+
+        $this->assertNotContains('television', $token->getVariants());
+    }
+
+    public function testSynonymsWorkWithTypoToleranceDisabled(): void
+    {
+        $tokenizer = $this->createTokenizer(
+            Configuration::create()
+                ->withLanguages(['en'])
+                ->withTypoTolerance(TypoTolerance::disabled())
+                ->withSynonyms([
+                    'tv' => ['television'],
+                ]),
+        );
+
+        $token = $this->findToken($tokenizer->tokenize('my television is broken'), 'television');
+
+        $this->assertContains('tv', $token->getVariants());
+    }
+
     /**
      * @param array<string> $languages
      * @param array<string> $expectedTokens
@@ -353,5 +438,16 @@ final class TokenizerTest extends TestCase
         ;
 
         return new Tokenizer($engine, $languageDetector);
+    }
+
+    private function findToken(TokenCollection $tokens, string $term): Token
+    {
+        foreach ($tokens->all() as $token) {
+            if ($token->getTerm() === $term) {
+                return $token;
+            }
+        }
+
+        $this->fail(\sprintf('No token with term "%s" found. Terms: %s', $term, implode(', ', $tokens->allTerms())));
     }
 }


### PR DESCRIPTION
(🥂 Cheers to 1.0! 🥂)

This adds a new feature: match documents by synonyms / aliases of the used query terms.

### Usage

Configure via `$configuration->withSynonyms()`.

 Each mapping is one-directional: the key is the query term, its values are the document terms it should also match.

 ```php
   $configuration = \Loupe\Loupe\Configuration::create()
       ->withSynonyms([
           'jacket' => ['parka', 'windbreaker'],
       ])
   ;
 ```

 Two-way synonyms need to be declared explicitly:

 ```php
   $configuration = \Loupe\Loupe\Configuration::create()
       ->withSynonyms([
           'couch' => ['sofa'],
           'sofa'  => ['couch'],

       ])
   ;
 ```

### Implementation

Synonyms are resolved at index time. During tokenization, a matching document token has the query terms added as additional token variants. The same mechanism already used for stems and prefixes.

There's no query-side cost, search latency is unaffected. The cost is a slightly larger index.

A document containing the queried term outranks one that only matches through a synonym.

### Limitations

Changing synonyms requires a reindex. The synonym map is part of the configuration hash, so `Loupe::needsReindex()` triggers after a change.

No resolution chains: `a → b` and `b → c` does not mean `a → c`. That relation must be declared explicitly.

Multi-word synonyms are not supported at this point since they throw up some more complicated questions.