### PR TITLE
Improve total hit counting for row-preserving searches

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -104,6 +104,8 @@ class Searcher
 
     private Sorting $sorting;
 
+    private bool $fullResultCountRequired = false;
+
     /**
      * @param T $queryParameters
      */
@@ -243,6 +245,11 @@ class Searcher
         ];
 
         $this->queryBuilder->addOrderBy($sort, $order);
+    }
+
+    public function markFullResultCountRequired(): void
+    {
+        $this->fullResultCountRequired = true;
     }
 
     public function bindQueryParameter(mixed $value, mixed $type = ParameterType::STRING, string|null $parameterName = null): string
@@ -884,6 +891,8 @@ class Searcher
         if (null === $distinct) {
             return;
         }
+
+        $this->markFullResultCountRequired();
 
         if (!\in_array($distinct, $this->engine->getIndexInfo()->getSingleFilterableAttributes(), true)) {
             throw InvalidSearchParametersException::distinctAttributeMustBeASingleFilterableAttribute();
@@ -1620,6 +1629,8 @@ class Searcher
                     continue;
                 }
 
+                $this->markFullResultCountRequired();
+
                 $this->queryBuilder->addSelect($cteName.'.distance AS '.self::DISTANCE_ALIAS.'_'.$attribute);
                 $this->queryBuilder
                     ->innerJoin(
@@ -1659,14 +1670,17 @@ class Searcher
 
     private function selectTotalHits(): void
     {
-        // Only apply max total hits to search queries
+        // COUNT() OVER() makes SQLite process the complete sorted result before LIMIT can apply. If the query preserves
+        // the match count, count the materialized matches directly instead.
+        $count = $this->fullResultCountRequired
+            ? 'COUNT() OVER()'
+            : \sprintf('(SELECT COUNT(*) FROM %s)', self::CTE_MATCHES);
+
         if ($this->queryParameters instanceof SearchParameters) {
-            $select = \sprintf('MIN(%d, COUNT() OVER()) AS totalHits', $this->engine->getConfiguration()->getMaxTotalHits());
-        } else {
-            $select = 'COUNT() OVER() AS totalHits';
+            $count = \sprintf('MIN(%d, %s)', $this->engine->getConfiguration()->getMaxTotalHits(), $count);
         }
 
-        $this->queryBuilder->addSelect($select);
+        $this->queryBuilder->addSelect($count.' AS totalHits');
     }
 
     private function sortDocuments(): void

--- a/src/Internal/Search/Sorting.php
+++ b/src/Internal/Search/Sorting.php
@@ -33,6 +33,10 @@ class Sorting
     {
         foreach ($this->sorters as $sorter) {
             $sorter->apply($searcher, $this->engine);
+
+            if ($sorter->requiresFullResultCount($searcher->getQueryParameters())) {
+                $searcher->markFullResultCountRequired();
+            }
         }
     }
 

--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -28,6 +28,11 @@ abstract class AbstractSorter
         return $this->id;
     }
 
+    public function requiresFullResultCount(AbstractQueryParameters $queryParameters): bool
+    {
+        return true;
+    }
+
     public function setId(int $id): self
     {
         $this->id = $id;

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -164,6 +164,12 @@ class Relevance extends AbstractSorter
         return new self($direction);
     }
 
+    public function requiresFullResultCount(AbstractQueryParameters $queryParameters): bool
+    {
+        return $queryParameters instanceof SearchParameters
+            && $queryParameters->getRankingScoreThreshold() > 0;
+    }
+
     public static function supports(string $value, Engine $engine): bool
     {
         return Searcher::RELEVANCE_ALIAS === $value;

--- a/src/Internal/Search/Sorting/SingleAttribute.php
+++ b/src/Internal/Search/Sorting/SingleAttribute.php
@@ -68,6 +68,11 @@ class SingleAttribute extends AbstractSorter
         return new self($value, $direction);
     }
 
+    public function requiresFullResultCount(AbstractQueryParameters $queryParameters): bool
+    {
+        return false;
+    }
+
     public static function supports(string $value, Engine $engine): bool
     {
         // We support if it's configured sortable


### PR DESCRIPTION
Avoid using `COUNT() OVER()` when the final query preserves the number of rows in `_cte_matches`.

`COUNT() OVER()` forces SQLite to process the complete sorted result before applying the result limit. For row-preserving searches, this PR instead counts the already-materialized `_cte_matches` CTE using a scalar subquery.

Queries that can change the final result count continue using `COUNT() OVER()`, including:

- distinct searches
- ranking-score thresholds
- multi-value sorting
- geo sorting and geo-distance selection

Relevance sorting in either direction, single-attribute sorting, unsorted searches and browse queries can use the optimized count.

## Benchmarks

Compared with `main`, using `composer bench`:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| Multi-word queries | 99.59 ms | 92.45 ms | -7.2% |
| Plain query | 5.15 ms | 4.07 ms | -21.0% |
| Single-word queries | 25.24 ms | 21.29 ms | -15.6% |
| Typo query with facets | 6.48 ms | 6.24 ms | -3.7% |
