### PR TITLE
Force reindex when languages change

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -231,6 +231,7 @@ final class Configuration
         $hash[] = json_encode($this->getFilterableAttributes());
         $hash[] = json_encode($this->getMaxTotalHits());
         $hash[] = json_encode($this->getSortableAttributes());
+        $hash[] = json_encode($this->getLanguages());
         $hash[] = json_encode($this->getStopWords());
 
         $hash[] = $this->getTypoTolerance()->isDisabled() ? 'disabled' : 'enabled';

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -66,6 +66,12 @@ final class ConfigurationTest extends TestCase
             false,
         ];
 
+        yield 'Languages are relevant' => [
+            Configuration::create(),
+            Configuration::create()->withLanguages(['fr', 'en']),
+            false,
+        ];
+
         yield 'Stop words are relevant' => [
             Configuration::create(),
             Configuration::create()->withStopWords(['a', 'the']),


### PR DESCRIPTION
Changing the languages should probably trigger a reindex since it influences stemming and decompounding. 