### PR TITLE
docs: bump pymdown-extensions to 11.0.2 (GHSA-9xwg-3r6f-jcx2, GHSA-gm37-52c6-37mw)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs==1.6.1
 mkdocs-material==9.7.6
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.2


### PR DESCRIPTION
Updates pymdown-extensions in docs/requirements.txt to 11.0.2 to clear two advisories reported against the pinned 10.21.3.

Evidence:
- docs/requirements.txt pinned `pymdown-extensions==10.21.3`
- `osv-scanner` reported PYSEC-2026-3609 / GHSA-9xwg-3r6f-jcx2 (path traversal in the b64 extension, fixed in 11.0.0) and PYSEC-2026-3654 / GHSA-gm37-52c6-37mw (ReDoS in caret, tilde, betterem, fixed in 11.0.1) before the update
- updated version: `pymdown-extensions==11.0.2`

Validation:
- `osv-scanner` reports no issues for docs/requirements.txt after the update
- followed the Docs workflow steps: `python -m pip install -r docs/requirements.txt`, `python docs/prepare_docs.py`, `mkdocs build --strict -f docs/mkdocs.yml`. All pass.

Scope: docs/requirements.txt only.
