### PR TITLE
Accelerate bulk writes with SQLite JSON

### DIFF
--- a/src/Internal/Index/BulkUpserter/BulkUpserter.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserter.php
@@ -15,6 +15,7 @@ class BulkUpserter
         private readonly Connection $connection,
         private readonly BulkUpsertConfig $bulkUpsertConfig,
         private readonly int $variableLimit,
+        private readonly bool $jsonEachAvailable,
     ) {
     }
 
@@ -78,11 +79,19 @@ class BulkUpserter
      * @param array<array<int, mixed>>         $rows
      * @param array<int<0, max>|string, mixed> $parameters
      */
-    private function buildValuesClause(array $rows, array &$parameters): string
+    private function buildRowsClause(array $rows, array &$parameters): string
     {
+        if ($this->jsonEachAvailable) {
+            $parameters[] = Util::encodeJson($this->normalizeRows($rows));
+
+            return \sprintf(
+                'SELECT %s FROM json_each(?) WHERE true',
+                implode(', ', $this->jsonExtractColumns()),
+            );
+        }
+
         $columnKeys = array_keys($this->bulkUpsertConfig->getRowColumns());
         $columnsCount = \count($columnKeys);
-
         $tuples = [];
 
         foreach ($rows as $row) {
@@ -90,10 +99,10 @@ class BulkUpserter
                 $parameters[] = $row[$columnKey] ?? null;
             }
 
-            $tuples[] = $this->placeholdersRow($columnsCount);
+            $tuples[] = '('.implode(',', array_fill(0, $columnsCount, '?')).')';
         }
 
-        return implode(',', $tuples);
+        return 'VALUES '.implode(',', $tuples);
     }
 
     /**
@@ -105,7 +114,7 @@ class BulkUpserter
     private function executeModern(array $rows, array $updateColumns): array
     {
         $parameters = [];
-        $values = $this->buildValuesClause($rows, $parameters);
+        $rowsClause = $this->buildRowsClause($rows, $parameters);
         $conflictMode = $this->bulkUpsertConfig->getConflictMode();
         $returningColumns = $this->bulkUpsertConfig->getReturningColumns();
 
@@ -117,10 +126,10 @@ class BulkUpserter
         }
 
         $sql = \sprintf(
-            'INSERT INTO %s (%s) VALUES %s ON CONFLICT (%s) DO ',
+            'INSERT INTO %s (%s) %s ON CONFLICT (%s) DO ',
             $this->bulkUpsertConfig->getTable(),
             implode(', ', $this->bulkUpsertConfig->getRowColumns()),
-            $values,
+            $rowsClause,
             implode(', ', $this->bulkUpsertConfig->getUniqueColumns()),
         );
 
@@ -185,9 +194,41 @@ class BulkUpserter
         return $types;
     }
 
-    private function placeholdersRow(int $n): string
+    /**
+     * @return list<string>
+     */
+    private function jsonExtractColumns(): array
     {
-        return '('.implode(',', array_fill(0, $n, '?')).')';
+        $columns = [];
+
+        for ($column = 0; $column < \count($this->bulkUpsertConfig->getRowColumns()); ++$column) {
+            $columns[] = \sprintf("json_extract(value, '$[%d]')", $column);
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array<array<int, mixed>> $rows
+     *
+     * @return list<list<mixed>>
+     */
+    private function normalizeRows(array $rows): array
+    {
+        $columnKeys = array_keys($this->bulkUpsertConfig->getRowColumns());
+        $normalizedRows = [];
+
+        foreach ($rows as $row) {
+            $normalizedRow = [];
+
+            foreach ($columnKeys as $columnKey) {
+                $normalizedRow[] = $row[$columnKey] ?? null;
+            }
+
+            $normalizedRows[] = $normalizedRow;
+        }
+
+        return $normalizedRows;
     }
 
     /**

--- a/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
@@ -4,26 +4,42 @@ declare(strict_types=1);
 
 namespace Loupe\Loupe\Internal\Index\BulkUpserter;
 
+use Doctrine\DBAL\Exception;
 use Loupe\Loupe\Internal\ConnectionPool;
 
 class BulkUpserterFactory
 {
     /**
-     * We tried using a higher variable limit fetching it dynamically using
-     * > SELECT * FROM pragma_compile_options WHERE compile_options LIKE 'MAX_VARIABLE_NUMBER=%'
-     * but there's no real positive effect. Longer UPSERT queries will be faster indeed but only by
-     * a neglectable amount of time. They will, however, use a lot more memory for the prepared
-     * statements. Hence, we hard code it to 999 which is also a limit that is supported in all
-     * SQLite configurations.
+     * JSON transport removes SQLite's variable limit, but larger chunks were slower in the full indexing benchmark
+     * and require larger temporary JSON strings. Keep the established limit as a memory-conscious batch-size target.
      */
     public const VARIABLE_LIMIT = 999;
 
+    private readonly bool $jsonEachAvailable;
+
     public function __construct(private readonly ConnectionPool $connectionPool)
     {
+        $this->jsonEachAvailable = $this->detectJsonEach();
     }
 
     public function create(BulkUpsertConfig $bulkUpsertConfig): BulkUpserter
     {
-        return new BulkUpserter($this->connectionPool->loupeConnection, $bulkUpsertConfig, self::VARIABLE_LIMIT);
+        return new BulkUpserter(
+            $this->connectionPool->loupeConnection,
+            $bulkUpsertConfig,
+            self::VARIABLE_LIMIT,
+            $this->jsonEachAvailable,
+        );
+    }
+
+    private function detectJsonEach(): bool
+    {
+        try {
+            return 1 === (int) $this->connectionPool->loupeConnection
+                ->fetchOne("SELECT value FROM json_each('[1]')")
+            ;
+        } catch (Exception) {
+            return false;
+        }
     }
 }

--- a/tests/Unit/Internal/Index/BulkUpserter/BulkUpserterTest.php
+++ b/tests/Unit/Internal/Index/BulkUpserter/BulkUpserterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit\Internal\Index\BulkUpserter;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Logging\Middleware;
+use Loupe\Loupe\Internal\ConnectionPool;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpsertConfig;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserter;
+use Loupe\Loupe\Internal\Index\BulkUpserter\BulkUpserterFactory;
+use Loupe\Loupe\Internal\Index\BulkUpserter\ConflictMode;
+use Loupe\Loupe\Logger\InMemoryLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BulkUpserterTest extends TestCase
+{
+    #[DataProvider('jsonModesProvider')]
+    public function testJsonTransportPreservesTypesAndConflictModes(bool $jsonEachAvailable): void
+    {
+        $connection = $this->createConnection();
+        $connection->executeStatement(
+            'CREATE TABLE test_values (id INTEGER PRIMARY KEY, boolean_value BOOLEAN, integer_value INTEGER, float_value REAL, numeric_string TEXT, plain_string TEXT, nullable_value TEXT)',
+        );
+        $columns = ['id', 'boolean_value', 'integer_value', 'float_value', 'numeric_string', 'plain_string', 'nullable_value'];
+
+        $rows = [
+            [1, false, 42, 1.25, '123', 'text', null],
+            [2, true, -7, -2.5, '001', 'other', null],
+        ];
+
+        $insertConfig = BulkUpsertConfig::create('test_values', $columns, $rows, ['id'], ConflictMode::Update)
+            ->withReturningColumns(['id', 'plain_string'])
+        ;
+        $results = $this->upsert($connection, $insertConfig, $jsonEachAvailable);
+
+        $this->assertSame([['id' => 1, 'plain_string' => 'text'], ['id' => 2, 'plain_string' => 'other']], $results);
+        $storageTypes = $connection->fetchNumeric(
+            'SELECT typeof(boolean_value), typeof(integer_value), typeof(float_value), typeof(numeric_string), typeof(plain_string), typeof(nullable_value) FROM test_values WHERE id = 1',
+        );
+        $this->assertSame(['integer', 'integer', 'real', 'text', 'text', 'null'], $storageTypes);
+
+        $updateConfig = BulkUpsertConfig::create(
+            'test_values',
+            $columns,
+            [[1, true, 84, 2.5, '456', 'updated', null]],
+            ['id'],
+            ConflictMode::Update,
+        );
+        $this->upsert($connection, $updateConfig, $jsonEachAvailable);
+        $updatedRow = $connection->fetchNumeric(
+            'SELECT boolean_value, integer_value, float_value, numeric_string, plain_string, nullable_value FROM test_values WHERE id = 1',
+        );
+        $this->assertSame([1, 84, 2.5, '456', 'updated', null], $updatedRow);
+
+        $ignoreConfig = BulkUpsertConfig::create(
+            'test_values',
+            $columns,
+            [[1, false, 0, 0.0, '0', 'ignored', null]],
+            ['id'],
+            ConflictMode::Ignore,
+        );
+        (new BulkUpserter($connection, $ignoreConfig, 999, $jsonEachAvailable))->execute();
+        $this->assertSame('updated', $connection->fetchOne('SELECT plain_string FROM test_values WHERE id = 1'));
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function jsonModesProvider(): iterable
+    {
+        yield 'native json_each' => [true];
+        yield 'DBAL fallback' => [false];
+    }
+
+    public function testFactoryDetectsJsonEachAndKeepsMiddlewareActive(): void
+    {
+        $logger = new InMemoryLogger();
+        $configuration = new Configuration();
+        $configuration->setMiddlewares([new Middleware($logger)]);
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $configuration);
+        $connection->executeStatement('CREATE TABLE test_values (id INTEGER PRIMARY KEY, value TEXT)');
+        $factory = new BulkUpserterFactory(new ConnectionPool($connection, $connection));
+        $config = BulkUpsertConfig::create(
+            'test_values',
+            ['id', 'value'],
+            [[1, 'logged']],
+            ['id'],
+            ConflictMode::Update,
+        );
+
+        $factory->create($config)->execute();
+
+        $this->assertNotEmpty(array_filter(
+            $logger->getRecords(),
+            static fn (array $record): bool => str_contains((string) ($record['context']['sql'] ?? ''), 'json_each(?)'),
+        ));
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function upsert(Connection $connection, BulkUpsertConfig $config, bool $jsonEachAvailable): array
+    {
+        return (new BulkUpserter($connection, $config, 999, $jsonEachAvailable))->execute();
+    }
+
+    private function createConnection(): Connection
+    {
+        return DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+    }
+}


### PR DESCRIPTION
Loupe's multi-row UPSERTs previously bound up to 999 scalar parameters through Doctrine DBAL. Indexing the movies fixture caused millions of individual `bindValue()` calls.

This change encodes each existing chunk as one JSON parameter and expands its rows with SQLite's `json_each()` table-valued function.

Support for `json_each()` is detected once when the bulk upserter factory is created. SQLite installations without JSON table functions retain the previous placeholder-based DBAL implementation. This is because `json_each()` does not necessarily have to be available in our currently supported minimum version 3.35.0, see https://www.sqlite.org/json1.html#compiling_in_json_support.

## Performance

Cold indexing of all 32k movies on current `main`:

| Implementation | Time | Change vs. main | PHP peak memory |
| --- | ---: | ---: | ---: |
| `main` | 47.48 s | baseline | 111.23 MB |
| JSON bulk writes | 42.25 s | 11.0% faster | 111.23 MB |