### PR TITLE
ci: update checkout and setup-python to current majors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,10 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v7
               with:
                   python-version: "3.12"
                   cache: pip

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,7 +26,7 @@ jobs:
                   coverage: none
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v7
 
             - name: Install lowest supported SQLite version "${{ matrix.sqlite }}"
               if: ${{ matrix.sqlite == '3.16.0' }}


### PR DESCRIPTION
Updates the GitHub-maintained actions in tests.yaml and docs.yml.

Changes:
- actions/checkout v3 -> v7 (tests.yaml)
- actions/checkout v4 -> v7, actions/setup-python v5 -> v7 (docs.yml)

setup-python v7 drops the pip-install input, which these workflows do not use. The python 3.12 and pip cache inputs are unchanged. peaceiris/actions-gh-pages stays pinned by commit, and code-quality.yml keeps its reusable workflow reference.

Validation:
- YAML parse of both workflows passes
- checkout v7.0.1 and setup-python v7.0.0 exist on the actions org releases

Scope: .github/workflows/tests.yaml and .github/workflows/docs.yml only.