### PR TITLE
Optimize relevance processing

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -432,6 +432,10 @@ class Engine
 
     private function wrapSQLiteMethodForCache(string $prefix, callable $callback): \Closure
     {
+        if ('loupe_relevance' === $prefix) {
+            return $this->wrapRelevanceForCache($callback);
+        }
+
         return function () use ($prefix, $callback) {
             $args = \func_get_args();
             $cacheKey = $prefix.':'.implode('--', $args);
@@ -442,6 +446,21 @@ class Engine
             }
 
             return $this->cache[$cacheKey] = $callback(...$args);
+        };
+    }
+
+    private function wrapRelevanceForCache(callable $callback): \Closure
+    {
+        // The configuration is immutable for an Engine instance, so only the per-document positions vary.
+        return function (string $searchableAttributes, string $rankingRules, string $termPositions) use ($callback): float {
+            $cacheKey = 'loupe_relevance:'.$termPositions;
+            $cachedValue = $this->cache[$cacheKey] ?? null;
+
+            if (null !== $cachedValue) {
+                return $cachedValue;
+            }
+
+            return $this->cache[$cacheKey] = $callback($searchableAttributes, $rankingRules, $termPositions);
         };
     }
 }

--- a/src/Internal/Search/Ranking/TermPositions.php
+++ b/src/Internal/Search/Ranking/TermPositions.php
@@ -67,7 +67,9 @@ class TermPositions
         }
 
         foreach (explode(';', $positionsInDocumentPerTerm) as $termSearchedFor) {
-            [$positionsForTerm, $hasExactMatch] = array_pad(explode('|', $termSearchedFor, 2), 2, null);
+            $termParts = explode('|', $termSearchedFor, 2);
+            $positionsForTerm = $termParts[0];
+            $hasExactMatch = $termParts[1] ?? null;
 
             // Document did not match this term
             if ('0' === $positionsForTerm) {
@@ -80,8 +82,12 @@ class TermPositions
             $shouldInferExactMatch = null === $hasExactMatch;
             $hasExactMatch = '1' === $hasExactMatch;
 
-            foreach (explode(',', $positionsForTerm ?? '0') as $positionAttributeCombination) {
-                [$position, $attribute, $numberOfTypos, $foldingMismatch] = array_pad(explode(':', $positionAttributeCombination, 4), 4, '0');
+            foreach (explode(',', $positionsForTerm) as $positionAttributeCombination) {
+                $positionParts = explode(':', $positionAttributeCombination, 4);
+                $position = $positionParts[0];
+                $attribute = $positionParts[1];
+                $numberOfTypos = $positionParts[2] ?? '0';
+                $foldingMismatch = $positionParts[3] ?? '0';
                 $attributePositions[$attribute][] = new Position((int) $position, (int) $numberOfTypos);
                 if ($shouldInferExactMatch) {
                     $hasExactMatch = $hasExactMatch || (0 === (int) $numberOfTypos && '0' === $foldingMismatch);


### PR DESCRIPTION
Optimize relevance calculation by reducing work in two hot paths:

- Relevance cache keys now contain only the per-document term-position payload. Searchable attributes and ranking rules are immutable for the lifetime of an engine, so including them in every cache key was redundant.
- Term-position parsing avoids repeated `array_pad()` allocations for every term and occurrence.

Compared with `main`, averaging two fresh `composer bench` runs per branch:

| Benchmark | Main | This branch | Change |
|---|---:|---:|---:|
| Multi-word queries | 91.31 ms | 90.21 ms | -1.2% |
| Single-word queries | 22.83 ms | 22.14 ms | -3.0% |
| Typo query with facets | 6.72 ms | 6.46 ms | -3.9% |