### PR TITLE
Optimize SQLite cache by operation

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -25,6 +25,7 @@ use Loupe\Loupe\Internal\StateSetIndex\DefaultStateSetIndex;
 use Loupe\Loupe\Internal\StateSetIndex\StateSet;
 use Loupe\Loupe\Internal\StateSetIndex\StateSetIndexInterface;
 use Loupe\Loupe\Internal\Tokenizer\Tokenizer;
+use Loupe\Loupe\LoupeFactory;
 use Loupe\Loupe\SearchParameters;
 use Loupe\Loupe\SearchResult;
 use Loupe\Matcher\Formatter;
@@ -113,13 +114,11 @@ class Engine
             return $this;
         }
 
-        $this->ticketHandler->claimTicket();
-
-        try {
-            $this->indexer->addDocuments($documents);
-        } finally {
-            $this->ticketHandler->release();
-        }
+        $this->executeIndexOperation(
+            function () use ($documents): void {
+                $this->indexer->addDocuments($documents);
+            },
+        );
 
         return $this;
     }
@@ -160,13 +159,11 @@ class Engine
 
     public function deleteAllDocuments(): self
     {
-        $this->ticketHandler->claimTicket();
-
-        try {
-            $this->indexer->deleteAllDocuments();
-        } finally {
-            $this->ticketHandler->release();
-        }
+        $this->executeIndexOperation(
+            function (): void {
+                $this->indexer->deleteAllDocuments();
+            },
+        );
 
         return $this;
     }
@@ -176,13 +173,11 @@ class Engine
      */
     public function deleteDocuments(array $ids): self
     {
-        $this->ticketHandler->claimTicket();
-
-        try {
-            $this->indexer->deleteDocuments($ids);
-        } finally {
-            $this->ticketHandler->release();
-        }
+        $this->executeIndexOperation(
+            function () use ($ids): void {
+                $this->indexer->deleteDocuments($ids);
+            },
+        );
 
         return $this;
     }
@@ -364,6 +359,23 @@ class Engine
             ->executeQuery('SELECT (SELECT page_count FROM pragma_page_count) * (SELECT page_size FROM pragma_page_size)')
             ->fetchOne()
         ;
+    }
+
+    private function executeIndexOperation(callable $operation): void
+    {
+        $this->ticketHandler->claimTicket();
+
+        try {
+            $this->getConnection()->executeStatement('PRAGMA cache_size = -'.LoupeFactory::SQLITE_INDEX_CACHE_SIZE);
+            $this->getConnection()->executeStatement('PRAGMA shrink_memory');
+            $operation();
+        } finally {
+            try {
+                $this->getConnection()->executeStatement('PRAGMA cache_size = -'.LoupeFactory::SQLITE_SEARCH_CACHE_SIZE);
+            } finally {
+                $this->ticketHandler->release();
+            }
+        }
     }
 
     private function maybeWrapStateSetIndexWithCache(): void

--- a/src/LoupeFactory.php
+++ b/src/LoupeFactory.php
@@ -20,6 +20,10 @@ final class LoupeFactory implements LoupeFactoryInterface
 {
     public const SQLITE_BUSY_TIMEOUT = 5000;
 
+    public const SQLITE_INDEX_CACHE_SIZE = 4000;
+
+    public const SQLITE_SEARCH_CACHE_SIZE = 32000;
+
     public function create(string $dataDir, Configuration $configuration): Loupe
     {
         if ('' === $dataDir) {
@@ -113,8 +117,8 @@ final class LoupeFactory implements LoupeFactoryInterface
     private function optimizeSQLiteConnection(Connection $connection): void
     {
         $optimizations = [
-            // Set cache size to 20MB to reduce disk i/o
-            'PRAGMA cache_size = -20000',
+            // Set cache size to 32MB to reduce disk i/o while searching
+            'PRAGMA cache_size = -'.self::SQLITE_SEARCH_CACHE_SIZE,
             // Set mmap size to 32MB to avoid i/o for database reads
             'PRAGMA mmap_size = 33554432',
             // Store temporary tables in memory instead of on disk

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -559,6 +559,48 @@ final class IndexTest extends TestCase
         $this->assertNotCount(0, $logger->getRecords());
     }
 
+    public function testSQLiteCacheIsAdjustedWhileIndexing(): void
+    {
+        $logger = new InMemoryLogger();
+        $loupe = $this->createLoupe(Configuration::create()->withLogger($logger));
+
+        $loupe->addDocument(self::getSandraDocument());
+
+        $cacheStatements = array_values($this->getLoggedStatements($logger, 'PRAGMA cache_size'));
+        $this->assertSame(
+            ['PRAGMA cache_size = -4000', 'PRAGMA cache_size = -32000'],
+            \array_slice($cacheStatements, -2),
+        );
+        $this->assertCount(1, $this->getLoggedStatements($logger, 'PRAGMA shrink_memory'));
+    }
+
+    public function testSQLiteSearchCacheIsRestoredWhenIndexingFails(): void
+    {
+        $logger = new InMemoryLogger();
+        $configuration = Configuration::create()
+            ->withFilterableAttributes(['departments', 'gender'])
+            ->withSortableAttributes(['firstname'])
+            ->withLogger($logger)
+        ;
+        $loupe = $this->createLoupe($configuration);
+
+        try {
+            $loupe->addDocuments([
+                self::getSandraDocument(),
+                array_merge(self::getUtaDocument(), ['departments' => [1, 3, 8]]),
+            ]);
+            $this->fail('Indexing should have failed.');
+        } catch (InvalidDocumentException) {
+            // Cache restoration is asserted below.
+        }
+
+        $cacheStatements = array_values($this->getLoggedStatements($logger, 'PRAGMA cache_size'));
+        $this->assertSame(
+            ['PRAGMA cache_size = -4000', 'PRAGMA cache_size = -32000'],
+            \array_slice($cacheStatements, -2),
+        );
+    }
+
     public function testNullValueIsIrrelevantForDocumentSchema(): void
     {
         $configuration = Configuration::create()


### PR DESCRIPTION
`main` uses a 32 MiB page-cache budget during indexing. This PR lowers the configured indexing ceiling by 28 MiB, or
87.5%, without reducing the cache available to searches. The configured reduction is not a promise of 28 MiB lower
RSS because SQLite allocates pages on demand.

The indexing benchmarks did not show a material throughput regression at 4 MiB. Search performance remains on the
existing 32 MiB setting - lowering search to 4 MiB too did not work out because searches were faster with 32 MiB.