### PR TITLE
Roll back failed index operations

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -86,16 +86,7 @@ class Engine
         private readonly string|null $dataDir = null,
     ) {
         $this->indexInfo = new IndexInfo($this);
-        $stateSetIndex = new StateSetIndex(
-            new Config(
-                $this->configuration->getTypoTolerance()->getIndexLength(),
-                $this->configuration->getTypoTolerance()->getAlphabetSize(),
-            ),
-            new Utf8Alphabet(),
-            new StateSet($this),
-            new NullDataStore(),
-        );
-        $this->stateSetIndex = new DefaultStateSetIndex($stateSetIndex);
+        $this->stateSetIndex = $this->createStateSetIndex(new StateSet($this));
         $this->ticketHandler = new TicketHandler($this->connectionPool, $this->getLogger());
         $this->indexer = new Indexer($this, $this->ticketHandler);
         $this->stopwords = new InMemoryStopWords($this->configuration->getStopWords());
@@ -367,18 +358,52 @@ class Engine
     private function executeIndexOperation(callable $operation): void
     {
         $this->ticketHandler->claimTicket();
+        $operationSucceeded = false;
 
         try {
             $this->getConnection()->executeStatement('PRAGMA cache_size = -'.LoupeFactory::SQLITE_INDEX_CACHE_SIZE);
             $this->getConnection()->executeStatement('PRAGMA shrink_memory');
             $operation();
+            $operationSucceeded = true;
         } finally {
             try {
                 $this->getConnection()->executeStatement('PRAGMA cache_size = -'.LoupeFactory::SQLITE_SEARCH_CACHE_SIZE);
             } finally {
-                $this->ticketHandler->release();
+                if ($operationSucceeded) {
+                    $this->ticketHandler->release();
+                } else {
+                    $this->abortIndexOperation();
+                }
             }
         }
+    }
+
+    private function abortIndexOperation(): void
+    {
+        try {
+            $this->ticketHandler->abort();
+        } finally {
+            $this->indexer->discardPendingChanges();
+            $this->indexInfo->reset();
+            $stateSet = new StateSet($this);
+            $stateSet->reset();
+            $this->stateSetIndex = $this->createStateSetIndex($stateSet);
+        }
+    }
+
+    private function createStateSetIndex(StateSet $stateSet): StateSetIndexInterface
+    {
+        $stateSetIndex = new StateSetIndex(
+            new Config(
+                $this->configuration->getTypoTolerance()->getIndexLength(),
+                $this->configuration->getTypoTolerance()->getAlphabetSize(),
+            ),
+            new Utf8Alphabet(),
+            $stateSet,
+            new NullDataStore(),
+        );
+
+        return new DefaultStateSetIndex($stateSetIndex);
     }
 
     private function maybeWrapStateSetIndexWithCache(): void

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -122,6 +122,12 @@ class Indexer
         $this->changes[] = $change;
     }
 
+    public function discardPendingChanges(): void
+    {
+        $this->changes = [];
+        $this->existingHashes = [];
+    }
+
     /**
      * @param non-empty-array<array<string, mixed>> $documents
      */

--- a/src/Internal/StateSetIndex/StateSet.php
+++ b/src/Internal/StateSetIndex/StateSet.php
@@ -98,6 +98,17 @@ class StateSet implements StateSetInterface
         $this->dirty = true;
     }
 
+    public function reset(): void
+    {
+        $this->initialized = false;
+        $this->dirty = false;
+
+        $cacheFile = $this->getStateSetCacheFile();
+        if (null !== $cacheFile && file_exists($cacheFile)) {
+            unlink($cacheFile);
+        }
+    }
+
     /**
      * @param array<int, bool> $stateSet
      * ^ */

--- a/src/Internal/TicketHandler.php
+++ b/src/Internal/TicketHandler.php
@@ -119,6 +119,36 @@ class TicketHandler
      */
     public function release(): void
     {
+        $this->releaseTicket();
+
+        if ($this->writeLockAlreadyAcquired) {
+            $this->commitExclusiveTransaction($this->connectionPool->loupeConnection);
+            $this->writeLockAlreadyAcquired = false;
+            $this->log('Writer lock released');
+        }
+    }
+
+    /**
+     * Delete our ticket and roll back the writer transaction.
+     */
+    public function abort(): void
+    {
+        try {
+            if ($this->writeLockAlreadyAcquired) {
+                $this->rollbackExclusiveTransaction($this->connectionPool->loupeConnection);
+                $this->log('Writer transaction aborted');
+            }
+        } finally {
+            if ($this->writeLockAlreadyAcquired) {
+                $this->writeLockAlreadyAcquired = false;
+            }
+
+            $this->releaseTicket();
+        }
+    }
+
+    private function releaseTicket(): void
+    {
         // Acknowledge/delete our ticket under ticket DB exclusive transaction
         if (0 !== $this->currentTicket) {
             try {
@@ -134,12 +164,6 @@ class TicketHandler
             } finally {
                 $this->currentTicket = 0;
             }
-        }
-
-        if ($this->writeLockAlreadyAcquired) {
-            $this->commitExclusiveTransaction($this->connectionPool->loupeConnection);
-            $this->writeLockAlreadyAcquired = false;
-            $this->log('Writer lock released');
         }
     }
 

--- a/tests/Unit/Internal/EngineTest.php
+++ b/tests/Unit/Internal/EngineTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit\Internal;
+
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\LoupeFactory;
+use Loupe\Loupe\SearchParameters;
+use PHPUnit\Framework\TestCase;
+
+final class EngineTest extends TestCase
+{
+    public function testFailedIndexOperationRollsBackAndReleasesTicket(): void
+    {
+        $engine = $this->createEngine();
+        $engine->addDocuments([['id' => 1, 'title' => 'Existing document']]);
+        $engine->getConnection()->executeStatement(
+            "CREATE TRIGGER fail_term_relation BEFORE INSERT ON terms_documents BEGIN SELECT RAISE(ABORT, 'Forced failure'); END",
+        );
+
+        try {
+            $engine->addDocuments([['id' => 2, 'title' => 'Retry succeeds']]);
+            $this->fail('The index operation should have failed.');
+        } catch (\Throwable $exception) {
+            $this->assertStringContainsString('Forced failure', $exception->getMessage());
+        }
+
+        $this->assertSame(1, $engine->countDocuments());
+        $engine->getConnection()->executeStatement('DROP TRIGGER fail_term_relation');
+        $engine->addDocuments([['id' => 2, 'title' => 'Retry succeeds']]);
+
+        $this->assertSame(2, $engine->countDocuments());
+        $result = $engine->search(SearchParameters::create()->withQuery('retry'));
+        $this->assertSame(1, $result->getTotalHits());
+    }
+
+    private function createEngine(): Engine
+    {
+        $loupe = (new LoupeFactory())->createInMemory(Configuration::create());
+        $engineProperty = new \ReflectionProperty($loupe, 'engine');
+        $engine = $engineProperty->getValue($loupe);
+        $this->assertInstanceOf(Engine::class, $engine);
+
+        return $engine;
+    }
+}


### PR DESCRIPTION
Prevent an exception during indexing from committing a partially written document.

- Add an explicit writer-transaction abort path.
- Delete the writer ticket after rollback so another writer can continue.
- Discard queued indexer changes after an aborted operation.
- Reset `IndexInfo` and reconstruct the state-set index from persisted state.
- Cover a failure after partial SQL writes and prove that a retry succeeds.