### PR TITLE
Preserve phrase query count performance

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -1672,7 +1672,7 @@ class Searcher
     {
         // COUNT() OVER() makes SQLite process the complete sorted result before LIMIT can apply. If the query preserves
         // the match count, count the materialized matches directly instead.
-        $count = $this->fullResultCountRequired
+        $count = $this->shouldUseWindowForTotalHits()
             ? 'COUNT() OVER()'
             : \sprintf('(SELECT COUNT(*) FROM %s)', self::CTE_MATCHES);
 
@@ -1681,6 +1681,23 @@ class Searcher
         }
 
         $this->queryBuilder->addSelect($count.' AS totalHits');
+    }
+
+    private function shouldUseWindowForTotalHits(): bool
+    {
+        if ($this->fullResultCountRequired) {
+            return true;
+        }
+
+        // Phrase queries already produce a small materialized match set, which is cheaper to count in the result window
+        // than to scan again in a scalar subquery.
+        foreach ($this->getSearchTokens()->all() as $token) {
+            if ($token->isPartOfPhrase()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function sortDocuments(): void


### PR DESCRIPTION
Use `COUNT() OVER()` for phrase queries while retaining the faster scalar match count for other row-preserving searches.

The scalar subquery introduced on `main` allows SQLite to apply `LIMIT` earlier for ordinary searches. Phrase queries are different: they already produce a small materialized match set, so scanning that CTE again in a scalar subquery is slower than counting the result window directly.

Queries requiring the complete transformed result count continue to use `COUNT() OVER()` as before.

Compared with `main` using `composer bench`:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Phrase group queries | 21.88 ms | 20.86 ms | -4.7% |