### PR TITLE
Add streaming document sources

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -17,15 +17,18 @@ Or you can index multiple documents:
 
 ```php
 $loupe->addDocuments([
-    'id' => 11,
-    'title' => 'Star Wars',
-    'overview' => 'Princess Leia is captured and held hostage by the evil Imperial forces …',
-    'genres' => ['Adventure', 'Action', 'Science Fiction']
-], [
-    'id' => 12,
-    'title' => 'Finding Nemo',
-    'overview' => 'Nemo, an adventurous young clownfish, …',
-    'genres' => ['Animation', 'Family']
+    [
+        'id' => 11,
+        'title' => 'Star Wars',
+        'overview' => 'Princess Leia is captured and held hostage by the evil Imperial forces …',
+        'genres' => ['Adventure', 'Action', 'Science Fiction']
+    ],
+    [
+        'id' => 12,
+        'title' => 'Finding Nemo',
+        'overview' => 'Nemo, an adventurous young clownfish, …',
+        'genres' => ['Animation', 'Family']
+    ]
 ]);
 ```
 
@@ -35,6 +38,68 @@ which only have to happen once after all the documents are added. So it is more 
 instead of calling `addDocument()` multiple times.
 
 Both of the methods might throw exceptions in case of invalid data (e.g. documents not matching the schema).
+
+### Streaming large JSON files
+
+Passing an array to `addDocuments()` requires the complete dataset to be held in PHP memory. For large JSON files,
+you can instead pass a `DocumentSource`. Loupe validates the complete source first and indexes it in a second pass,
+so the factory must return a **new iterable every time it is called**. This preserves the all-or-nothing validation
+behavior without materializing all documents at once.
+
+Loupe does not depend on a JSON streaming library. The following examples show how to integrate two popular options.
+Each yielded document must be decoded as an associative array.
+
+#### JSON Machine
+
+Install [JSON Machine] with Composer:
+
+```console
+composer require halaxa/json-machine
+```
+
+Configure its decoder to return associative arrays and create a new iterator inside the factory:
+
+```php
+use JsonMachine\Items;
+use JsonMachine\JsonDecoder\ExtJsonDecoder;
+use Loupe\Loupe\Indexing\DocumentSource;
+
+$documents = DocumentSource::fromFactory(
+    static fn (): iterable => Items::fromFile('/path/to/movies.json', [
+        'decoder' => new ExtJsonDecoder(true),
+    ]),
+);
+
+$loupe->addDocuments($documents);
+```
+
+If the documents are nested below a property such as `results`, add `'pointer' => '/results'` to the options passed
+to `Items::fromFile()`.
+
+#### Cerbero JSON Parser
+
+Install [Cerbero JSON Parser] with Composer:
+
+```console
+composer require cerbero/json-parser
+```
+
+The parser decodes JSON objects as associative arrays by default. Instantiate it inside the factory so each Loupe
+pass starts from the beginning of the file:
+
+```php
+use Cerbero\JsonParser\JsonParser;
+use Loupe\Loupe\Indexing\DocumentSource;
+
+$documents = DocumentSource::fromFactory(
+    static fn (): iterable => new JsonParser('/path/to/movies.json'),
+);
+
+$loupe->addDocuments($documents);
+```
+
+Do not create either parser before the factory and return the same instance from it. Streaming iterators are usually
+one-shot, while `DocumentSource` deliberately requires a fresh traversal for validation and indexing.
 
 ## Removing documents
 
@@ -65,3 +130,5 @@ $loupe->deleteAllDocuments();
 For schema related logic, read [the dedicated schema docs][Schema].
 
 [Schema]: schema.md
+[Cerbero JSON Parser]: https://github.com/cerbero90/json-parser
+[JSON Machine]: https://github.com/halaxa/json-machine

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -217,8 +217,10 @@ foreach ($thousandsOfQueries as $query) {
 }
 ```
 
-The same also applies when indexing documents. Do not pass 20.000 documents to `$loupe->addDocuments()` if memory is
-relevant. Try splitting them in smaller chunks and measure your process.
+When indexing a large dataset, avoid materializing all documents in one PHP array. Use a repeatable
+[`DocumentSource`](indexing.md#streaming-large-json-files) to stream them while retaining complete validation before
+anything is written. If the producer cannot be traversed twice, split the documents into smaller arrays and measure
+your process.
 
 > Hint: Do not measure using memory_get_usage(true), Blackfire, Tideways or any other PHP profiler. You will miss out on
 > all the allocations that are NOT created by PHP/your code. You won't see what SQLite itself is using so monitor your

--- a/src/Indexing/DocumentSource.php
+++ b/src/Indexing/DocumentSource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Indexing;
+
+final class DocumentSource implements DocumentSourceInterface
+{
+    /**
+     * @param \Closure(): iterable<int|string, array<string, mixed>> $factory
+     */
+    private function __construct(private readonly \Closure $factory)
+    {
+    }
+
+    /**
+     * @param callable(): iterable<int|string, array<string, mixed>> $factory
+     */
+    public static function fromFactory(callable $factory): self
+    {
+        return new self($factory(...));
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from ($this->factory)();
+    }
+}

--- a/src/Indexing/DocumentSourceInterface.php
+++ b/src/Indexing/DocumentSourceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Indexing;
+
+/**
+ * @extends \IteratorAggregate<int|string, array<string, mixed>>
+ */
+interface DocumentSourceInterface extends \IteratorAggregate
+{
+    /**
+     * A document source must return a fresh iterator on every invocation.
+     *
+     * @return \Traversable<int|string, array<string, mixed>>
+     */
+    public function getIterator(): \Traversable;
+}

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -11,6 +11,7 @@ use Loupe\Loupe\BrowseParameters;
 use Loupe\Loupe\BrowseResult;
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidDocumentException;
+use Loupe\Loupe\Indexing\DocumentSourceInterface;
 use Loupe\Loupe\Internal\Cache\NamespacedCachePool;
 use Loupe\Loupe\Internal\Filter\Parser;
 use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserterFactory;
@@ -104,13 +105,13 @@ class Engine
     }
 
     /**
-     * @param array<array<string, mixed>> $documents
+     * @param array<array<string, mixed>>|DocumentSourceInterface $documents
      *
      * @throws InvalidDocumentException
      */
-    public function addDocuments(array $documents): self
+    public function addDocuments(DocumentSourceInterface|array $documents): self
     {
-        if ([] === $documents) {
+        if (\is_array($documents) && [] === $documents) {
             return $this;
         }
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -6,6 +6,7 @@ namespace Loupe\Loupe\Internal\Index;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Loupe\Loupe\Exception\IndexException;
+use Loupe\Loupe\Indexing\DocumentSourceInterface;
 use Loupe\Loupe\Internal\Engine;
 use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpsertConfig;
 use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserter;
@@ -33,6 +34,8 @@ class Indexer
      */
     private const MAX_TERMS_PER_BATCH = 16000;
 
+    private const SOURCE_HASH_BATCH_SIZE = 1000;
+
     /**
      * @var array<int, callable>
      */
@@ -52,79 +55,17 @@ class Indexer
     }
 
     /**
-     * @param non-empty-array<array<string, mixed>> $documents
+     * @param non-empty-array<array<string, mixed>>|DocumentSourceInterface $documents
      */
-    public function addDocuments(array $documents): void
+    public function addDocuments(DocumentSourceInterface|array $documents): void
     {
-        $firstDocument = reset($documents);
+        if ($documents instanceof DocumentSourceInterface) {
+            $this->addDocumentsFromSource($documents);
 
-        // Prepare setup if needed
-        if ($this->engine->getIndexInfo()->needsSetup()) {
-            $this->engine->getIndexInfo()->setup($firstDocument);
+            return;
         }
 
-        // Migrate the data if needed
-        if ($this->engine->needsReindex()) {
-            $this->migrateDatabase($firstDocument);
-        }
-
-        // Fix, validate and record schema updates if needed
-        foreach ($documents as $document) {
-            $this->engine->getIndexInfo()->fixAndValidateDocument($document);
-        }
-
-        // Pre-load existing content hashes so unchanged documents can skip tokenization
-        $this->existingHashes = $this->loadExistingHashes($documents);
-
-        $processBatch = function (PreparedDocumentCollection $preparedDocuments): void {
-            if ($preparedDocuments->empty()) {
-                return;
-            }
-
-            $this->recordChange(
-                function () use ($preparedDocuments): void {
-                    $prepared = $this->bulkInsertDocuments($preparedDocuments);
-                    $this->removeCurrentDocumentData($prepared);
-                    $this->bulkInsertMultiAttributes($prepared);
-                    $this->bulkInsertTerms($prepared);
-                },
-            );
-
-            $this->commitChanges();
-        };
-
-        // Now index the documents in chunks as preparing too many documents and keeping it all in memory before
-        // inserting would result in too much memory usage.
-        while (!empty($documents)) {
-            $preparedDocuments = new PreparedDocumentCollection();
-
-            foreach ($documents as $k => $document) {
-                $preparedDocument = $this->prepareDocument($document);
-                $userId = $preparedDocument->getUserId();
-                unset($documents[$k]);
-
-                // Do not add unchanged documents to the batch: they only contain the base columns and violate NOT NULL constraints
-                if (isset($this->existingHashes[$userId]) && $this->existingHashes[$userId] === $preparedDocument->getContentHash()) {
-                    continue;
-                }
-
-                $preparedDocuments->add($preparedDocument);
-
-                if ($preparedDocuments->getTermsCount() >= self::MAX_TERMS_PER_BATCH) {
-                    break;
-                }
-            }
-
-            $processBatch($preparedDocuments);
-        }
-
-        // Finally, revise storage once
-        $this->recordChange(
-            function (): void {
-                $this->reviseStorage(false);
-            },
-        );
-        $this->commitChanges();
+        $this->addDocumentsFromArray($documents);
     }
 
     public function deleteAllDocuments(): void
@@ -179,6 +120,176 @@ class Indexer
     public function recordChange(callable $change): void
     {
         $this->changes[] = $change;
+    }
+
+    /**
+     * @param non-empty-array<array<string, mixed>> $documents
+     */
+    private function addDocumentsFromArray(array $documents): void
+    {
+        $this->prepareIndex(reset($documents));
+
+        foreach ($documents as $document) {
+            $this->engine->getIndexInfo()->fixAndValidateDocument($document);
+        }
+
+        // Pre-load existing content hashes so unchanged documents can skip tokenization
+        $this->existingHashes = $this->loadExistingHashes($documents);
+        $this->indexPreparedDocuments($this->prepareDocumentArray($documents));
+        $this->reviseStorageAfterIndexing();
+    }
+
+    private function addDocumentsFromSource(DocumentSourceInterface $documents): void
+    {
+        if (!$this->validateDocumentSource($documents)) {
+            return;
+        }
+
+        $this->indexPreparedDocuments($this->prepareDocumentSource($documents));
+        $this->reviseStorageAfterIndexing();
+    }
+
+    /**
+     * @param array<string, mixed> $firstDocument
+     */
+    private function prepareIndex(array $firstDocument): void
+    {
+        // Prepare setup if needed
+        if ($this->engine->getIndexInfo()->needsSetup()) {
+            $this->engine->getIndexInfo()->setup($firstDocument);
+        }
+
+        // Migrate the data if needed
+        if ($this->engine->needsReindex()) {
+            $this->migrateDatabase($firstDocument);
+        }
+    }
+
+    private function validateDocumentSource(DocumentSourceInterface $documents): bool
+    {
+        $hasDocuments = false;
+
+        foreach ($documents as $document) {
+            if (!$hasDocuments) {
+                $this->prepareIndex($document);
+                $hasDocuments = true;
+            }
+
+            $this->engine->getIndexInfo()->fixAndValidateDocument($document);
+        }
+
+        return $hasDocuments;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $documents
+     *
+     * @return \Generator<PreparedDocument>
+     */
+    private function prepareDocumentArray(array $documents): \Generator
+    {
+        foreach ($documents as $key => $document) {
+            unset($documents[$key]);
+            $preparedDocument = $this->prepareDocument($document);
+
+            if ($this->documentChanged($preparedDocument)) {
+                yield $preparedDocument;
+            }
+        }
+    }
+
+    /**
+     * @return \Generator<PreparedDocument>
+     */
+    private function prepareDocumentSource(DocumentSourceInterface $documents): \Generator
+    {
+        $batch = [];
+
+        foreach ($documents as $document) {
+            $this->engine->getIndexInfo()->fixAndValidateDocument($document);
+            $batch[] = $document;
+
+            if (\count($batch) >= self::SOURCE_HASH_BATCH_SIZE) {
+                yield from $this->prepareDocumentBatch($batch);
+                $batch = [];
+            }
+        }
+
+        if ([] !== $batch) {
+            yield from $this->prepareDocumentBatch($batch);
+        }
+    }
+
+    /**
+     * @param non-empty-array<array<string, mixed>> $documents
+     *
+     * @return \Generator<PreparedDocument>
+     */
+    private function prepareDocumentBatch(array $documents): \Generator
+    {
+        $this->existingHashes = $this->loadExistingHashes($documents);
+
+        foreach ($documents as $document) {
+            $preparedDocument = $this->prepareDocument($document);
+
+            if ($this->documentChanged($preparedDocument)) {
+                yield $preparedDocument;
+            }
+        }
+    }
+
+    /**
+     * @param iterable<PreparedDocument> $documents
+     */
+    private function indexPreparedDocuments(iterable $documents): void
+    {
+        $batch = new PreparedDocumentCollection();
+
+        foreach ($documents as $document) {
+            $batch->add($document);
+
+            if ($batch->getTermsCount() >= self::MAX_TERMS_PER_BATCH) {
+                $this->processPreparedDocuments($batch);
+                $batch = new PreparedDocumentCollection();
+            }
+        }
+
+        $this->processPreparedDocuments($batch);
+    }
+
+    private function processPreparedDocuments(PreparedDocumentCollection $documents): void
+    {
+        if ($documents->empty()) {
+            return;
+        }
+
+        $this->recordChange(
+            function () use ($documents): void {
+                $prepared = $this->bulkInsertDocuments($documents);
+                $this->removeCurrentDocumentData($prepared);
+                $this->bulkInsertMultiAttributes($prepared);
+                $this->bulkInsertTerms($prepared);
+            },
+        );
+        $this->commitChanges();
+    }
+
+    private function documentChanged(PreparedDocument $document): bool
+    {
+        $userId = $document->getUserId();
+
+        return !isset($this->existingHashes[$userId]) || $this->existingHashes[$userId] !== $document->getContentHash();
+    }
+
+    private function reviseStorageAfterIndexing(): void
+    {
+        // Finally, revise storage once
+        $this->recordChange(
+            function (): void {
+                $this->reviseStorage(false);
+            },
+        );
+        $this->commitChanges();
     }
 
     /**

--- a/src/Loupe.php
+++ b/src/Loupe.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Loupe\Loupe;
 
 use Loupe\Loupe\Exception\IndexException;
+use Loupe\Loupe\Indexing\DocumentSourceInterface;
 use Loupe\Loupe\Internal\Engine;
 
 final class Loupe
@@ -22,9 +23,9 @@ final class Loupe
     }
 
     /**
-     * @param array<int, array<string, mixed>> $documents
+     * @param array<int, array<string, mixed>>|DocumentSourceInterface $documents
      */
-    public function addDocuments(array $documents): void
+    public function addDocuments(DocumentSourceInterface|array $documents): void
     {
         $this->engine->addDocuments($documents);
     }

--- a/tests/Functional/IndexTest.php
+++ b/tests/Functional/IndexTest.php
@@ -6,6 +6,7 @@ namespace Loupe\Loupe\Tests\Functional;
 
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Exception\InvalidDocumentException;
+use Loupe\Loupe\Indexing\DocumentSource;
 use Loupe\Loupe\Internal\LoupeTypes;
 use Loupe\Loupe\Logger\InMemoryLogger;
 use Loupe\Loupe\SearchParameters;
@@ -599,6 +600,49 @@ final class IndexTest extends TestCase
             ['PRAGMA cache_size = -4000', 'PRAGMA cache_size = -32000'],
             \array_slice($cacheStatements, -2),
         );
+    }
+
+    public function testDocumentsCanBeIndexedFromRewindableSource(): void
+    {
+        $iterations = 0;
+        $documents = [self::getSandraDocument(), self::getUtaDocument()];
+        $source = DocumentSource::fromFactory(
+            static function () use (&$iterations, $documents): iterable {
+                ++$iterations;
+
+                yield from $documents;
+            },
+        );
+        $loupe = $this->createLoupe(Configuration::create());
+
+        $loupe->addDocuments($source);
+
+        $this->assertSame(2, $iterations);
+        $this->assertSame(2, $loupe->countDocuments());
+    }
+
+    public function testDocumentSourceIsValidatedBeforeIndexing(): void
+    {
+        $configuration = Configuration::create()
+            ->withFilterableAttributes(['departments', 'gender'])
+            ->withSortableAttributes(['firstname'])
+        ;
+        $source = DocumentSource::fromFactory(
+            static function (): iterable {
+                yield self::getSandraDocument();
+                yield array_merge(self::getUtaDocument(), ['departments' => [1, 3, 8]]);
+            },
+        );
+        $loupe = $this->createLoupe($configuration);
+
+        try {
+            $loupe->addDocuments($source);
+            $this->fail('Indexing should have failed.');
+        } catch (InvalidDocumentException) {
+            // The unchanged index is asserted below.
+        }
+
+        $this->assertSame(0, $loupe->countDocuments());
     }
 
     public function testNullValueIsIrrelevantForDocumentSchema(): void


### PR DESCRIPTION
Allow callers to provide a rewindable `DocumentSourceInterface` in addition to an array of documents.

Performance impact versus `main`:

The decoded 32k movie input array accounts for roughly 40 MiB in the benchmark process. `main` requires that entire
array to remain resident. A streaming source removes that corpus-sized input allocation and keeps total indexing RSS
below 150 MiB in the measured setup.

This PR is primarily a peak-memory and scalability improvement. It does not claim that decoding through an external
streaming library is inherently faster as decoder performance depends on the selected library. Loupe's own indexing
results remain identical.
