### PR TITLE
Optimize match position aggregation

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -52,6 +52,8 @@ class Searcher
 
     public const CTE_TERM_DOCUMENT_MATCHES_PREFIX = '_cte_term_document_matches_';
 
+    public const CTE_TERM_DOCUMENT_POSITIONS_PREFIX = '_cte_term_document_positions_';
+
     public const CTE_TERM_DOCUMENTS_PREFIX = '_cte_term_documents_';
 
     public const CTE_TERM_MATCHES_PREFIX = '_cte_term_matches_';
@@ -631,26 +633,28 @@ class Searcher
         }
 
         foreach ($tokenCollection->all() as $token) {
-            $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
+            $matchesCteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
+            if (!$this->hasCTE($matchesCteName)) {
+                continue;
+            }
 
-            $this->queryBuilder->addSelect(\sprintf(
-                "(SELECT GROUP_CONCAT(attribute || ':' || position || ':' || start || ':' || end) FROM %s WHERE %s._id = %s.document) AS %s",
-                $cteName,
-                $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-                $cteName,
-                self::MATCH_POSITION_INFO_PREFIX.$token->getId(),
-            ));
+            $positionsCteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_POSITIONS_PREFIX, $token);
+            $positionsQueryBuilder = $this->engine->getConnection()->createQueryBuilder();
+            $positionsQueryBuilder
+                ->select('document')
+                ->addSelect("GROUP_CONCAT(attribute || ':' || position || ':' || start || ':' || end) AS positions")
+                ->from($matchesCteName)
+                ->groupBy('document')
+            ;
+            $this->addCTE(new Cte($positionsCteName, ['document_id', 'positions'], $positionsQueryBuilder));
 
             $this->queryBuilder
-                ->innerJoin(
+                ->addSelect($positionsCteName.'.positions AS '.self::MATCH_POSITION_INFO_PREFIX.$token->getId())
+                ->leftJoin(
                     self::CTE_MATCHES,
-                    self::CTE_MATCHES,
-                    $cteName,
-                    \sprintf(
-                        '%s.document_id = %s.document_id',
-                        $cteName,
-                        self::CTE_MATCHES,
-                    ),
+                    $positionsCteName,
+                    $positionsCteName,
+                    \sprintf('%s.document_id = %s.document_id', $positionsCteName, self::CTE_MATCHES),
                 )
             ;
         }

--- a/tests/Functional/Formatting/HighlightingTest.php
+++ b/tests/Functional/Formatting/HighlightingTest.php
@@ -14,6 +14,27 @@ final class HighlightingTest extends TestCase
 {
     use FunctionalTestTrait;
 
+    public function testHighlightingPreservesAnyMatchingStrategy(): void
+    {
+        $loupe = $this->createLoupe(Configuration::create()->withSearchableAttributes(['title']));
+        $loupe->addDocuments([
+            ['id' => 1, 'title' => 'Alpha'],
+            ['id' => 2, 'title' => 'Beta'],
+        ]);
+
+        $result = $loupe->search(
+            SearchParameters::create()
+                ->withQuery('alpha beta')
+                ->withAttributesToHighlight(['title']),
+        );
+
+        $this->assertSame(2, $result->getTotalHits());
+        $this->assertSame(
+            ['<em>Alpha</em>', '<em>Beta</em>'],
+            array_column(array_column($result->getHits(), '_formatted'), 'title'),
+        );
+    }
+
     /**
      * @return iterable<array-key, array<mixed>>
      */


### PR DESCRIPTION
Avoid multiplying raw term-position rows and repeatedly scanning them while formatting or exposing match positions.

- Aggregate positions once per document and query token in a dedicated CTE.
- Join the compact aggregate instead of correlating repeated `GROUP_CONCAT` scans.
- Preserve optional matches with a left join.
- Fix highlighting with `MatchingStrategy::Any`, which previously could require all query tokens implicitly.

#### Performance impact versus `main`

Representative highlighted searches on the 32k movie index:

| Query | Before | After | Improvement |
|---|---:|---:|---:|
| `batman` | about 1,032 ms | about 14.3 ms | about 72x |
| `star wars` | about 3,827 ms | about 17.4 ms | about 220x |

A common-term `the` stress query completed at approximately 170 ms with roughly 106 MiB RSS. Plain searches that do
not request formatting or match positions do not use this additional aggregation.
