### PR TITLE
Improve term document search join order

### DIFF
--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -108,6 +108,12 @@ class IndexInfo
         );
     }
 
+    public static function getPrimaryKeyIndexName(string $tableName): string
+    {
+        // SQLite exposes the implicit index for our composite primary keys using this generated name.
+        return 'sqlite_autoindex_'.$tableName.'_1';
+    }
+
     /**
      * @param array<string, mixed> $document
      */

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -652,7 +652,7 @@ class Searcher
             $cteSelectQb->from(\sprintf(
                 '%s %s'
                 .' CROSS JOIN %s'
-                .' CROSS JOIN %s %s INDEXED BY sqlite_autoindex_terms_documents_1'
+                .' CROSS JOIN %s %s INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS)
                 .' ON %s.id = %s.term'
                 .' AND %s.document = %s.document'
                 .' AND %s.attribute = %s.attribute'
@@ -672,14 +672,7 @@ class Searcher
                 $previousPhraseAlias,
             ));
         } else {
-            // Join from term_matches CTE — not from terms_documents - to force primary key usage
-            $cteSelectQb->from($termMatchesCTE);
-            $cteSelectQb->innerJoin(
-                $termMatchesCTE,
-                IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
-                $termsDocumentsAlias.' INDEXED BY sqlite_autoindex_terms_documents_1',
-                \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias),
-            );
+            $this->addTermDocumentsJoin($cteSelectQb, $termMatchesCTE, $termsDocumentsAlias);
         }
 
         // Restrict to shared candidate documents only for real multi-token queries.
@@ -728,6 +721,32 @@ class Searcher
             [],
             $materialized,
         ));
+    }
+
+    private function addTermDocumentsJoin(QueryBuilder $queryBuilder, string $termMatchesCTE, string $termsDocumentsAlias): void
+    {
+        if (['*'] !== $this->queryParameters->getAttributesToSearchOn()) {
+            // Pin the join order so SQLite does not scan every term occurrence before applying the attribute filter.
+            $queryBuilder->from(\sprintf(
+                '%s CROSS JOIN %s %s INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS).' ON %s.id = %s.term',
+                $termMatchesCTE,
+                IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+                $termsDocumentsAlias,
+                $termMatchesCTE,
+                $termsDocumentsAlias,
+            ));
+
+            return;
+        }
+
+        // Join from term_matches CTE — not from terms_documents — while allowing SQLite to optimize the join order.
+        $queryBuilder->from($termMatchesCTE);
+        $queryBuilder->innerJoin(
+            $termMatchesCTE,
+            IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+            $termsDocumentsAlias.' INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS),
+            \sprintf('%s.id = %s.term', $termMatchesCTE, $termsDocumentsAlias),
+        );
     }
 
     private function addTermDocumentMatchesCTEs(TokenCollection $tokenCollection): void


### PR DESCRIPTION
This change specifically optimizes searches using `attributesToSearchOn` which currently take 2s+ in our benchmarks.
SQLite was reordering the existing `INNER JOIN` and scanning the complete `terms_documents` occurrence index before applying the attribute restriction. `INDEXED BY` selected the primary index but did not control the join order.
For attribute-restricted searches, using `CROSS JOIN` pins the small term-match CTE as the outer relation. SQLite then performs targeted `term = ?` lookups using the existing `(term, document, position)` primary-key index instead of scanning every term occurrence.

The standout improvement is clearly the handling of attribute queries:

`benchSingleQueryOnAttributes`: 2.29 seconds → 3.54 ms, roughly a 646× speedup.
`benchMultiQueryOnAttributes`: 510 ms → 10.52 ms, roughly a 48× speedup.

So basically back to normal, I would say because 2.3s aren't really acceptable 😊 🚀 