### PR TITLE
Cache the fastset dictionary data in the loupe data directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/cache": "^2.0 || ^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
-        "loupe/matcher": "^0.3.2"
+        "loupe/matcher": "^0.3.3"
     },
     "require-dev": {
         "phpbench/phpbench": "^1.2",

--- a/src/Internal/Tokenizer/Tokenizer.php
+++ b/src/Internal/Tokenizer/Tokenizer.php
@@ -142,10 +142,34 @@ class Tokenizer implements TokenizerInterface
 
         if (!isset($this->languageTokenizers[$language])) {
             $locale = Locale::fromString($language);
-            $this->languageTokenizers[$language] = LoupeMatcherTokenizer::createFromPreconfiguredLocaleConfiguration($locale);
+            $this->languageTokenizers[$language] = $this->createLanguageTokenizer($locale);
         }
 
         return $this->languageTokenizers[$language];
+    }
+
+    private function createLanguageTokenizer(Locale $locale): LoupeMatcherTokenizer
+    {
+        $dataDir = $this->engine->getDataDir();
+
+        if (null === $dataDir) {
+            return LoupeMatcherTokenizer::createFromPreconfiguredLocaleConfiguration($locale);
+        }
+
+        $lockHandle = fopen($dataDir.'/fastset.lock', 'c');
+
+        if (false === $lockHandle) {
+            throw new \RuntimeException('Could not open the FastSet cache lock file.');
+        }
+
+        try {
+            flock($lockHandle, LOCK_EX);
+
+            return LoupeMatcherTokenizer::createFromPreconfiguredLocaleConfiguration($locale, $dataDir.'/fastset');
+        } finally {
+            flock($lockHandle, LOCK_UN);
+            fclose($lockHandle);
+        }
     }
 
     private function tokenizeWithoutVariants(string $string, string|null $language, int|null $maxTokens = null): TokenCollection

--- a/tests/Unit/Internal/Tokenizer/TokenizerTest.php
+++ b/tests/Unit/Internal/Tokenizer/TokenizerTest.php
@@ -9,12 +9,25 @@ use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\LanguageDetection\NitotmLanguageDetector;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
+use Loupe\Loupe\Tests\StorageFixturesTestTrait;
 use Loupe\Matcher\StopWords\InMemoryStopWords;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class TokenizerTest extends TestCase
 {
+    use StorageFixturesTestTrait;
+
+    public function testFastSetCacheIsStoredInDataDirectory(): void
+    {
+        $dataDir = $this->createTemporaryDirectory();
+        $tokenizer = $this->createTokenizer(Configuration::create()->withLanguages(['de']), $dataDir);
+
+        $tokenizer->tokenize('Dies ist ein deutscher Satz mit einem langen zusammengesetzten Zeitungspapierwort.');
+
+        $this->assertDirectoryExists($dataDir.'/fastset/de');
+    }
+
     public function testMaximumTokens(): void
     {
         $tokenizer = $this->createTokenizer();
@@ -341,7 +354,7 @@ final class TokenizerTest extends TestCase
         ];
     }
 
-    private function createTokenizer(Configuration|null $configuration = null): Tokenizer
+    private function createTokenizer(Configuration|null $configuration = null, string|null $dataDir = null): Tokenizer
     {
         $configuration ??= Configuration::create();
         $languageDetector = new NitotmLanguageDetector($configuration->getLanguages());
@@ -350,6 +363,11 @@ final class TokenizerTest extends TestCase
         $engine
             ->method('getConfiguration')
             ->willReturn($configuration)
+        ;
+
+        $engine
+            ->method('getDataDir')
+            ->willReturn($dataDir)
         ;
 
         return new Tokenizer($engine, $languageDetector);


### PR DESCRIPTION
This should improve readonly container configuration. See https://github.com/loupe-php/matcher/issues/36