### PR TITLE
Improve performance of document browsing API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,13 @@
             "@php vendor/bin/phpbench run --report=aggregate --group=index",
             "@bench-index-size"
         ],
+        "bench-browse": [
+            "@php vendor/bin/phpbench run --report=aggregate --group=browse",
+            "@bench-browse-size"
+        ],
         "bench-size": "@php tests/bin/report-database-size.php var/bench/movies-search/loupe.db",
         "bench-index-size": "@php tests/bin/report-database-size.php var/bench/movies-index/loupe.db",
+        "bench-browse-size": "@php tests/bin/report-database-size.php var/bench/browse-articles/loupe.db",
         "cs-fixer": "@php vendor/terminal42/code-quality-tools/tools/ecs/vendor/bin/ecs check src tests --config vendor/terminal42/code-quality-tools/tools/ecs/config.php --fix --ansi",
         "rector": "@php vendor/terminal42/code-quality-tools/tools/rector/vendor/bin/rector process src tests --config vendor/terminal42/code-quality-tools/tools/rector/config.php --ansi",
         "phpstan": "@php vendor/terminal42/code-quality-tools/tools/phpstan/vendor/bin/phpstan analyze src tests --configuration vendor/terminal42/code-quality-tools/tools/phpstan/config.php --ansi",

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -7,6 +7,7 @@ namespace Loupe\Loupe\Internal;
 use Composer\InstalledVersions;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
+use Doctrine\DBAL\Query\QueryBuilder;
 use Loupe\Loupe\BrowseParameters;
 use Loupe\Loupe\BrowseResult;
 use Loupe\Loupe\Configuration;
@@ -126,6 +127,10 @@ class Engine
         $this->maybeWrapStateSetIndexWithCache();
 
         try {
+            if ($this->canScanDocuments($parameters)) {
+                return $this->getConnection()->transactional(fn (): BrowseResult => $this->scanDocuments($parameters));
+            }
+
             return (new Searcher($this, $this->filterParser, $parameters))->fetchResult();
         } catch (Exception $exception) {
             // If we need a re-index (e.g. schema has changed via an update from an old to a newer Loupe version)
@@ -353,6 +358,92 @@ class Engine
             ->executeQuery('SELECT (SELECT page_count FROM pragma_page_count) * (SELECT page_size FROM pragma_page_size)')
             ->fetchOne()
         ;
+    }
+
+    private function scanDocuments(BrowseParameters $parameters): BrowseResult
+    {
+        $start = (int) floor(microtime(true) * 1000);
+
+        $limit = $parameters->getLimit();
+        $offset = $parameters->getOffset();
+
+        if (null !== $parameters->getHitsPerPage() || null !== $parameters->getPage()) {
+            $limit = $parameters->getHitsPerPage() ?? SearchParameters::MAX_LIMIT;
+            $offset = (($parameters->getPage() ?? 1) - 1) * $limit;
+        }
+
+        $documentsAlias = $this->indexInfo->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $queryBuilder = $this->getConnection()->createQueryBuilder()
+            ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
+            ->orderBy($documentsAlias.'._id', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+        ;
+
+        $hits = $this->fetchHits($queryBuilder, $documentsAlias, $parameters->getAttributesToRetrieve());
+        $totalHits = [] === $hits ? 0 : $this->countDocuments();
+        $totalPages = 0 === $limit ? 0 : (int) ceil($totalHits / $limit);
+        $currentPage = 0 === $limit ? 0 : (int) floor($offset / $limit) + 1;
+
+        return new BrowseResult(
+            $hits,
+            $parameters->getQuery(),
+            (int) floor(microtime(true) * 1000) - $start,
+            $limit,
+            $currentPage,
+            $totalPages,
+            $totalHits,
+        );
+    }
+
+    private function canScanDocuments(BrowseParameters $parameters): bool
+    {
+        return '' === $parameters->getQuery()
+            && '' === $parameters->getFilter()
+            && $parameters->getOffset() >= 0
+            && $parameters->getLimit() >= 0;
+    }
+
+    /**
+     * @param array<string> $attributesToRetrieve
+     *
+     * @return array<array<string, mixed>>
+     */
+    private function fetchHits(QueryBuilder $queryBuilder, string $documentsAlias, array $attributesToRetrieve): array
+    {
+        $primaryKey = $this->configuration->getPrimaryKey();
+
+        if ([$primaryKey] === $attributesToRetrieve) {
+            $ids = $queryBuilder
+                ->select($this->primaryKeyExpression($documentsAlias, $primaryKey))
+                ->setParameter('__loupe_pk_path', '$.'.$primaryKey)
+                ->fetchFirstColumn()
+            ;
+
+            return array_map(static fn (mixed $id): array => [$primaryKey => $id], $ids);
+        }
+
+        $documents = $queryBuilder->select($documentsAlias.'._document')->fetchFirstColumn();
+
+        if (\in_array('*', $attributesToRetrieve, true)) {
+            return array_map(Util::decodeJson(...), $documents);
+        }
+
+        $keep = array_flip($attributesToRetrieve);
+
+        return array_map(
+            static fn (string $document): array => array_intersect_key(Util::decodeJson($document), $keep),
+            $documents,
+        );
+    }
+
+    private function primaryKeyExpression(string $documentsAlias, string $primaryKey): string
+    {
+        return match ($this->indexInfo->getDocumentSchema()[$primaryKey] ?? null) {
+            LoupeTypes::TYPE_STRING => $documentsAlias.'._user_id',
+            LoupeTypes::TYPE_NUMBER => \sprintf('CAST(%s._user_id AS NUMERIC)', $documentsAlias),
+            default => \sprintf('json_extract(%s._document, :__loupe_pk_path)', $documentsAlias),
+        };
     }
 
     private function executeIndexOperation(callable $operation): void

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -423,18 +423,24 @@ class Engine
             return array_map(static fn (mixed $id): array => [$primaryKey => $id], $ids);
         }
 
-        $documents = $queryBuilder->select($documentsAlias.'._document')->fetchFirstColumn();
+        $documents = $queryBuilder->select($documentsAlias.'._document')->executeQuery()->iterateColumn();
+        $hits = [];
 
         if (\in_array('*', $attributesToRetrieve, true)) {
-            return array_map(Util::decodeJson(...), $documents);
+            foreach ($documents as $document) {
+                $hits[] = Util::decodeJson($document);
+            }
+
+            return $hits;
         }
 
         $keep = array_flip($attributesToRetrieve);
 
-        return array_map(
-            static fn (string $document): array => array_intersect_key(Util::decodeJson($document), $keep),
-            $documents,
-        );
+        foreach ($documents as $document) {
+            $hits[] = array_intersect_key(Util::decodeJson($document), $keep);
+        }
+
+        return $hits;
     }
 
     private function primaryKeyExpression(string $documentsAlias, string $primaryKey): string

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -7,7 +7,6 @@ namespace Loupe\Loupe\Internal;
 use Composer\InstalledVersions;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
-use Doctrine\DBAL\Query\QueryBuilder;
 use Loupe\Loupe\BrowseParameters;
 use Loupe\Loupe\BrowseResult;
 use Loupe\Loupe\Configuration;
@@ -20,6 +19,7 @@ use Loupe\Loupe\Internal\Index\Indexer;
 use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\Internal\LanguageDetection\NitotmLanguageDetector;
 use Loupe\Loupe\Internal\LanguageDetection\PreselectedLanguageDetector;
+use Loupe\Loupe\Internal\Search\Browser;
 use Loupe\Loupe\Internal\Search\Searcher;
 use Loupe\Loupe\Internal\Search\Sorting\Relevance;
 use Loupe\Loupe\Internal\StateSetIndex\CachedStateSetIndex;
@@ -127,11 +127,7 @@ class Engine
         $this->maybeWrapStateSetIndexWithCache();
 
         try {
-            if ($this->canScanDocuments($parameters)) {
-                return $this->getConnection()->transactional(fn (): BrowseResult => $this->scanDocuments($parameters));
-            }
-
-            return (new Searcher($this, $this->filterParser, $parameters))->fetchResult();
+            return (new Browser($this, $this->filterParser, $parameters))->fetchResult();
         } catch (Exception $exception) {
             // If we need a re-index (e.g. schema has changed via an update from an old to a newer Loupe version)
             // we return an empty result. Otherwise, we want to see the exception
@@ -358,98 +354,6 @@ class Engine
             ->executeQuery('SELECT (SELECT page_count FROM pragma_page_count) * (SELECT page_size FROM pragma_page_size)')
             ->fetchOne()
         ;
-    }
-
-    private function scanDocuments(BrowseParameters $parameters): BrowseResult
-    {
-        $start = (int) floor(microtime(true) * 1000);
-
-        $limit = $parameters->getLimit();
-        $offset = $parameters->getOffset();
-
-        if (null !== $parameters->getHitsPerPage() || null !== $parameters->getPage()) {
-            $limit = $parameters->getHitsPerPage() ?? SearchParameters::MAX_LIMIT;
-            $offset = (($parameters->getPage() ?? 1) - 1) * $limit;
-        }
-
-        $documentsAlias = $this->indexInfo->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
-        $queryBuilder = $this->getConnection()->createQueryBuilder()
-            ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
-            ->orderBy($documentsAlias.'._id', 'ASC')
-            ->setFirstResult($offset)
-            ->setMaxResults($limit)
-        ;
-
-        $hits = $this->fetchHits($queryBuilder, $documentsAlias, $parameters->getAttributesToRetrieve());
-        $totalHits = [] === $hits ? 0 : $this->countDocuments();
-        $totalPages = 0 === $limit ? 0 : (int) ceil($totalHits / $limit);
-        $currentPage = 0 === $limit ? 0 : (int) floor($offset / $limit) + 1;
-
-        return new BrowseResult(
-            $hits,
-            $parameters->getQuery(),
-            (int) floor(microtime(true) * 1000) - $start,
-            $limit,
-            $currentPage,
-            $totalPages,
-            $totalHits,
-        );
-    }
-
-    private function canScanDocuments(BrowseParameters $parameters): bool
-    {
-        return '' === $parameters->getQuery()
-            && '' === $parameters->getFilter()
-            && $parameters->getOffset() >= 0
-            && $parameters->getLimit() >= 0;
-    }
-
-    /**
-     * @param array<string> $attributesToRetrieve
-     *
-     * @return array<array<string, mixed>>
-     */
-    private function fetchHits(QueryBuilder $queryBuilder, string $documentsAlias, array $attributesToRetrieve): array
-    {
-        $primaryKey = $this->configuration->getPrimaryKey();
-
-        if ([$primaryKey] === $attributesToRetrieve) {
-            $ids = $queryBuilder
-                ->select($this->primaryKeyExpression($documentsAlias, $primaryKey))
-                ->setParameter('__loupe_pk_path', '$.'.$primaryKey)
-                ->fetchFirstColumn()
-            ;
-
-            return array_map(static fn (mixed $id): array => [$primaryKey => $id], $ids);
-        }
-
-        $documents = $queryBuilder->select($documentsAlias.'._document')->executeQuery()->iterateColumn();
-        $hits = [];
-
-        if (\in_array('*', $attributesToRetrieve, true)) {
-            foreach ($documents as $document) {
-                $hits[] = Util::decodeJson($document);
-            }
-
-            return $hits;
-        }
-
-        $keep = array_flip($attributesToRetrieve);
-
-        foreach ($documents as $document) {
-            $hits[] = array_intersect_key(Util::decodeJson($document), $keep);
-        }
-
-        return $hits;
-    }
-
-    private function primaryKeyExpression(string $documentsAlias, string $primaryKey): string
-    {
-        return match ($this->indexInfo->getDocumentSchema()[$primaryKey] ?? null) {
-            LoupeTypes::TYPE_STRING => $documentsAlias.'._user_id',
-            LoupeTypes::TYPE_NUMBER => \sprintf('CAST(%s._user_id AS NUMERIC)', $documentsAlias),
-            default => \sprintf('json_extract(%s._document, :__loupe_pk_path)', $documentsAlias),
-        };
     }
 
     private function executeIndexOperation(callable $operation): void

--- a/src/Internal/Search/Browser.php
+++ b/src/Internal/Search/Browser.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Internal\Search;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use Loupe\Loupe\BrowseParameters;
+use Loupe\Loupe\BrowseResult;
+use Loupe\Loupe\Internal\Engine;
+use Loupe\Loupe\Internal\Filter\Parser;
+use Loupe\Loupe\Internal\Index\IndexInfo;
+use Loupe\Loupe\Internal\LoupeTypes;
+use Loupe\Loupe\Internal\Util;
+use Loupe\Loupe\SearchParameters;
+
+class Browser
+{
+    public function __construct(
+        private readonly Engine $engine,
+        private readonly Parser $filterParser,
+        private readonly BrowseParameters $parameters,
+    ) {
+    }
+
+    public function fetchResult(): BrowseResult
+    {
+        if (!$this->canScanDocuments()) {
+            return (new Searcher($this->engine, $this->filterParser, $this->parameters))->fetchResult();
+        }
+
+        return $this->engine->getConnection()->transactional(fn (): BrowseResult => $this->scanDocuments());
+    }
+
+    private function canScanDocuments(): bool
+    {
+        return '' === $this->parameters->getQuery()
+            && '' === $this->parameters->getFilter()
+            && $this->parameters->getOffset() >= 0
+            && $this->parameters->getLimit() >= 0;
+    }
+
+    /**
+     * @param array<string> $attributesToRetrieve
+     *
+     * @return array<array<string, mixed>>
+     */
+    private function fetchHits(QueryBuilder $queryBuilder, string $documentsAlias, array $attributesToRetrieve): array
+    {
+        $primaryKey = $this->engine->getConfiguration()->getPrimaryKey();
+
+        if ([$primaryKey] === $attributesToRetrieve) {
+            $ids = $queryBuilder
+                ->select($this->primaryKeyExpression($documentsAlias, $primaryKey))
+                ->setParameter('__loupe_pk_path', '$.'.$primaryKey)
+                ->fetchFirstColumn()
+            ;
+
+            return array_map(static fn (mixed $id): array => [$primaryKey => $id], $ids);
+        }
+
+        $documents = $queryBuilder->select($documentsAlias.'._document')->executeQuery()->iterateColumn();
+        $hits = [];
+
+        if (\in_array('*', $attributesToRetrieve, true)) {
+            foreach ($documents as $document) {
+                $hits[] = Util::decodeJson($document);
+            }
+
+            return $hits;
+        }
+
+        $keep = array_flip($attributesToRetrieve);
+
+        foreach ($documents as $document) {
+            $hits[] = array_intersect_key(Util::decodeJson($document), $keep);
+        }
+
+        return $hits;
+    }
+
+    private function primaryKeyExpression(string $documentsAlias, string $primaryKey): string
+    {
+        return match ($this->engine->getIndexInfo()->getDocumentSchema()[$primaryKey] ?? null) {
+            LoupeTypes::TYPE_STRING => $documentsAlias.'._user_id',
+            LoupeTypes::TYPE_NUMBER => \sprintf('CAST(%s._user_id AS NUMERIC)', $documentsAlias),
+            default => \sprintf('json_extract(%s._document, :__loupe_pk_path)', $documentsAlias),
+        };
+    }
+
+    private function scanDocuments(): BrowseResult
+    {
+        $start = (int) floor(microtime(true) * 1000);
+
+        $limit = $this->parameters->getLimit();
+        $offset = $this->parameters->getOffset();
+
+        if (null !== $this->parameters->getHitsPerPage() || null !== $this->parameters->getPage()) {
+            $limit = $this->parameters->getHitsPerPage() ?? SearchParameters::MAX_LIMIT;
+            $offset = (($this->parameters->getPage() ?? 1) - 1) * $limit;
+        }
+
+        $documentsAlias = $this->engine->getIndexInfo()->getAliasForTable(IndexInfo::TABLE_NAME_DOCUMENTS);
+        $queryBuilder = $this->engine->getConnection()->createQueryBuilder()
+            ->from(IndexInfo::TABLE_NAME_DOCUMENTS, $documentsAlias)
+            ->orderBy($documentsAlias.'._id', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+        ;
+
+        $hits = $this->fetchHits($queryBuilder, $documentsAlias, $this->parameters->getAttributesToRetrieve());
+        $totalHits = [] === $hits ? 0 : $this->engine->countDocuments();
+        $totalPages = 0 === $limit ? 0 : (int) ceil($totalHits / $limit);
+        $currentPage = 0 === $limit ? 0 : (int) floor($offset / $limit) + 1;
+
+        return new BrowseResult(
+            $hits,
+            $this->parameters->getQuery(),
+            (int) floor(microtime(true) * 1000) - $start,
+            $limit,
+            $currentPage,
+            $totalPages,
+            $totalHits,
+        );
+    }
+}

--- a/tests/Benchmark/BrowseBench.php
+++ b/tests/Benchmark/BrowseBench.php
@@ -38,6 +38,15 @@ class BrowseBench extends AbstractBench
 
     private Loupe $loupe;
 
+    public function setUp(): void
+    {
+        $this->loupe = self::loupe(self::searchIndexPath());
+        $this->documentCount = $this->loupe->countDocuments();
+
+        $this->articles = self::articlesLoupe();
+        $this->articlesCount = $this->articles->countDocuments();
+    }
+
     public function benchBrowseLargeSubset(): void
     {
         $this->browseAll($this->articles, $this->articlesCount, ['id', 'title']);
@@ -76,15 +85,6 @@ class BrowseBench extends AbstractBench
         $this->browseAll($this->loupe, $this->documentCount, ['*']);
     }
 
-    public function setUp(): void
-    {
-        $this->loupe = self::loupe(self::searchIndexPath());
-        $this->documentCount = $this->loupe->countDocuments();
-
-        $this->articles = self::articlesLoupe();
-        $this->articlesCount = $this->articles->countDocuments();
-    }
-
     public static function setUpClass(): void
     {
         self::ensureSearchIndex();
@@ -95,7 +95,7 @@ class BrowseBench extends AbstractBench
     {
         $lorem = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor ';
 
-        for ($i = 1; $i <= self::ARTICLE_COUNT; $i++) {
+        for ($i = 1; $i <= self::ARTICLE_COUNT; ++$i) {
             yield [
                 'id' => $i,
                 'title' => 'Article number '.$i,
@@ -136,7 +136,7 @@ class BrowseBench extends AbstractBench
     {
         $loupe = self::articlesLoupe();
 
-        if (!$loupe->needsReindex() && $loupe->countDocuments() === self::ARTICLE_COUNT) {
+        if (!$loupe->needsReindex() && self::ARTICLE_COUNT === $loupe->countDocuments()) {
             return;
         }
 

--- a/tests/Benchmark/BrowseBench.php
+++ b/tests/Benchmark/BrowseBench.php
@@ -38,10 +38,6 @@ class BrowseBench extends AbstractBench
 
     private Loupe $loupe;
 
-    /**
-     * Large documents, narrow projection: the case where transferring and decoding
-     * the whole document is most wasteful.
-     */
     public function benchBrowseLargeSubset(): void
     {
         $this->browseAll($this->articles, $this->articlesCount, ['id', 'title']);
@@ -52,25 +48,16 @@ class BrowseBench extends AbstractBench
         $this->browseAll($this->articles, $this->articlesCount, ['*']);
     }
 
-    /**
-     * Only the primary key: the narrowest possible projection.
-     */
     public function benchBrowsePrimaryKey(): void
     {
         $this->browseAll($this->loupe, $this->documentCount, ['id']);
     }
 
-    /**
-     * A typical listing projection: a couple of small attributes out of a small document.
-     */
     public function benchBrowseSubset(): void
     {
         $this->browseAll($this->loupe, $this->documentCount, ['id', 'title', 'release_date']);
     }
 
-    /**
-     * Filtered browsing with a narrow projection.
-     */
     public function benchBrowseSubsetFiltered(): void
     {
         for ($offset = 0; $offset < $this->documentCount; $offset += self::PAGE_SIZE) {
@@ -84,9 +71,6 @@ class BrowseBench extends AbstractBench
         }
     }
 
-    /**
-     * Control: retrieving everything must not regress.
-     */
     public function benchBrowseWholeDocument(): void
     {
         $this->browseAll($this->loupe, $this->documentCount, ['*']);
@@ -107,10 +91,6 @@ class BrowseBench extends AbstractBench
         self::ensureArticleIndex();
     }
 
-    /**
-     * A corpus of documents that carry a large body, as produced by indexing pages,
-     * articles or file contents. Documents average roughly 4 KB.
-     */
     private static function articleDocuments(): \Generator
     {
         $lorem = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor ';

--- a/tests/Benchmark/BrowseBench.php
+++ b/tests/Benchmark/BrowseBench.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Benchmark;
+
+use Loupe\Loupe\BrowseParameters;
+use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Indexing\DocumentSource;
+use Loupe\Loupe\Loupe;
+use Loupe\Loupe\LoupeFactory;
+use PhpBench\Attributes\BeforeClassMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\OutputTimeUnit;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+#[BeforeClassMethods('setUpClass')]
+#[BeforeMethods('setUp')]
+#[Revs(1)]
+#[Iterations(10)]
+#[Warmup(2)]
+#[OutputTimeUnit('milliseconds', precision: 2)]
+#[Groups(['browse'])]
+class BrowseBench extends AbstractBench
+{
+    private const ARTICLE_COUNT = 20_000;
+
+    private const PAGE_SIZE = 1_000;
+
+    private Loupe $articles;
+
+    private int $articlesCount = 0;
+
+    private int $documentCount = 0;
+
+    private Loupe $loupe;
+
+    /**
+     * Large documents, narrow projection: the case where transferring and decoding
+     * the whole document is most wasteful.
+     */
+    public function benchBrowseLargeSubset(): void
+    {
+        $this->browseAll($this->articles, $this->articlesCount, ['id', 'title']);
+    }
+
+    public function benchBrowseLargeWholeDocument(): void
+    {
+        $this->browseAll($this->articles, $this->articlesCount, ['*']);
+    }
+
+    /**
+     * Only the primary key: the narrowest possible projection.
+     */
+    public function benchBrowsePrimaryKey(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['id']);
+    }
+
+    /**
+     * A typical listing projection: a couple of small attributes out of a small document.
+     */
+    public function benchBrowseSubset(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['id', 'title', 'release_date']);
+    }
+
+    /**
+     * Filtered browsing with a narrow projection.
+     */
+    public function benchBrowseSubsetFiltered(): void
+    {
+        for ($offset = 0; $offset < $this->documentCount; $offset += self::PAGE_SIZE) {
+            $this->loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve(['id', 'title'])
+                    ->withFilter('release_date > 0')
+                    ->withLimit(self::PAGE_SIZE)
+                    ->withOffset($offset),
+            );
+        }
+    }
+
+    /**
+     * Control: retrieving everything must not regress.
+     */
+    public function benchBrowseWholeDocument(): void
+    {
+        $this->browseAll($this->loupe, $this->documentCount, ['*']);
+    }
+
+    public function setUp(): void
+    {
+        $this->loupe = self::loupe(self::searchIndexPath());
+        $this->documentCount = $this->loupe->countDocuments();
+
+        $this->articles = self::articlesLoupe();
+        $this->articlesCount = $this->articles->countDocuments();
+    }
+
+    public static function setUpClass(): void
+    {
+        self::ensureSearchIndex();
+        self::ensureArticleIndex();
+    }
+
+    /**
+     * A corpus of documents that carry a large body, as produced by indexing pages,
+     * articles or file contents. Documents average roughly 4 KB.
+     */
+    private static function articleDocuments(): \Generator
+    {
+        $lorem = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor ';
+
+        for ($i = 1; $i <= self::ARTICLE_COUNT; $i++) {
+            yield [
+                'id' => $i,
+                'title' => 'Article number '.$i,
+                'author' => 'Author '.($i % 500),
+                'published_at' => 1_600_000_000 + $i,
+                'body' => str_repeat($lorem, 52),
+            ];
+        }
+    }
+
+    private static function articlesConfiguration(): Configuration
+    {
+        return Configuration::create()
+            ->withSearchableAttributes(['title', 'body'])
+            ->withFilterableAttributes(['published_at'])
+            ->withSortableAttributes(['published_at'])
+            ->withLanguages(['en'])
+        ;
+    }
+
+    private static function articlesIndexPath(): string
+    {
+        return self::projectRoot().'/var/bench/browse-articles';
+    }
+
+    private static function articlesLoupe(): Loupe
+    {
+        $dataDir = self::articlesIndexPath();
+
+        if (!is_dir($dataDir)) {
+            mkdir($dataDir, 0777, true);
+        }
+
+        return (new LoupeFactory())->create($dataDir, self::articlesConfiguration());
+    }
+
+    private static function ensureArticleIndex(): void
+    {
+        $loupe = self::articlesLoupe();
+
+        if (!$loupe->needsReindex() && $loupe->countDocuments() === self::ARTICLE_COUNT) {
+            return;
+        }
+
+        unset($loupe);
+        self::clearDir(self::articlesIndexPath());
+
+        $loupe = self::articlesLoupe();
+        $loupe->addDocuments(DocumentSource::fromFactory(self::articleDocuments(...)));
+    }
+
+    /**
+     * @param array<string> $attributesToRetrieve
+     */
+    private function browseAll(Loupe $loupe, int $documentCount, array $attributesToRetrieve): void
+    {
+        for ($offset = 0; $offset < $documentCount; $offset += self::PAGE_SIZE) {
+            $loupe->browse(
+                BrowseParameters::create()
+                    ->withAttributesToRetrieve($attributesToRetrieve)
+                    ->withLimit(self::PAGE_SIZE)
+                    ->withOffset($offset),
+            );
+        }
+    }
+}

--- a/tests/Functional/BrowseTest.php
+++ b/tests/Functional/BrowseTest.php
@@ -45,6 +45,57 @@ final class BrowseTest extends TestCase
         );
     }
 
+    public function testBrowsePrimaryKeyOnly(): void
+    {
+        $loupe = $this->setupLoupeWithMoviesFixture();
+
+        $this->browseAndAssertResults(
+            $loupe,
+            BrowseParameters::create()
+                ->withAttributesToRetrieve(['id'])
+                ->withHitsPerPage(3)
+                ->withPage(2),
+            [
+                'hits' => [
+                    ['id' => 11],
+                    ['id' => 12],
+                    ['id' => 13],
+                ],
+                'query' => '',
+                'hitsPerPage' => 3,
+                'page' => 2,
+                'totalPages' => 7,
+                'totalHits' => 19,
+            ],
+        );
+    }
+
+    public function testBrowsePrimaryKeyOnlyKeepsIdTypeAndGaps(): void
+    {
+        $configuration = Configuration::create()
+            ->withPrimaryKey('sku')
+            ->withFilterableAttributes(['stock'])
+        ;
+
+        $loupe = $this->createLoupe($configuration);
+        $loupe->addDocuments([
+            ['sku' => '0042', 'stock' => 1],
+            ['sku' => 'a-1', 'stock' => 2],
+            ['sku' => '7', 'stock' => 3],
+        ]);
+        $loupe->deleteDocument('a-1');
+
+        $result = $loupe->browse(BrowseParameters::create()->withAttributesToRetrieve(['sku']));
+        $this->assertSame([['sku' => '0042'], ['sku' => '7']], $result->getHits());
+        $this->assertSame(2, $result->getTotalHits());
+
+        $result = $loupe->browse(
+            BrowseParameters::create()->withAttributesToRetrieve(['sku'])->withFilter('stock > 1'),
+        );
+        $this->assertSame([['sku' => '7']], $result->getHits());
+        $this->assertSame(1, $result->getTotalHits());
+    }
+
     public function testMaxTotalHitsDoesNotApplyToBrowseApi(): void
     {
         $configuration = Configuration::create()


### PR DESCRIPTION
## Changes

- Create Browser class for optimized browsing / document scanning
- Read documents table directly instead of going through the Searcher if neither query nor filter are used
- Skip reading the document body if only the primary key is requested
- Stream document pages instead of single-column fetch for memory reduction
- Note: on the fast path, the primary key's type is reconstructed from the schema

## Benchmarks

  ### Speed

  | Subject | Corpus | Before | After | Δ |
  |---|---|---:|---:|---:|
  | `benchBrowsePrimaryKey` | 31,944 × 510 B | 127.40 ms | 18.10 ms | **−85.79%** |
  | `benchBrowseWholeDocument` | 31,944 × 510 B | 127.46 ms | 90.16 ms | **−29.26%** |
  | `benchBrowseSubset` | 31,944 × 510 B | 127.46 ms | 92.82 ms | **−27.18%** |
  | `benchBrowseLargeSubset` | 20,000 × 4 KB | 561.70 ms | 533.15 ms | −5.08% |
  | `benchBrowseLargeWholeDocument` | 20,000 × 4 KB | 573.28 ms | 554.50 ms | −3.28% |
  | `benchBrowseSubsetFiltered` | 31,944 × 510 B | 222.03 ms | 215.87 ms | −2.77% |

  ### Memory

  | Subject | Before | After | Δ |
  |---|---:|---:|---:|
  | `benchBrowseSubset` | 2.207 MB | 1.603 MB | −27.37% |
  | `benchBrowsePrimaryKey` | 2.088 MB | 1.522 MB | −27.11% |
  | `benchBrowseLargeSubset` | 1.956 MB | 1.571 MB | −19.68% |
  | `benchBrowseWholeDocument` | 3.073 MB | 2.514 MB | −18.19% |
  | `benchBrowseLargeWholeDocument` | 6.187 MB | 5.806 MB | −6.16% |
  | `benchBrowseSubsetFiltered` | 2.560 MB | 2.560 MB | ±0.00% |
