### PR TITLE
Optimize single-attribute sorting

### DIFF
--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -66,15 +66,21 @@ abstract class AbstractSorter
             )
         ;
 
-        $alias = $cteName.'.sort_order';
+        $this->addOrderByExpression($searcher, $engine, $direction, $cteName.'.sort_order');
+    }
 
+    /**
+     * @param Searcher<AbstractQueryParameters> $searcher
+     */
+    protected function addOrderByExpression(Searcher $searcher, Engine $engine, Direction $direction, string $expression): void
+    {
         // Because of how Loupe works (SQLite's loosely typed system) we need to always ensure that null and empty values
         // are ordered ascending first.
         // Null and empty values should always come last for Loupe (or generally speaking for any search engine probably).
         $searcher->addOrderBy(
             Operator::Equals->buildSql(
                 $engine->getConnection(),
-                $alias,
+                $expression,
                 FilterValue::createNull(),
             ),
             Direction::ASC->getSQL(),
@@ -84,13 +90,13 @@ abstract class AbstractSorter
         $searcher->addOrderBy(
             Operator::Equals->buildSql(
                 $engine->getConnection(),
-                $alias,
+                $expression,
                 FilterValue::createEmpty(),
             ),
             Direction::ASC->getSQL(),
             true,
         );
 
-        $searcher->addOrderBy($alias, $direction->getSQL(), true);
+        $searcher->addOrderBy($expression, $direction->getSQL(), true);
     }
 }

--- a/src/Internal/Search/Sorting/SingleAttribute.php
+++ b/src/Internal/Search/Sorting/SingleAttribute.php
@@ -33,34 +33,8 @@ class SingleAttribute extends AbstractSorter
             $attribute = '_user_id';
         }
 
-        $qb = $engine->getConnection()->createQueryBuilder();
-        $qb
-            ->select(
-                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS).'._id AS document_id',
-                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS).'.'.$attribute.' AS sort_order',
-            )
-            ->from(
-                IndexInfo::TABLE_NAME_DOCUMENTS,
-                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-            )
-            ->innerJoin(
-                $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS),
-                Searcher::CTE_MATCHES,
-                Searcher::CTE_MATCHES,
-                \sprintf(
-                    '%s.document_id = %s._id',
-                    Searcher::CTE_MATCHES,
-                    $engine->getIndexInfo()->getAliasForTable(
-                        IndexInfo::TABLE_NAME_DOCUMENTS,
-                    ),
-                ),
-            )
-            ->groupBy('document_id')
-        ;
-
-        $cteName = 'order_'.$this->attributeName;
-
-        $this->addAndOrderByCte($searcher, $engine, $this->direction, $cteName, $qb);
+        $documentsAlias = $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $this->addOrderByExpression($searcher, $engine, $this->direction, $documentsAlias.'.'.$attribute);
     }
 
     public static function fromString(string $value, Engine $engine, Direction $direction): self


### PR DESCRIPTION
Remove the `order_<attribute>` CTE used for single-value sortable attributes and order directly on the corresponding
document column.

- Avoid scanning and grouping documents and matches only to join the result back to the same document row.
- Preserve the existing null and empty-value ordering through the same sentinel expression.
- Leave multi-value and geo sorting paths unchanged.

#### Performance impact versus `main`

Across eight end-to-end sorted-search cases, including filters, facets, and distinct:

- 100-cycle run: 6,599.6 ms to 5,204.0 ms, 21.1% faster.
- A second 50-cycle run: 3,289.2 ms to 2,699.7 ms, about 18% faster.
- Peak RSS: 84.39 MiB to 83.14 MiB.
