### PR TITLE
Reduce term occurrence index maintenance

### DIFF
--- a/src/Internal/Engine.php
+++ b/src/Internal/Engine.php
@@ -43,7 +43,7 @@ use Toflar\StateSetIndex\StateSetIndex;
 
 class Engine
 {
-    public const VERSION = '0.13.3'; // Increase this whenever a re-index of all documents is needed
+    public const VERSION = '0.13.4'; // Increase this whenever a re-index of all documents is needed
 
     private const SQLITE_FUNCTION_CACHE_MAX_ENTRIES = 100000;
 

--- a/src/Internal/Index/IndexInfo.php
+++ b/src/Internal/Index/IndexInfo.php
@@ -110,12 +110,6 @@ class IndexInfo
         );
     }
 
-    public static function getPrimaryKeyIndexName(string $tableName): string
-    {
-        // SQLite exposes the implicit index for our composite primary keys using this generated name.
-        return 'sqlite_autoindex_'.$tableName.'_1';
-    }
-
     /**
      * @param array<string, mixed> $document
      */
@@ -648,9 +642,10 @@ class IndexInfo
             ->setNotnull(true)
         ;
 
-        $table->setPrimaryKey(['term', 'document', 'position']);
         $table->addIndex(['document']);
-        $table->addIndex(
+        // The covering search index also enforces occurrence uniqueness.
+        // This avoids maintaining a redundant primary-key index.
+        $table->addUniqueIndex(
             ['term', 'document', 'attribute', 'position', 'folded'],
             self::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
         );

--- a/src/Internal/Index/Indexer.php
+++ b/src/Internal/Index/Indexer.php
@@ -730,7 +730,7 @@ class Indexer
                 IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
                 ['document', 'attribute', 'position', 'start', 'end', 'folded', 'term'],
                 $rows,
-                ['term', 'document', 'position'],
+                ['term', 'document', 'attribute', 'position', 'folded'],
                 ConflictMode::Ignore,
             ))
             ->execute()

--- a/src/Internal/Search/Searcher.php
+++ b/src/Internal/Search/Searcher.php
@@ -817,7 +817,7 @@ class Searcher
         if (['*'] !== $this->queryParameters->getAttributesToSearchOn()) {
             // Pin the join order so SQLite does not scan every term occurrence before applying the attribute filter.
             $queryBuilder->from(\sprintf(
-                '%s CROSS JOIN %s %s INDEXED BY '.IndexInfo::getPrimaryKeyIndexName(IndexInfo::TABLE_NAME_TERMS_DOCUMENTS).' ON %s.id = %s.term',
+                '%s CROSS JOIN %s %s INDEXED BY '.IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH.' ON %s.id = %s.term',
                 $termMatchesCTE,
                 IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
                 $termsDocumentsAlias,

--- a/tests/Functional/ConnectionTest.php
+++ b/tests/Functional/ConnectionTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Tools\DsnParser;
 use Loupe\Loupe\Configuration;
+use Loupe\Loupe\Internal\Index\IndexInfo;
 use Loupe\Loupe\LoupeFactory;
 use Loupe\Loupe\Tests\StorageFixturesTestTrait;
 use PHPUnit\Framework\TestCase;
@@ -36,6 +37,26 @@ final class ConnectionTest extends TestCase
         (new LoupeFactory())->create($dir, Configuration::create());
 
         $this->assertSame(8192, $this->createConnection($dir)->fetchOne('PRAGMA page_size'));
+    }
+
+    public function testTermDocumentsSearchIndexIsUnique(): void
+    {
+        $dir = $this->createTemporaryDirectory();
+        $loupe = (new LoupeFactory())->create($dir, Configuration::create());
+        $loupe->addDocument(['id' => 1, 'title' => 'The quick brown fox']);
+
+        $connection = $this->createConnection($dir);
+        $searchIndex = $connection->fetchAssociative(\sprintf(
+            "SELECT `unique`, origin FROM pragma_index_list('%s') WHERE name = '%s'",
+            IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+            IndexInfo::INDEX_NAME_TERMS_DOCUMENTS_SEARCH,
+        ));
+
+        $this->assertSame(['unique' => 1, 'origin' => 'c'], $searchIndex);
+        $this->assertFalse($connection->fetchOne(\sprintf(
+            "SELECT 1 FROM pragma_index_list('%s') WHERE origin = 'pk'",
+            IndexInfo::TABLE_NAME_TERMS_DOCUMENTS,
+        )));
     }
 
     private function createConnection(string $dir): Connection


### PR DESCRIPTION
The `terms_documents` table currently maintains both a composite primary-key index and the wider `terms_documents_search` covering index. Both begin with the same term and document columns, so every occurrence insert maintains two largely overlapping indexes.

This changes `terms_documents_search` into the uniqueness constraint and removes the redundant composite primary key. The bulk insert conflict target and attribute-limited search index hint now reference the covering index directly.

Measured against `main` using PHP 8.4.20, SQLite 3.53.0, and the repository PHPBench scripts:

| Benchmark | `main` | This branch | Change |
|---|---:|---:|---:|
| Index 10k documents | 8.34s | 7.26s | 13.0% faster |
| Index full movie corpus | 32.21s | 27.64s | 14.2% faster |
| Movie database size | 266.88 MiB | 219.20 MiB | 17.9% smaller |

Query and browse performance remained effectively unchanged within benchmark variance.