### PR TITLE
Speed up primary-key iteration

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -126,6 +126,14 @@ class Engine
         $this->maybeWrapStateSetIndexWithCache();
 
         try {
+            if (
+                '' === $parameters->getQuery()
+                && '' === $parameters->getFilter()
+                && [$this->configuration->getPrimaryKey()] === $parameters->getAttributesToRetrieve()
+            ) {
+                return $this->getConnection()->transactional(fn () => $this->browsePrimaryKeys($parameters));
+            }
+
             return (new Searcher($this, $this->filterParser, $parameters))->fetchResult();
         } catch (Exception $exception) {
             // If we need a re-index (e.g. schema has changed via an update from an old to a newer Loupe version)
@@ -353,6 +361,49 @@ class Engine
             ->executeQuery('SELECT (SELECT page_count FROM pragma_page_count) * (SELECT page_size FROM pragma_page_size)')
             ->fetchOne()
         ;
+    }
+
+    private function browsePrimaryKeys(BrowseParameters $parameters): BrowseResult
+    {
+        $start = (int) floor(microtime(true) * 1000);
+        $limit = $parameters->getLimit();
+        $offset = $parameters->getOffset();
+
+        if (null !== $parameters->getHitsPerPage() || null !== $parameters->getPage()) {
+            $limit = $parameters->getHitsPerPage() ?? SearchParameters::MAX_LIMIT;
+            $offset = (($parameters->getPage() ?? 1) - 1) * $limit;
+        }
+
+        $documentsAlias = $this->indexInfo->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $primaryKey = $this->configuration->getPrimaryKey();
+        $primaryKeyExpression = match ($this->indexInfo->getLoupeTypeForAttribute($primaryKey)) {
+            LoupeTypes::TYPE_NUMBER => \sprintf('CAST(%s._user_id AS NUMERIC)', $documentsAlias),
+            LoupeTypes::TYPE_STRING => $documentsAlias.'._user_id',
+            default => \sprintf("json_extract(%s._document, '$.%s')", $documentsAlias, $primaryKey),
+        };
+        $userIds = $this->getConnection()->createQueryBuilder()
+            ->select($primaryKeyExpression)
+            ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
+            ->orderBy($documentsAlias.'._id', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->fetchFirstColumn()
+        ;
+        $hits = array_map(static fn (mixed $userId): array => [$primaryKey => $userId], $userIds);
+        $totalHits = [] === $hits ? 0 : $this->countDocuments();
+        $totalPages = 0 === $limit ? 0 : (int) ceil($totalHits / $limit);
+        $currentPage = 0 === $limit ? 0 : (int) floor($offset / $limit) + 1;
+        $end = (int) floor(microtime(true) * 1000);
+
+        return new BrowseResult(
+            $hits,
+            $parameters->getQuery(),
+            $end - $start,
+            $limit,
+            $currentPage,
+            $totalPages,
+            $totalHits,
+        );
     }
 
     private function executeIndexOperation(callable $operation): void

--- a/tests/Benchmark/BrowseBench.php
+++ b/tests/Benchmark/BrowseBench.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Benchmark;
+
+use Loupe\Loupe\BrowseParameters;
+use Loupe\Loupe\Loupe;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\OutputTimeUnit;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+#[BeforeClassMethods('setUpClass')]
+#[BeforeMethods('setUp')]
+#[Revs(1)]
+#[Iterations(5)]
+#[Warmup(2)]
+#[OutputTimeUnit('milliseconds', precision: 2)]
+#[Groups(['browse'])]
+class BrowseBench extends AbstractBench
+{
+    private Loupe $loupe;
+
+    public function setUp(): void
+    {
+        $this->loupe = self::loupe(self::searchIndexPath());
+    }
+
+    public function benchAllPrimaryKeys(): void
+    {
+        $documentCount = $this->loupe->countDocuments();
+
+        for ($offset = 0; $offset < $documentCount; $offset += 1_000) {
+            $this->loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve(['id'])
+                    ->withLimit(1_000)
+                    ->withOffset($offset),
+            );
+        }
+    }
+
+    public static function setUpClass(): void
+    {
+        self::ensureSearchIndex();
+    }
+}

--- a/tests/Functional/BrowseTest.php
+++ b/tests/Functional/BrowseTest.php
@@ -45,6 +45,35 @@ final class BrowseTest extends TestCase
         );
     }
 
+    public function testBrowseOnlyPrimaryKey(): void
+    {
+        foreach ([[1, 2], ['0001', '0002']] as $ids) {
+            $loupe = $this->createLoupe(Configuration::create()->withSearchableAttributes(['content']));
+            $loupe->addDocuments([
+                ['id' => $ids[0], 'content' => 'dog'],
+                ['id' => $ids[1], 'content' => 'cat'],
+            ]);
+
+            $result = $loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve(['id'])
+                    ->withLimit(1)
+                    ->withOffset(1),
+            );
+
+            $this->assertSame([['id' => $ids[1]]], $result->getHits());
+            $this->assertSame(2, $result->getTotalHits());
+            $this->assertSame(2, $result->getTotalPages());
+
+            $queriedResult = $loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve(['id'])
+                    ->withQuery('dog'),
+            );
+            $this->assertSame([['id' => $ids[0]]], $queriedResult->getHits());
+        }
+    }
+
     public function testMaxTotalHitsDoesNotApplyToBrowseApi(): void
     {
         $configuration = Configuration::create()


### PR DESCRIPTION
This adds a special-case fast path to the browse API: primary-key-only iteration.

I've been trying to snapshot the existing document ids before and after an insert for proper cleanup of stale documents. Doing that I've noticed the browse API json-decodes every document, regardless of retrieved attributes, resulting in comparably slow ~~and memory-intensive~~ requests.

Public API is unchanged, it just internally branches on `withAttributesToRetrieve(['id'])` vs. all other requests.

**Benchmarks**

Added a benchmark for the browse API.

140 ms → 20 ms (-86%)
6MB → 4MB (-33%)

Correction: a prior benchmark overstated the memory reductions.

**Alternative**

As an alternative to an id-only fast path, one could consider using  `json_extract` to select only the columns worth fetching. That's more generic, but would require another benchmark and implementation.