### PR TITLE
Eliminate redundant relevance join

### DIFF
--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -106,6 +106,10 @@ class Searcher
 
     private bool $fullResultCountRequired = false;
 
+    private bool $matchesJoined = false;
+
+    private bool $resultConstrainedToMatches = false;
+
     /**
      * @param T $queryParameters
      */
@@ -249,6 +253,28 @@ class Searcher
         $this->fullResultCountRequired = true;
     }
 
+    public function markResultConstrainedToMatches(): void
+    {
+        $this->resultConstrainedToMatches = true;
+    }
+
+    public function requireMatchesJoin(): void
+    {
+        if ($this->matchesJoined) {
+            return;
+        }
+
+        $documentsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $this->queryBuilder->innerJoin(
+            $documentsAlias,
+            self::CTE_MATCHES,
+            self::CTE_MATCHES,
+            \sprintf('%s._id = %s.document_id', $documentsAlias, self::CTE_MATCHES),
+        );
+        $this->matchesJoined = true;
+        $this->resultConstrainedToMatches = true;
+    }
+
     public function bindQueryParameter(mixed $value, mixed $type = ParameterType::STRING, string|null $parameterName = null): string
     {
         if (null !== $parameterName) {
@@ -286,6 +312,7 @@ class Searcher
         $this->addFacets();
         $this->sortDocuments();
         $this->selectDistance();
+        $this->ensureResultConstrainedToMatches();
         $this->applyDistinct();
         $this->selectTotalHits();
         $this->limitPagination();
@@ -629,6 +656,8 @@ class Searcher
         if (!$this->askedForFormattingOrMatchesPosition()) {
             return;
         }
+
+        $this->requireMatchesJoin();
 
         foreach ($tokenCollection->all() as $token) {
             $cteName = $this->getCTENameForToken(self::CTE_TERM_DOCUMENT_MATCHES_PREFIX, $token);
@@ -1619,6 +1648,13 @@ class Searcher
         $this->queryBuilder->setMaxResults($limit);
     }
 
+    private function ensureResultConstrainedToMatches(): void
+    {
+        if (!$this->resultConstrainedToMatches) {
+            $this->requireMatchesJoin();
+        }
+    }
+
     private function needsFoldingState(): bool
     {
         return \in_array('exactness', $this->engine->getConfiguration()->getRankingRules(), true);
@@ -1693,6 +1729,7 @@ class Searcher
                 }
 
                 $this->markFullResultCountRequired();
+                $this->requireMatchesJoin();
 
                 $this->queryBuilder->addSelect($cteName.'.distance AS '.self::DISTANCE_ALIAS.'_'.$attribute);
                 $this->queryBuilder
@@ -1718,16 +1755,6 @@ class Searcher
             ->addSelect($documentsAlias.'._id AS '.self::DOCUMENT_ID_ALIAS)
             ->addSelect($documentsAlias.'._document')
             ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
-            ->innerJoin(
-                $documentsAlias,
-                self::CTE_MATCHES,
-                self::CTE_MATCHES,
-                \sprintf(
-                    '%s._id = %s.document_id',
-                    $documentsAlias,
-                    self::CTE_MATCHES,
-                ),
-            )
         ;
     }
 

--- a/src/Internal/Search/Sorting/AbstractSorter.php
+++ b/src/Internal/Search/Sorting/AbstractSorter.php
@@ -51,6 +51,7 @@ abstract class AbstractSorter
             return;
         }
 
+        $searcher->requireMatchesJoin();
         $searcher->addCTE(new Cte($cteName, ['document_id', 'sort_order'], $queryBuilder));
 
         $searcher->getQueryBuilder()

--- a/src/Internal/Search/Sorting/Relevance.php
+++ b/src/Internal/Search/Sorting/Relevance.php
@@ -6,6 +6,7 @@ namespace Loupe\Loupe\Internal\Search\Sorting;
 
 use Loupe\Loupe\Configuration;
 use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\Search\AbstractQueryParameters;
 use Loupe\Loupe\Internal\Search\Cte;
 use Loupe\Loupe\Internal\Search\Ranking\AttributeWeight;
@@ -102,13 +103,15 @@ class Relevance extends AbstractSorter
 
         $searcher->addCTE(new Cte(self::CTE_NAME, ['document_id', 'relevance_per_term'], $qb));
 
-        // Join the CTE
-        $searcher->getQueryBuilder()->join(
-            Searcher::CTE_MATCHES,
+        // The relevance CTE starts from the complete matches relation, so it can constrain the final result directly.
+        $documentsAlias = $engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $searcher->getQueryBuilder()->innerJoin(
+            $documentsAlias,
             self::CTE_NAME,
             self::CTE_NAME,
-            \sprintf('%s.document_id = %s.document_id', self::CTE_NAME, Searcher::CTE_MATCHES),
+            \sprintf('%s.document_id = %s._id', self::CTE_NAME, $documentsAlias),
         );
+        $searcher->markResultConstrainedToMatches();
 
         // Searchable attributes to determine attribute weight
         $searchableAttributes = $engine->getConfiguration()->getSearchableAttributes();


### PR DESCRIPTION
The relevance CTE already contains exactly the matching document set, but the final query joined both the match CTE
and the relevance CTE. Join documents directly through relevance when no other result feature consumes the raw match
CTE.

- Track whether a sorter already constrains the result to matching documents.
- Skip the final match join only when relevance provides that constraint.
- Retain the match join for formatting, match positions, multi-value or geo sorting, distance output, and browse paths.

#### Performance impact versus `main`

- Isolated SQL improvement: approximately 5.3%.
- End-to-end search improvement: approximately 3.5% to 5.7%, depending on the query.