### PR TITLE
Add a browse benchmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,13 @@
             "@php vendor/bin/phpbench run --report=aggregate --group=index",
             "@bench-index-size"
         ],
+        "bench-browse": [
+            "@php vendor/bin/phpbench run --report=aggregate --group=browse",
+            "@bench-browse-size"
+        ],
         "bench-size": "@php tests/bin/report-database-size.php var/bench/movies-search/loupe.db",
         "bench-index-size": "@php tests/bin/report-database-size.php var/bench/movies-index/loupe.db",
+        "bench-browse-size": "@php tests/bin/report-database-size.php var/bench/browse-articles/loupe.db",
         "cs-fixer": "@php vendor/terminal42/code-quality-tools/tools/ecs/vendor/bin/ecs check src tests --config vendor/terminal42/code-quality-tools/tools/ecs/config.php --fix --ansi",
         "rector": "@php vendor/terminal42/code-quality-tools/tools/rector/vendor/bin/rector process src tests --config vendor/terminal42/code-quality-tools/tools/rector/config.php --ansi",
         "phpstan": "@php vendor/terminal42/code-quality-tools/tools/phpstan/vendor/bin/phpstan analyze src tests --configuration vendor/terminal42/code-quality-tools/tools/phpstan/config.php --ansi",

--- a/tests/Benchmark/BrowseBench.php
+++ b/tests/Benchmark/BrowseBench.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Benchmark;
+
+use Loupe\Loupe\BrowseParameters;
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Indexing\DocumentSource;
+use Loupe\Loupe\Loupe;
+use Loupe\Loupe\LoupeFactory;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\OutputTimeUnit;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+#[BeforeClassMethods('setUpClass')]
+#[BeforeMethods('setUp')]
+#[Revs(1)]
+#[Iterations(10)]
+#[Warmup(2)]
+#[OutputTimeUnit('milliseconds', precision: 2)]
+#[Groups(['browse'])]
+class BrowseBench extends AbstractBench
+{
+    private const ARTICLE_COUNT = 20_000;
+
+    private const PAGE_SIZE = 1_000;
+
+    private Loupe $articles;
+
+    private int $articlesCount = 0;
+
+    private int $documentCount = 0;
+
+    private Loupe $loupe;
+
+    public function benchBrowseLargeSubset(): void
+    {
+        $this->browseAll($this->articles, $this->articlesCount, ['id', 'title']);
+    }
+
+    public function benchBrowseLargeWholeDocument(): void
+    {
+        $this->browseAll($this->articles, $this->articlesCount, ['*']);
+    }
+
+    public function benchBrowsePrimaryKey(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['id']);
+    }
+
+    public function benchBrowseSubset(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['id', 'title', 'release_date']);
+    }
+
+    public function benchBrowseSubsetFiltered(): void
+    {
+        for ($offset = 0; $offset < $this->documentCount; $offset += self::PAGE_SIZE) {
+            $this->loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve(['id', 'title'])
+                    ->withFilter('release_date > 0')
+                    ->withLimit(self::PAGE_SIZE)
+                    ->withOffset($offset),
+            );
+        }
+    }
+
+    public function benchBrowseWholeDocument(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['*']);
+    }
+
+    public function setUp(): void
+    {
+        $this->loupe = self::loupe(self::searchIndexPath());
+        $this->documentCount = $this->loupe->countDocuments();
+
+        $this->articles = self::articlesLoupe();
+        $this->articlesCount = $this->articles->countDocuments();
+    }
+
+    public static function setUpClass(): void
+    {
+        self::ensureSearchIndex();
+        self::ensureArticleIndex();
+    }
+
+    private static function articleDocuments(): \Generator
+    {
+        $lorem = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor ';
+
+        for ($i = 1; $i <= self::ARTICLE_COUNT; $i++) {
+            yield [
+                'id' => $i,
+                'title' => 'Article number '.$i,
+                'author' => 'Author '.($i % 500),
+                'published_at' => 1_600_000_000 + $i,
+                'body' => str_repeat($lorem, 52),
+            ];
+        }
+    }
+
+    private static function articlesConfiguration(): Configuration
+    {
+        return Configuration::create()
+            ->withSearchableAttributes(['title', 'body'])
+            ->withFilterableAttributes(['published_at'])
+            ->withSortableAttributes(['published_at'])
+            ->withLanguages(['en'])
+        ;
+    }
+
+    private static function articlesIndexPath(): string
+    {
+        return self::projectRoot().'/var/bench/browse-articles';
+    }
+
+    private static function articlesLoupe(): Loupe
+    {
+        $dataDir = self::articlesIndexPath();
+
+        if (!is_dir($dataDir)) {
+            mkdir($dataDir, 0777, true);
+        }
+
+        return (new LoupeFactory())->create($dataDir, self::articlesConfiguration());
+    }
+
+    private static function ensureArticleIndex(): void
+    {
+        $loupe = self::articlesLoupe();
+
+        if (!$loupe->needsReindex() && $loupe->countDocuments() === self::ARTICLE_COUNT) {
+            return;
+        }
+
+        unset($loupe);
+        self::clearDir(self::articlesIndexPath());
+
+        $loupe = self::articlesLoupe();
+        $loupe->addDocuments(DocumentSource::fromFactory(self::articleDocuments(...)));
+    }
+
+    /**
+     * @param array<string> $attributesToRetrieve
+     */
+    private function browseAll(Loupe $loupe, int $documentCount, array $attributesToRetrieve): void
+    {
+        for ($offset = 0; $offset < $documentCount; $offset += self::PAGE_SIZE) {
+            $loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve($attributesToRetrieve)
+                    ->withLimit(self::PAGE_SIZE)
+                    ->withOffset($offset),
+            );
+        }
+    }
+}


### PR DESCRIPTION
Add benchmarks for two scenarios: 0.5KB movies + 4KB documents. Each iterated in batches of 1000 documents. Some retrieving just the id, some a small subset, some the whole document, plus one filtered.

```sh
composer run bench:browse
```

**Current baseline**

```
+-------------+-------------------------------+-----+------+-----+----------+----------+--------+
| benchmark   | subject                       | set | revs | its | mem_peak | mode     | rstdev |
+-------------+-------------------------------+-----+------+-----+----------+----------+--------+
| BrowseBench | benchBrowseLargeSubset        |     | 1    | 10  | 9.774mb  | 215.23ms | ±1.78% |
| BrowseBench | benchBrowseLargeWholeDocument |     | 1    | 10  | 14.008mb | 226.36ms | ±1.54% |
| BrowseBench | benchBrowsePrimaryKey         |     | 1    | 10  | 1.521mb  | 46.50ms  | ±3.21% |
| BrowseBench | benchBrowseSubset             |     | 1    | 10  | 2.277mb  | 89.04ms  | ±0.72% |
| BrowseBench | benchBrowseSubsetFiltered     |     | 1    | 10  | 2.560mb  | 239.33ms | ±3.37% |
| BrowseBench | benchBrowseWholeDocument      |     | 1    | 10  | 3.194mb  | 85.14ms  | ±1.79% |
+-------------+-------------------------------+-----+------+-----+----------+----------+--------+
```