### PR TITLE
deps: bump pymdown-extensions to 10.21.3 (GHSA-62q4-447f-wv8h)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.6
-pymdown-extensions==10.21.2
+pymdown-extensions==10.21.3


### PR DESCRIPTION
Updates `pymdown-extensions` from 10.21.2 to 10.21.3 to address PYSEC-2026-2999 / GHSA-62q4-447f-wv8h (path traversal bypass regression in `pymdownx.snippets`).

Evidence:
- `docs/requirements.txt` referenced `pymdown-extensions==10.21.2`
- `osv-scanner` reported PYSEC-2026-2999 / GHSA-62q4-447f-wv8h before the update
- updated version: `10.21.3` (same major)

Validation:
- `osv-scanner` no longer reports PYSEC-2026-2999 after the update
- `pip install pymdown-extensions==10.21.3` succeeds and `pymdownx` imports cleanly

Note: `osv-scanner` still reports separate advisories for `pymdown-extensions@10.21.3`: PYSEC-2026-3609 / GHSA-9xwg-3r6f-jcx2, PYSEC-2026-3654 / GHSA-gm37-52c6-37mw. Those are fixed in 11.x, which is a major upgrade out of scope for this patch.

Scope: dependency update only, one line in `docs/requirements.txt`.
