### PR TITLE
Upgrade loupe/matcher to 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/cache": "^2.0 || ^3.0",
         "psr/log": "^2.0 || ^3.0",
         "nitotm/efficient-language-detector": "^3.1",
-        "loupe/matcher": "^0.3.3"
+        "loupe/matcher": "^0.4"
     },
     "require-dev": {
         "phpbench/phpbench": "^1.2",


### PR DESCRIPTION
Performance on 32k movies:

- Indexing median: 77.73 → 63.46 seconds
- 18.4% faster
- Peak RSS: 136.62 → 121.53 MiB
- 15.09 MiB less memory

🚀 