### PR TITLE
Allow configuring JSON backend

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -40,6 +40,8 @@ final class Configuration
 
     private \Closure|null $jsonDecoder = null;
 
+    private \Closure|null $jsonEncoder = null;
+
     private int $maxQueryTokens = 10;
 
     private int $maxTotalHits = 1000;
@@ -257,6 +259,11 @@ final class Configuration
         return $this->jsonDecoder;
     }
 
+    public function getJsonEncoder(): \Closure|null
+    {
+        return $this->jsonEncoder;
+    }
+
     public function getLogger(): LoggerInterface|null
     {
         return $this->logger;
@@ -448,6 +455,14 @@ final class Configuration
     {
         $clone = clone $this;
         $clone->jsonDecoder = \Closure::fromCallable($jsonDecoder);
+
+        return $clone;
+    }
+
+    public function withJsonEncoder(callable $jsonEncoder): self
+    {
+        $clone = clone $this;
+        $clone->jsonEncoder = \Closure::fromCallable($jsonEncoder);
 
         return $clone;
     }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -38,6 +38,8 @@ final class Configuration
 
     private LoggerInterface|null $logger = null;
 
+    private \Closure|null $jsonDecoder = null;
+
     private int $maxQueryTokens = 10;
 
     private int $maxTotalHits = 1000;
@@ -250,6 +252,11 @@ final class Configuration
         return $this->languages;
     }
 
+    public function getJsonDecoder(): \Closure|null
+    {
+        return $this->jsonDecoder;
+    }
+
     public function getLogger(): LoggerInterface|null
     {
         return $this->logger;
@@ -433,6 +440,14 @@ final class Configuration
 
         $clone = clone $this;
         $clone->languages = $languages;
+
+        return $clone;
+    }
+
+    public function withJsonDecoder(callable $jsonDecoder): self
+    {
+        $clone = clone $this;
+        $clone->jsonDecoder = \Closure::fromCallable($jsonDecoder);
 
         return $clone;
     }

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -230,7 +230,7 @@ class Engine
         ;
 
         if ($document) {
-            return Util::decodeJson($document);
+            return Util::decodeJson($document, $this->getConfiguration()->getJsonDecoder());
         }
 
         return null;

--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -92,7 +92,7 @@ class Engine
         $this->stopwords = new InMemoryStopWords($this->configuration->getStopWords());
         $this->formatter = new Formatter(new Matcher($this->getTokenizer(), $this->stopwords));
         $this->filterParser = new Parser($this);
-        $this->bulkUpserterFactory = new BulkUpserterFactory($this->connectionPool);
+        $this->bulkUpserterFactory = new BulkUpserterFactory($this->connectionPool, $this->configuration->getJsonEncoder());
 
         $this->registerSQLiteFunctions($this->connectionPool->loupeConnection);
     }

--- a/src/Internal/Index/BulkUpserter/BulkUpserter.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserter.php
@@ -16,6 +16,7 @@ class BulkUpserter
         private readonly BulkUpsertConfig $bulkUpsertConfig,
         private readonly int $variableLimit,
         private readonly bool $jsonEachAvailable,
+        private readonly \Closure|null $jsonEncoder = null,
     ) {
     }
 
@@ -82,7 +83,7 @@ class BulkUpserter
     private function buildRowsClause(array $rows, array &$parameters): string
     {
         if ($this->jsonEachAvailable) {
-            $parameters[] = Util::encodeJson($this->normalizeRows($rows));
+            $parameters[] = Util::encodeJson($this->normalizeRows($rows), 0, $this->jsonEncoder);
 
             return \sprintf(
                 'SELECT %s FROM json_each(?) WHERE true',

--- a/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
+++ b/src/Internal/Index/BulkUpserter/BulkUpserterFactory.php
@@ -17,8 +17,10 @@ class BulkUpserterFactory
 
     private readonly bool $jsonEachAvailable;
 
-    public function __construct(private readonly ConnectionPool $connectionPool)
-    {
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly \Closure|null $jsonEncoder = null,
+    ) {
         $this->jsonEachAvailable = $this->detectJsonEach();
     }
 
@@ -29,6 +31,7 @@ class BulkUpserterFactory
             $bulkUpsertConfig,
             self::VARIABLE_LIMIT,
             $this->jsonEachAvailable,
+            $this->jsonEncoder,
         );
     }
 

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -238,7 +238,7 @@ class IndexInfo
             if (false === $schema) {
                 $this->documentSchema = [];
             } else {
-                $this->documentSchema = Util::decodeJson($schema);
+                $this->documentSchema = Util::decodeJson($schema, $this->engine->getConfiguration()->getJsonDecoder());
             }
         }
 

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -947,7 +947,7 @@ class Indexer
 
         $preparedDocument = new PreparedDocument(
             $userId,
-            Util::encodeJson($documentData),
+            Util::encodeJson($documentData, 0, $this->engine->getConfiguration()->getJsonEncoder()),
         );
 
         // Terms and attributes of unchanged documents are excluded by the SQL change detection: skip expensive tokenization & attribute extraction

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -872,7 +872,7 @@ class Indexer
 
         foreach ($this->engine->getConnection()->executeQuery('SELECT '.$documentColumn.' FROM documents_migration')
             ->iterateAssociative() as $row) {
-            $chunk[] = json_decode($row[$documentColumn], true);
+            $chunk[] = Util::decodeJson($row[$documentColumn], $this->engine->getConfiguration()->getJsonDecoder());
 
             if (\count($chunk) >= 100) {
                 $this->addDocuments($chunk);

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -325,7 +325,7 @@ class Searcher
         $hits = [];
 
         foreach ($this->query()->iterateAssociative() as $result) {
-            $document = Util::decodeJson($result['_document']);
+            $document = Util::decodeJson($result['_document'], $this->engine->getConfiguration()->getJsonDecoder());
 
             foreach ($result as $k => $v) {
                 if (str_starts_with($k, self::DISTANCE_ALIAS)) {

--- a/src/Internal/Util.php
+++ b/src/Internal/Util.php
@@ -45,12 +45,22 @@ class Util
     /**
      * @return array<mixed>
      */
-    public static function decodeJson(string $data): array
+    public static function decodeJson(string $data, callable|null $decoder = null): array
     {
+        if (null !== $decoder) {
+            $decoded = $decoder($data);
+
+            if (!\is_array($decoded)) {
+                throw new InvalidJsonException('JSON must decode to an array.');
+            }
+
+            return $decoded;
+        }
+
         $data = json_decode($data, true);
 
         if (!\is_array($data)) {
-            throw new InvalidJsonException(json_last_error_msg());
+            throw new InvalidJsonException(JSON_ERROR_NONE === json_last_error() ? 'JSON must decode to an array.' : json_last_error_msg());
         }
 
         return $data;

--- a/src/Internal/Util.php
+++ b/src/Internal/Util.php
@@ -69,8 +69,18 @@ class Util
     /**
      * @param array<mixed> $data
      */
-    public static function encodeJson(array $data, int $flags = 0): string
+    public static function encodeJson(array $data, int $flags = 0, callable|null $encoder = null): string
     {
+        if (null !== $encoder) {
+            $json = $encoder($data, $flags);
+
+            if (!\is_string($json)) {
+                throw new InvalidJsonException('The configured JSON encoder must return a string.');
+            }
+
+            return $json;
+        }
+
         $json = json_encode($data, $flags);
 
         if (false === $json) {

--- a/tests/Benchmark/AbstractBench.php
+++ b/tests/Benchmark/AbstractBench.php
@@ -30,12 +30,26 @@ abstract class AbstractBench
 
     protected static function configuration(): Configuration
     {
-        return Configuration::create()
+        $configuration = Configuration::create()
             ->withSearchableAttributes(['title', 'overview'])
             ->withFilterableAttributes(['release_date', 'genres'])
             ->withSortableAttributes(['release_date'])
             ->withLanguages(['en'])
         ;
+
+        $encoderFunction = match (getenv('LOUPE_JSON_ENCODER')) {
+            'fastjson' => 'fastjson_encode',
+            'simdjson' => 'simdjson_encode',
+            default => null,
+        };
+
+        if (null === $encoderFunction || !\function_exists($encoderFunction)) {
+            return $configuration;
+        }
+
+        return $configuration->withJsonEncoder(
+            static fn (array $data, int $flags): mixed => $encoderFunction($data, $flags),
+        );
     }
 
     protected static function ensureMoviesJson(): void

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -153,4 +153,18 @@ final class ConfigurationTest extends TestCase
         $this->assertSame(Configuration::create()->toString(), $configuration->toString());
         $this->assertSame(Configuration::create()->getIndexHash(), $configuration->getIndexHash());
     }
+
+    public function testJsonEncoderIsRuntimeOnly(): void
+    {
+        $configuration = Configuration::create()->withJsonEncoder(
+            static fn (array $data, int $flags): string => json_encode($data, $flags | JSON_THROW_ON_ERROR),
+        );
+
+        $encoder = $configuration->getJsonEncoder();
+        $this->assertInstanceOf(\Closure::class, $encoder);
+        $this->assertSame('{"id":1}', $encoder(['id' => 1], 0));
+
+        $this->assertSame(Configuration::create()->toString(), $configuration->toString());
+        $this->assertSame(Configuration::create()->getIndexHash(), $configuration->getIndexHash());
+    }
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -139,4 +139,18 @@ final class ConfigurationTest extends TestCase
 
         $this->assertNotInstanceOf(CacheItemPoolInterface::class, $configuration->getQueryCache());
     }
+
+    public function testJsonDecoderIsRuntimeOnly(): void
+    {
+        $configuration = Configuration::create()->withJsonDecoder(
+            static fn (string $json): array => json_decode($json, true, 512, JSON_THROW_ON_ERROR),
+        );
+
+        $decoder = $configuration->getJsonDecoder();
+        $this->assertInstanceOf(\Closure::class, $decoder);
+        $this->assertSame(['id' => 1], $decoder('{"id":1}'));
+
+        $this->assertSame(Configuration::create()->toString(), $configuration->toString());
+        $this->assertSame(Configuration::create()->getIndexHash(), $configuration->getIndexHash());
+    }
 }

--- a/tests/Unit/Internal/UtilTest.php
+++ b/tests/Unit/Internal/UtilTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Loupe\Loupe\Tests\Unit\Internal;
+
+use Loupe\Loupe\Exception\InvalidJsonException;
+use Loupe\Loupe\Internal\Util;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class UtilTest extends TestCase
+{
+    public function testDecodeJson(): void
+    {
+        $this->assertSame(
+            ['id' => 1, 'nested' => ['value', true, null]],
+            Util::decodeJson('{"id":1,"nested":["value",true,null]}'),
+        );
+    }
+
+    public function testDecodeJsonWithDecoder(): void
+    {
+        $decoder = static fn (string $json): array => json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(['id' => 2], Util::decodeJson('{"id":2}', $decoder));
+    }
+
+    public function testDecodeJsonWithDecoderReturningNonArray(): void
+    {
+        $this->expectException(InvalidJsonException::class);
+        $this->expectExceptionMessage('JSON must decode to an array.');
+
+        Util::decodeJson('null', static fn (string $json): array|null => null);
+    }
+
+    #[DataProvider('provideInvalidJson')]
+    public function testDecodeJsonRejectsInvalidValues(string $json): void
+    {
+        $this->expectException(InvalidJsonException::class);
+
+        Util::decodeJson($json);
+    }
+
+    #[DataProvider('provideScalarJson')]
+    public function testDecodeJsonScalarReturnsClearMessage(string $json): void
+    {
+        $this->expectException(InvalidJsonException::class);
+        $this->expectExceptionMessage('JSON must decode to an array.');
+
+        Util::decodeJson($json);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideInvalidJson(): iterable
+    {
+        yield 'malformed' => ['{"id":'];
+        yield 'null' => ['null'];
+        yield 'scalar' => ['1'];
+        yield 'string' => ['"value"'];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideScalarJson(): iterable
+    {
+        yield 'null' => ['null'];
+        yield 'integer' => ['123'];
+        yield 'string' => ['"value"'];
+        yield 'boolean' => ['true'];
+    }
+}

--- a/tests/Unit/Internal/UtilTest.php
+++ b/tests/Unit/Internal/UtilTest.php
@@ -51,6 +51,27 @@ final class UtilTest extends TestCase
         Util::decodeJson($json);
     }
 
+    public function testEncodeJson(): void
+    {
+        $data = ['id' => 1, 'nested' => ['value', true, null]];
+
+        $this->assertSame($data, json_decode(Util::encodeJson($data), true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public function testEncodeJsonWithEncoder(): void
+    {
+        $encoder = static fn (array $data, int $flags): string => json_encode($data, $flags | JSON_THROW_ON_ERROR);
+
+        $this->assertSame('{"id":2}', Util::encodeJson(['id' => 2], 0, $encoder));
+    }
+
+    public function testEncodeJsonWithEncoderReturningNonString(): void
+    {
+        $this->expectException(InvalidJsonException::class);
+
+        Util::encodeJson(['id' => 1], 0, static fn (array $data, int $flags): mixed => null);
+    }
+
     /**
      * @return iterable<string, array{string}>
      */


### PR DESCRIPTION
Add configuration options for defining the json backend to use for encoding/decoding. Users can supply a callable for encoding (indexing) and/or decoding (searching). Useful in environments where you're able install PHP extensions of faster json-decode implementations.

```php
$configuration = Configuration::create()
    ->withJsonEncoder(static fn ($array) => fastjson_encode($array))
    ->withJsonDecoder(static fn ($json) => fastjson_decode($json, true));
```

### Benchmarks

Seeing around 11% speedup for search and 4% for indexing when using [fastjson](https://github.com/iliaal/fastjson).  
No change with default configuration, of course.

#### Search / decoding

  | Backend           | Time | Delta | Peak mem |
  |-------------------|---------------:|----------:|----------:|
  | native `ext-json` |        15.09 ms |        —  |  ~60.3 MB |
  | `fastjson` |        13.45 ms |   -10.9%  |  ~59.0 MB |

#### Indexing / encoding

  | Backend            | Time        | Delta | Peak mem |
  |--------------------|------------:|------:|---------:|
  | native `ext-json`  | 55,137.45 ms|   —   | 101.2 MB |
  | `fastjson` | 52,841.08 ms| -4.2% | 102.0 MB |
