### PR TITLE
Optimize unique term match CTEs

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -843,30 +843,44 @@ class Searcher
             }
         }
 
+        $this->addCTE($this->createTermMatchesCte($token, $selects));
+    }
+
+    /**
+     * @param list<string> $selects
+     */
+    private function createTermMatchesCte(Token $token, array $selects): Cte
+    {
         // Precompute per-term typos + is_exact_term so _cte_term_document_matches_N can join this tiny CTE instead of the big `terms` table
         $queryTermParam = $this->bindQueryParameter($token->getTerm());
         $firstCharDouble = $this->engine->getConfiguration()->getTypoTolerance()->firstCharTypoCountsDouble() ? 'true' : 'false';
         $unionSql = implode(' UNION ALL ', $selects);
+        $mayContainDuplicates = \count($selects) > 1;
+
+        $typos = \sprintf('loupe_levensthein(inner_terms.term, %s, %s)', $queryTermParam, $firstCharDouble);
+        $isExactTerm = \sprintf('CASE WHEN inner_terms.term = %s THEN 1 ELSE 0 END', $queryTermParam);
+        if ($mayContainDuplicates) {
+            $typos = 'MIN('.$typos.')';
+            $isExactTerm = 'MAX('.$isExactTerm.')';
+        }
 
         $cteSelectQb = $this->engine->getConnection()->createQueryBuilder();
         $cteSelectQb->select('inner_terms.id AS id');
-        $cteSelectQb->addSelect(\sprintf(
-            'MIN(loupe_levensthein(inner_terms.term, %s, %s)) AS typos',
-            $queryTermParam,
-            $firstCharDouble,
-        ));
-        $cteSelectQb->addSelect(\sprintf(
-            'MAX(CASE WHEN inner_terms.term = %s THEN 1 ELSE 0 END) AS is_exact_term',
-            $queryTermParam,
-        ));
+        $cteSelectQb->addSelect($typos.' AS typos');
+        $cteSelectQb->addSelect($isExactTerm.' AS is_exact_term');
         $cteSelectQb->from('('.$unionSql.')', 'inner_terms');
-        $cteSelectQb->groupBy('inner_terms.id');
+        if ($mayContainDuplicates) {
+            $cteSelectQb->groupBy('inner_terms.id');
+        }
 
-        $this->addCTE(new Cte(
+        return new Cte(
             $this->getCTENameForToken(self::CTE_TERM_MATCHES_PREFIX, $token),
             ['id', 'typos', 'is_exact_term'],
             $cteSelectQb,
-        ));
+            [],
+            // Aggregation already materializes multiple inputs. Keep the same evaluation boundary for one unique input.
+            $mayContainDuplicates ? null : true,
+        );
     }
 
     private function addTermMatchesCTEs(TokenCollection $tokenCollection): void


### PR DESCRIPTION
Avoid unnecessary aggregation when a term-match CTE contains only one input query.

A single input already returns unique term IDs, so applying `MIN()`, `MAX()` and `GROUP BY` cannot change the result but forces SQLite to create a temporary B-tree.

The CTE remains explicitly materialized. Without that boundary, SQLite may inline it and repeatedly evaluate the term-matching functions, which is slower.

When multiple exact, typo, variant or prefix queries are combined, duplicate term IDs remain possible and the existing aggregation is preserved.

## Performance

Compared with `main` using fresh `composer bench` runs:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Negated-term queries | 12.85 ms | 11.92 ms | -7.2% |
| Typo query with facets | 6.81 ms | 6.43 ms | -5.6% |
| Multi-word queries | 94.48 ms | 90.02 ms | -4.7% |
| Phrase group queries | 20.62 ms | 19.96 ms | -3.2% |
| Plain query | 4.41 ms | 4.27 ms | -3.2% |

Queries with multiple tokens benefit because non-final terms commonly have only one term-match input. Single-word queries generally retain multiple exact, typo and prefix inputs and therefore continue using aggregation.

All other benchmarks remain effectively unchanged.